### PR TITLE
Quadtree emptyness

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/index/quadtree/NodeBase.java
+++ b/modules/core/src/main/java/org/locationtech/jts/index/quadtree/NodeBase.java
@@ -127,10 +127,14 @@ public abstract class NodeBase implements Serializable {
   {
     boolean isEmpty = true;
     if (! items.isEmpty()) isEmpty = false;
-    for (int i = 0; i < 4; i++) {
-      if (subnode[i] != null) {
-        if (! subnode[i].isEmpty() )
-          isEmpty = false;
+    else {
+      for (int i = 0; i < 4; i++) {
+        if (subnode[i] != null) {
+          if (!subnode[i].isEmpty()) {
+            isEmpty = false;
+            break;
+          }
+        }
       }
     }
     return isEmpty;

--- a/modules/core/src/main/java/org/locationtech/jts/index/quadtree/Quadtree.java
+++ b/modules/core/src/main/java/org/locationtech/jts/index/quadtree/Quadtree.java
@@ -124,7 +124,7 @@ public class Quadtree
   public boolean isEmpty()
   {
     if (root == null) return true;
-    return false;
+    return root.isEmpty();
   }
   
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/index/quadtree/IsEmptyTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/index/quadtree/IsEmptyTest.java
@@ -1,0 +1,33 @@
+package org.locationtech.jts.index.quadtree;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.index.SpatialIndexTester;
+
+public class IsEmptyTest extends TestCase {
+
+  public static void main(String args[]) {
+        TestRunner.run(IsEmptyTest.class);
+    }
+
+  public IsEmptyTest(String name) {
+        super(name);
+    }
+
+  public void testSpatialIndex()
+            throws Exception
+  {
+    Quadtree index = new Quadtree();
+    assertTrue(index.size() == 0);
+    assertTrue(index.isEmpty());
+
+    index.insert(new Envelope(0,0,1,1), "test");
+    assertTrue(index.size() == 1);
+    assertTrue(!index.isEmpty());
+
+    index.remove(new Envelope(0,0,1,1), "test");
+    assertTrue(index.size() == 0);
+    assertTrue(index.isEmpty());
+  }
+}


### PR DESCRIPTION
Quadtree maybe empty even if root is not null. Test if root is empty instead.
NodeBase#isEmpty can return as soon as an element is found in the tree.