### PR TITLE
optimize line string covers on polygon

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/prep/PreparedLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/prep/PreparedLineString.java
@@ -45,6 +45,16 @@ public class PreparedLineString
   		segIntFinder = new FastSegmentSetIntersectionFinder(SegmentStringUtil.extractSegmentStrings(getGeometry()));
     return segIntFinder;
   }
+
+  @Override
+  public boolean covers(Geometry g)
+  {
+    /**
+     * A line cannot cover a non-empty polygon.
+     */
+    if (g.getDimension() > 1 && ! g.isEmpty()) return false;
+    return super.covers(g);
+  }
   
   public boolean intersects(Geometry g)
   {


### PR DESCRIPTION
This comes up a lot in elastic search (spatial4j) because it does quad tree rectangle comparisons. The current impl spend a ton of time doing matrix stuff when it obviously will return false.
