### PR TITLE
correct license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The JTS Topology Suite is a Java library for creating and manipulating vector ge
 
 JTS is open source software.  It is dual-licensed under:
 
-* [Eclipse Public License 1.0](http://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
+* [Eclipse Public License 1.0](https://www.eclipse.org/legal/epl-v10.html)
 * [Eclipse Distribution License 1.0](http://www.eclipse.org/org/documents/edl-v10.php) (a BSD Style License)
 
 In addition:


### PR DESCRIPTION
Update license reference.  From GPL 2.0 to Eclipse Public License - v 1.0