### PR TITLE
Remove erroneous override annotations

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/BaseGeometryFunction.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/BaseGeometryFunction.java
@@ -107,12 +107,9 @@ implements GeometryFunction, Comparable
 		return returnType;
 	}
 	
-  @Override
   public boolean isBinary() {
     return parameterTypes.length > 0 && parameterTypes[0] == Geometry.class;
   }
-
-  @Override
 
 	public String getSignature()
 	{

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/SpatialIndexFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/SpatialIndexFunctions.java
@@ -99,7 +99,6 @@ public class SpatialIndexFunctions
     final STRtree index = new STRtree();
     geom.apply(new GeometryFilter() {
 
-      @Override
       public void filter(Geometry geom) {
         // only insert atomic geometries
         if (geom instanceof GeometryCollection) return;
@@ -123,7 +122,6 @@ public class SpatialIndexFunctions
     final Quadtree index = new Quadtree();
     geom.apply(new GeometryFilter() {
 
-      @Override
       public void filter(Geometry geom) {
         // only insert atomic geometries
         if (geom instanceof GeometryCollection) return;


### PR DESCRIPTION
Causes compile problems in newer Java environments.

Signed-off-by: Björn Harrtell <bjorn@wololo.org>