### PR TITLE
Geometry Comparable refactor

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -158,15 +158,14 @@ public abstract class Geometry
 {
   private static final long serialVersionUID = 8763622679187376702L;
     
-  private static final Class[] sortedClasses = new Class[] { 
-    Point.class, 
-    MultiPoint.class,
-    LineString.class, 
-    LinearRing.class, 
-    MultiLineString.class,
-    Polygon.class, 
-    MultiPolygon.class, 
-    GeometryCollection.class };  
+  static final int SORTINDEX_POINT = 0;
+  static final int SORTINDEX_MULTIPOINT = 1;
+  static final int SORTINDEX_LINESTRING = 2;
+  static final int SORTINDEX_LINEARRING = 3;
+  static final int SORTINDEX_MULTILINESTRING = 4;
+  static final int SORTINDEX_POLYGON = 5;
+  static final int SORTINDEX_MULTIPOLYGON = 6;
+  static final int SORTINDEX_GEOMETRYCOLLECTION = 7;
   
   private final static GeometryComponentFilter geometryChangedFilter = new GeometryComponentFilter() {
     public void filter(Geometry geom) {
@@ -1675,8 +1674,8 @@ public abstract class Geometry
    */
   public int compareTo(Object o) {
     Geometry other = (Geometry) o;
-    if (getClassSortIndex() != other.getClassSortIndex()) {
-      return getClassSortIndex() - other.getClassSortIndex();
+    if (getSortIndex() != other.getSortIndex()) {
+      return getSortIndex() - other.getSortIndex();
     }
     if (isEmpty() && other.isEmpty()) {
       return 0;
@@ -1722,8 +1721,8 @@ public abstract class Geometry
    */
   public int compareTo(Object o, CoordinateSequenceComparator comp) {
     Geometry other = (Geometry) o;
-    if (getClassSortIndex() != other.getClassSortIndex()) {
-      return getClassSortIndex() - other.getClassSortIndex();
+    if (getSortIndex() != other.getSortIndex()) {
+      return getSortIndex() - other.getSortIndex();
     }
     if (isEmpty() && other.isEmpty()) {
       return 0;
@@ -1854,15 +1853,8 @@ public abstract class Geometry
     if (tolerance == 0) { return a.equals(b); }
     return a.distance(b) <= tolerance;
   }
-
-  private int getClassSortIndex() {
-		for (int i = 0; i < sortedClasses.length; i++) {
-			if (sortedClasses[i].isInstance(this))
-				return i;
-		}
-		Assert.shouldNeverReachHere("Class not supported: " + this.getClass());
-		return -1;
-	}
+  
+  abstract protected int getSortIndex();
 
   private Point createPointFromInternalCoord(Coordinate coord, Geometry exemplar)
   {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
@@ -263,6 +263,10 @@ public class GeometryCollection extends Geometry {
 
   }
   
+  protected int getSortIndex() {
+    return Geometry.SORTINDEX_GEOMETRYCOLLECTION;
+  }
+  
   /**
    * Creates a {@link GeometryCollection} with
    * every component reversed.

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
@@ -317,5 +317,9 @@ public class LineString
     LineString line = (LineString) o;
     return comp.compare(this.points, line.points);
   }
+  
+  protected int getSortIndex() {
+    return Geometry.SORTINDEX_LINESTRING;
+  }
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
@@ -123,6 +123,10 @@ public class LinearRing extends LineString
   public String getGeometryType() {
     return "LinearRing";
   }
+  
+  protected int getSortIndex() {
+    return Geometry.SORTINDEX_LINEARRING;
+  }
 
   public Geometry reverse()
   {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
@@ -120,5 +120,8 @@ public class MultiLineString
     return super.equalsExact(other, tolerance);
   }
 
+  protected int getSortIndex() {
+    return Geometry.SORTINDEX_MULTILINESTRING;
+  }
 }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
@@ -97,6 +97,10 @@ public class MultiPoint
   protected Coordinate getCoordinate(int n) {
     return ((Point) geometries[n]).getCoordinate();
   }
+  
+  protected int getSortIndex() {
+    return Geometry.SORTINDEX_MULTIPOINT;
+  }
 
 }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
@@ -129,6 +129,10 @@ public class MultiPolygon
     }
     return getFactory().createMultiPolygon(revGeoms);
   }
+
+  protected int getSortIndex() {
+    return Geometry.SORTINDEX_MULTIPOLYGON;
+  }
 }
 
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
@@ -207,6 +207,10 @@ public class Point
     Point point = (Point) other;
     return comp.compare(this.coordinates, point.coordinates);
   }
+  
+  protected int getSortIndex() {
+    return Geometry.SORTINDEX_POINT;
+  }
 
   public CoordinateSequence getCoordinateSequence() {
     return coordinates;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -400,6 +400,10 @@ public class Polygon
     if (i < nHole2) return -1;
     return 0;
   }
+  
+  protected int getSortIndex() {
+    return Geometry.SORTINDEX_POLYGON;
+  }
 
   private void normalize(LinearRing ring, boolean clockwise) {
     if (ring.isEmpty()) {

--- a/modules/core/src/test/java/org/locationtech/jts/geom/GeometryImplTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/GeometryImplTest.java
@@ -41,6 +41,43 @@ public class GeometryImplTest extends TestCase {
         return new TestSuite(GeometryImplTest.class);
     }
 
+    public void testComparable() throws Exception {
+        Geometry point = reader.read("POINT EMPTY");
+        Geometry lineString = reader.read("LINESTRING EMPTY");
+        Geometry linearRing = reader.read("LINEARRING EMPTY");
+        Geometry polygon = reader.read("POLYGON EMPTY");
+        Geometry mpoint = reader.read("MULTIPOINT EMPTY");
+        Geometry mlineString = reader.read("MULTILINESTRING EMPTY");
+        Geometry mpolygon = reader.read("MULTIPOLYGON EMPTY");
+        Geometry gc = reader.read("GEOMETRYCOLLECTION EMPTY");
+
+        Geometry[] geometries = new Geometry[] {
+            gc,
+            mpolygon,
+            mlineString,
+            mpoint,
+            polygon,
+            linearRing,
+            lineString,
+            point
+        };
+
+        Geometry[] geometriesExpectedOrder = new Geometry[] {
+            point,
+            mpoint,
+            lineString,
+            linearRing,
+            mlineString,
+            polygon,
+            mpolygon,
+            gc
+        };
+
+        Arrays.sort(geometries);
+
+        assertTrue(Arrays.equals(geometries, geometriesExpectedOrder));
+    }
+
     public void testPolygonRelate() throws Exception {
         Geometry bigPolygon = reader.read(
                 "POLYGON ((0 0, 0 50, 50 50, 50 0, 0 0))");
@@ -81,7 +118,7 @@ public class GeometryImplTest extends TestCase {
 
     private void doTestFromCommcast2003AtYahooDotCa(WKTReader reader)
         throws ParseException {
-    	readerFloat.read(
+        readerFloat.read(
             "POLYGON ((708653.498611049 2402311.54647056, 708708.895756966 2402203.47250014, 708280.326454234 2402089.6337791, 708247.896591321 2402252.48269854, 708367.379593851 2402324.00761653, 708248.882609455 2402253.07294874, 708249.523621829 2402244.3124463, 708261.854734465 2402182.39086576, 708262.818392579 2402183.35452387, 708653.498611049 2402311.54647056))")
               .intersection(reader.read(
                 "POLYGON ((708258.754920656 2402197.91172757, 708257.029447455 2402206.56901508, 708652.961095455 2402312.65463437, 708657.068786251 2402304.6356364, 708258.754920656 2402197.91172757))"));


### PR DESCRIPTION
This simplifies the implementation and reduces circular dependency between Geometry subclasses and Geometry itself which is problematic when transpiling to JavaScript.