### PR TITLE
Fix LineString.normalize() side-effects

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
@@ -278,7 +278,9 @@ public class LineString
         // skip equal points on both ends
         if (!points.getCoordinate(i).equals(points.getCoordinate(j))) {
           if (points.getCoordinate(i).compareTo(points.getCoordinate(j)) > 0) {
-            CoordinateSequences.reverse(points);
+            CoordinateSequence copy = (CoordinateSequence) points.clone();
+            CoordinateSequences.reverse(copy);
+            points = copy;
           }
           return;
         }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/NormalizeTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/NormalizeTest.java
@@ -119,6 +119,18 @@ public class NormalizeTest extends TestCase {
     assertEqualsExact(expectedValue, l);
   }
 
+  public void testNormalizeStringNoSideEffect() throws Exception {
+    LineString l = (LineString) reader.read(
+            "LINESTRING (200 240, 140 160, 80 160, 160 80, 80 80)");
+    LineString ref = (LineString) reader.read(
+            "LINESTRING (200 240, 140 160)");
+    LineString seg = l.getFactory().createLineString(
+            new Coordinate[]{l.getCoordinates()[0], l.getCoordinates()[1]});
+    assertEqualsExact(ref, seg);
+    l.normalize();
+    assertEqualsExact(ref, seg);
+  }
+
   public void testNormalizeEmptyLineString() throws Exception {
     LineString l = (LineString) reader.read("LINESTRING EMPTY");
     l.normalize();


### PR DESCRIPTION
The method may have side effects if the linestring coordinates are reused because normalization can change ordinates. The patch makes a defensive copy of the CoordinateSequence before changing its ordinates and adds a unit test.