### PR TITLE
Allow requesting WKB output from jts tester

### DIFF
--- a/modules/tests/src/main/java/org/locationtech/jtstest/testrunner/GeometryResult.java
+++ b/modules/tests/src/main/java/org/locationtech/jtstest/testrunner/GeometryResult.java
@@ -14,6 +14,7 @@
 package org.locationtech.jtstest.testrunner;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.WKTWriter;
+import org.locationtech.jts.io.WKBWriter;
 
 
 /**
@@ -21,9 +22,14 @@ import org.locationtech.jts.io.WKTWriter;
  */
 public class GeometryResult implements Result {
   private Geometry geometry;
+  private boolean outputwkb = System.getenv("JTSTEST_WKB_OUTPUT") != null;
 
   public GeometryResult(Geometry geometry) {
     this.geometry = geometry;
+  }
+
+  public void setWKBOutput(boolean newval) {
+    this.outputwkb = newval;
   }
 
   public Geometry getGeometry() {
@@ -45,12 +51,22 @@ public class GeometryResult implements Result {
   }
 
   public String toLongString() {
-    return geometry.toText();
+    if ( this.outputwkb ) {
+      WKBWriter wkbwriter = new WKBWriter();
+      return WKBWriter.toHex(wkbwriter.write(geometry));
+    } else {
+      return geometry.toText();
+    }
   }
 
   public String toFormattedString() {
-    WKTWriter writer = new WKTWriter();
-    return writer.writeFormatted(geometry);
+    if ( this.outputwkb ) {
+      WKBWriter wkbwriter = new WKBWriter();
+      return WKBWriter.toHex(wkbwriter.write(geometry));
+    } else {
+      WKTWriter writer = new WKTWriter();
+      return writer.writeFormatted(geometry);
+    }
   }
 
   public String toShortString() {


### PR DESCRIPTION
Lets you export a JTSTEST_WKB_OUTPUT variable to obtain HEXWKB
print of results.

Helps debugging robustness issues, whereas the obtained result could
otherwise become invalid due to loss of precision upon converting to
WKT.

The change was needed to confirm invalid output obtained from the
test for bug reported as #107