### PR TITLE
Fix ScaledNoder behaviour

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/noding/ScaledNoder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/ScaledNoder.java
@@ -49,10 +49,10 @@ public class ScaledNoder
     this.noder = noder;
     this.scaleFactor = scaleFactor;
     // no need to scale if input precision is already integral
-    isScaled = ! isIntegerPrecision();
+    isScaled = ! isInfinitePrecision();
   }
 
-  public boolean isIntegerPrecision() { return scaleFactor == 1.0; }
+  public boolean isInfinitePrecision() { return scaleFactor == 0.0; }
 
   public Collection getNodedSubstrings()
   {


### PR DESCRIPTION
It was not consistent between scale=1 (no rounding) and other scales (rounding).
Now, it skip scaling process for 0.0 scale, but not for 1.0 scale.