### PR TITLE
Deprecate clone in favor of copy method

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/dissolve/LineDissolver.java
+++ b/modules/core/src/main/java/org/locationtech/jts/dissolve/LineDissolver.java
@@ -231,7 +231,7 @@ public class LineDissolver
     ringStartEdge = null;
     
     MarkHalfEdge.markBoth(e);
-    line.add(e.orig().clone(), false);
+    line.add(e.orig().copy(), false);
     // scan along the path until a node is found (if one exists)
     while (e.sym().degree() == 2) {
       updateRingStartEdge(e);
@@ -242,7 +242,7 @@ public class LineDissolver
         return;
       }
       // add point to line, and move to next edge
-      line.add(eNext.orig().clone(), false);
+      line.add(eNext.orig().copy(), false);
       e = eNext;
       MarkHalfEdge.markBoth(e);
     }
@@ -259,7 +259,7 @@ public class LineDissolver
     CoordinateList line = new CoordinateList();
     HalfEdge e = eStartRing;
     
-    line.add(e.orig().clone(), false);
+    line.add(e.orig().copy(), false);
     // scan along the path until a node is found (if one exists)
     while (e.sym().degree() == 2) {
       HalfEdge eNext = e.next();
@@ -268,11 +268,11 @@ public class LineDissolver
         break;
       
       // add point to line, and move to next edge
-      line.add(eNext.orig().clone(), false);
+      line.add(eNext.orig().copy(), false);
       e = eNext;
     }
     // add final node
-    line.add(e.dest().clone(), false);
+    line.add(e.dest().copy(), false);
     
     // store the scanned line
     addLine(line);

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
@@ -289,6 +289,10 @@ public class Coordinate implements Comparable, Cloneable, Serializable {
       return null;
     }
   }
+  
+  public Coordinate copy() {
+	return new Coordinate(this);
+  }
 
   /**
    * Computes the 2-dimensional Euclidean distance to another location.

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
@@ -164,6 +164,14 @@ public interface CoordinateSequence
    * Called by Geometry#clone.
    *
    * @return a copy of the coordinate sequence containing copies of all points
+   * @deprecated
    */
   Object clone();
+  
+  /**
+   * Returns a deep copy of this collection.
+   *
+   * @return a copy of the coordinate sequence containing copies of all points
+   */
+  CoordinateSequence copy();
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequenceFilter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequenceFilter.java
@@ -35,7 +35,7 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
  * <b>Note</b>: In general, it is preferable to treat Geometrys as immutable. 
  * Mutation should be performed by creating a new Geometry object (see {@link GeometryEditor} 
  * and {@link GeometryTransformer} for convenient ways to do this).
- * An exception to this rule is when a new Geometry has been created via {@link Geometry#clone()}.
+ * An exception to this rule is when a new Geometry has been created via {@link Geometry#copy()}.
  * In this case mutating the Geometry will not cause aliasing issues, 
  * and a filter is a convenient way to implement coordinate transformation.
  *  

--- a/modules/core/src/main/java/org/locationtech/jts/geom/DefaultCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/DefaultCoordinateSequence.java
@@ -141,8 +141,17 @@ class DefaultCoordinateSequence
    * Creates a deep copy of the Object
    *
    * @return The deep copy
+   * @deprecated
    */
   public Object clone() {
+    return copy();
+  }
+  /**
+   * Creates a deep copy of the DefaultCoordinateSequence
+   *
+   * @return The deep copy
+   */
+  public DefaultCoordinateSequence copy() {
     Coordinate[] cloneCoordinates = new Coordinate[size()];
     for (int i = 0; i < coordinates.length; i++) {
       cloneCoordinates[i] = (Coordinate) coordinates[i].clone();

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -1395,8 +1395,8 @@ public abstract class Geometry
         return OverlayOp.createEmptyResult(OverlayOp.UNION, this, other, factory);
         
     // special case: if either input is empty ==> other input
-      if (this.isEmpty()) return (Geometry) other.clone();
-      if (other.isEmpty()) return (Geometry) clone();
+      if (this.isEmpty()) return other.copy();
+      if (other.isEmpty()) return copy();
     }
     
     // TODO: optimize if envelopes of geometries do not intersect
@@ -1427,7 +1427,7 @@ public abstract class Geometry
   {
     // special case: if A.isEmpty ==> empty; if B.isEmpty ==> A
     if (this.isEmpty()) return OverlayOp.createEmptyResult(OverlayOp.DIFFERENCE, this, other, factory);
-    if (other.isEmpty()) return (Geometry) clone();
+    if (other.isEmpty()) return copy();
 
     checkNotGeometryCollection(this);
     checkNotGeometryCollection(other);
@@ -1461,8 +1461,8 @@ public abstract class Geometry
         return OverlayOp.createEmptyResult(OverlayOp.SYMDIFFERENCE, this, other, factory);
         
     // special case: if either input is empty ==> result = other arg
-      if (this.isEmpty()) return (Geometry) other.clone();
-      if (other.isEmpty()) return (Geometry) clone();
+      if (this.isEmpty()) return other.copy();
+      if (other.isEmpty()) return copy();
     }
 
     checkNotGeometryCollection(this);
@@ -1632,6 +1632,7 @@ public abstract class Geometry
    * their internal data.  Overrides should call this method first.
    *
    * @return a clone of this instance
+   * @deprecated
    */
   public Object clone() {
     try {
@@ -1644,6 +1645,16 @@ public abstract class Geometry
       return null;
     }
   }
+  
+  /**
+   * Creates and returns a full copy of this {@link Geometry} object
+   * (including all coordinates contained by it).
+   * Subclasses are responsible for implementing this method and copying
+   * their internal data.
+   *
+   * @return a clone of this instance
+   */
+  abstract public Geometry copy();
 
   /**
    *  Converts this <code>Geometry</code> to <b>normal form</b> (or <b>
@@ -1671,7 +1682,7 @@ public abstract class Geometry
    */
   public Geometry norm()
   {
-    Geometry copy = (Geometry) clone();
+    Geometry copy = copy();
     copy.normalize();
     return copy;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
@@ -213,14 +213,24 @@ public class GeometryCollection extends Geometry {
    * (including all coordinates contained by it).
    *
    * @return a clone of this instance
+   * @deprecated
    */
   public Object clone() {
-    GeometryCollection gc = (GeometryCollection) super.clone();
-    gc.geometries = new Geometry[geometries.length];
+    return copy();
+  }
+  
+  /**
+   * Creates and returns a full copy of this {@link GeometryCollection} object.
+   * (including all coordinates contained by it).
+   *
+   * @return a copy of this instance
+   */
+  public GeometryCollection copy() {
+    Geometry[] geometries = new Geometry[this.geometries.length];
     for (int i = 0; i < geometries.length; i++) {
-      gc.geometries[i] = (Geometry) geometries[i].clone();
+      geometries[i] = this.geometries[i].copy();
     }
-    return gc;// return the clone
+    return new GeometryCollection(geometries, factory);
   }
 
   public void normalize() {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
@@ -546,12 +546,12 @@ public class GeometryFactory
    * used to represent a geometry, or to change the 
    * factory used for a geometry.
    * <p>
-   * {@link Geometry#clone()} can also be used to make a deep copy,
+   * {@link Geometry#copy()} can also be used to make a deep copy,
    * but it does not allow changing the CoordinateSequence type.
    * 
    * @return a deep copy of the input geometry, using the CoordinateSequence type of this factory
    * 
-   * @see Geometry#clone() 
+   * @see Geometry#copy() 
    */
   public Geometry createGeometry(Geometry g)
   {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
@@ -259,11 +259,20 @@ public class LineString
    * (including all coordinates contained by it).
    *
    * @return a clone of this instance
+   * @deprecated
    */
   public Object clone() {
-    LineString ls = (LineString) super.clone();
-    ls.points = (CoordinateSequence) points.clone();
-    return ls;
+    return copy();
+  }
+  
+  /**
+   * Creates and returns a full copy of this {@link LineString} object.
+   * (including all coordinates contained by it).
+   *
+   * @return a copy of this instance
+   */
+  public LineString copy() {
+    return new LineString(points.copy(), factory);
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
@@ -127,10 +127,14 @@ public class LinearRing extends LineString
   protected int getSortIndex() {
     return Geometry.SORTINDEX_LINEARRING;
   }
+  
+  public LinearRing copy() {
+    return new LinearRing(points.copy(), factory);
+  }
 
   public Geometry reverse()
   {
-    CoordinateSequence seq = (CoordinateSequence) points.clone();
+    CoordinateSequence seq = points.copy();
     CoordinateSequences.reverse(seq);
     LinearRing rev = getFactory().createLinearRing(seq);
     return rev;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
@@ -112,6 +112,14 @@ public class MultiLineString
     }
     return getFactory().createMultiLineString(revLines);
   }
+  
+  public MultiLineString copy() {
+    LineString[] lineStrings = new LineString[this.geometries.length];
+    for (int i = 0; i < lineStrings.length; i++) {
+      lineStrings[i] = (LineString) this.geometries[i].copy();
+    }
+    return new MultiLineString(lineStrings, factory);
+  }
 
   public boolean equalsExact(Geometry other, double tolerance) {
     if (!isEquivalentClass(other)) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
@@ -98,6 +98,14 @@ public class MultiPoint
     return ((Point) geometries[n]).getCoordinate();
   }
   
+  public MultiPoint copy() {
+    Point[] points = new Point[this.geometries.length];
+    for (int i = 0; i < points.length; i++) {
+      points[i] = (Point) this.geometries[i].copy();
+    }
+    return new MultiPoint(points, factory);
+  }
+  
   protected int getSortIndex() {
     return Geometry.SORTINDEX_MULTIPOINT;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
@@ -129,6 +129,14 @@ public class MultiPolygon
     }
     return getFactory().createMultiPolygon(revGeoms);
   }
+  
+  public MultiPolygon copy() {
+    Polygon[] polygons = new Polygon[this.geometries.length];
+    for (int i = 0; i < polygons.length; i++) {
+      polygons[i] = (Polygon) this.geometries[i].copy();
+    }
+    return new MultiPolygon(polygons, factory);
+  }
 
   protected int getSortIndex() {
     return Geometry.SORTINDEX_MULTIPOLYGON;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
@@ -180,16 +180,25 @@ public class Point
    * (including all coordinates contained by it).
    *
    * @return a clone of this instance
+   * @deprecated
    */
   public Object clone() {
-    Point p = (Point) super.clone();
-    p.coordinates = (CoordinateSequence) coordinates.clone();
-    return p;// return the clone
+    return copy();
+  }
+  
+  /**
+   * Creates and returns a full copy of this {@link Point} object.
+   * (including all coordinates contained by it).
+   *
+   * @return a copy of this instance
+   */
+  public Point copy() {
+    return new Point(coordinates.copy(), factory);
   }
 
   public Geometry reverse()
   {
-    return (Geometry) clone();
+    return copy();
   }
   
   public void normalize() 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -350,15 +350,26 @@ public class Polygon
    * (including all coordinates contained by it).
    *
    * @return a clone of this instance
+   * @deprecated
    */
   public Object clone() {
-    Polygon poly = (Polygon) super.clone();
-    poly.shell = (LinearRing) shell.clone();
-    poly.holes = new LinearRing[holes.length];
+
+    return copy();
+  }
+  
+  /**
+   * Creates and returns a full copy of this {@link Polygon} object.
+   * (including all coordinates contained by it).
+   *
+   * @return a copy of this instance
+   */
+  public Polygon copy() {
+    LinearRing shellCopy = shell.copy();
+    LinearRing[] holeCopies = new LinearRing[this.holes.length];
     for (int i = 0; i < holes.length; i++) {
-      poly.holes[i] = (LinearRing) holes[i].clone();
+    	holeCopies[i] = holes[i].copy();
     }
-    return poly;// return the clone
+    return new Polygon(shellCopy, holeCopies, factory);
   }
 
   public Geometry convexHull() {
@@ -423,11 +434,11 @@ public class Polygon
 
   public Geometry reverse()
   {
-    Polygon poly = (Polygon) super.clone();
-    poly.shell = (LinearRing) ((LinearRing) shell.clone()).reverse();
+    Polygon poly = copy();
+    poly.shell = (LinearRing) shell.copy().reverse();
     poly.holes = new LinearRing[holes.length];
     for (int i = 0; i < holes.length; i++) {
-      poly.holes[i] = (LinearRing) ((LinearRing) holes[i].clone()).reverse();
+      poly.holes[i] = (LinearRing) holes[i].copy().reverse();
     }
     return poly;// return the clone
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
@@ -187,11 +187,20 @@ public class CoordinateArraySequence
    * Creates a deep copy of the Object
    *
    * @return The deep copy
+   * @deprecated
    */
   public Object clone() {
+    return copy();
+  }
+  /**
+   * Creates a deep copy of the CoordinateArraySequence
+   *
+   * @return The deep copy
+   */
+  public CoordinateArraySequence copy() {
     Coordinate[] cloneCoordinates = new Coordinate[size()];
     for (int i = 0; i < coordinates.length; i++) {
-      cloneCoordinates[i] = (Coordinate) coordinates[i].clone();
+      cloneCoordinates[i] = coordinates[i].copy();
     }
     return new CoordinateArraySequence(cloneCoordinates, dimension);
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
@@ -15,6 +15,7 @@ package org.locationtech.jts.geom.impl;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.ref.SoftReference;
+import java.util.Arrays;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
@@ -182,8 +183,11 @@ public abstract class PackedCoordinateSequence
 
   /**
    * @see java.lang.Object#clone()
+   * @deprecated
    */
   public abstract Object clone();
+  
+  public abstract PackedCoordinateSequence copy();
 
   /**
    * Sets the ordinate of a coordinate in this sequence.
@@ -307,10 +311,14 @@ public abstract class PackedCoordinateSequence
 
     /**
      * @see java.lang.Object#clone()
+     * @deprecated
      */
     public Object clone() {
-      double[] clone = new double[coords.length];
-      System.arraycopy(coords, 0, clone, 0, coords.length);
+      return copy();
+    }
+    
+    public Double copy() {
+      double[] clone = Arrays.copyOf(coords, coords.length);
       return new Double(clone, dimension);
     }
     
@@ -441,10 +449,14 @@ public abstract class PackedCoordinateSequence
 
     /**
      * @see java.lang.Object#clone()
+     * @deprecated
      */
     public Object clone() {
-      float[] clone = new float[coords.length];
-      System.arraycopy(coords, 0, clone, 0, coords.length);
+      return copy();
+    }
+    
+    public Float copy() {
+      float[] clone = Arrays.copyOf(coords, coords.length);
       return new Float(clone, dimension);
     }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/AffineTransformation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/AffineTransformation.java
@@ -981,7 +981,7 @@ public class AffineTransformation
    */
   public Geometry transform(Geometry g)
   {
-    Geometry g2 = (Geometry) g.clone();
+    Geometry g2 = g.copy();
     g2.apply(this);
     return g2;    
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryTransformer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryTransformer.java
@@ -154,7 +154,7 @@ public class GeometryTransformer
    */
   protected final CoordinateSequence copy(CoordinateSequence seq)
   {
-    return (CoordinateSequence) seq.clone();
+    return seq.copy();
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/GeometryGraph.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/GeometryGraph.java
@@ -176,7 +176,7 @@ public class GeometryGraph
     int i = 0;
     for (Iterator it = coll.iterator(); it.hasNext(); ) {
       Node node = (Node) it.next();
-      pts[i++] = (Coordinate) node.getCoordinate().clone();
+      pts[i++] = node.getCoordinate().copy();
     }
     return pts;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/index/SegmentIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/index/SegmentIntersector.java
@@ -171,7 +171,7 @@ numTests++;
           e1.addIntersections(li, segIndex1, 1);
         }
         if (li.isProper()) {
-          properIntersectionPoint = (Coordinate) li.getIntersection(0).clone();
+          properIntersectionPoint = li.getIntersection(0).copy();
           hasProper = true;
           if (isDoneWhenProperInt) {
         	  isDone = true;

--- a/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
@@ -451,10 +451,20 @@ public class LinearLocation
    * Copies this location
    *
    * @return a copy of this location
+   * @deprecated
    */
   public Object clone()
   {
-    return new LinearLocation(componentIndex, segmentIndex, segmentFraction);
+    return copy();
+  }
+  
+  /**
+   * Copies this location
+   *
+   * @return a copy of this location
+   */
+  public LinearLocation copy() {
+	return new LinearLocation(componentIndex, segmentIndex, segmentFraction);
   }
   
   public String toString()

--- a/modules/core/src/main/java/org/locationtech/jts/linearref/LocationIndexOfLine.java
+++ b/modules/core/src/main/java/org/locationtech/jts/linearref/LocationIndexOfLine.java
@@ -56,7 +56,7 @@ class LocationIndexOfLine
 
     // check for case where subline is zero length
     if (subLine.getLength() == 0.0) {
-      subLineLoc[1] = (LinearLocation) subLineLoc[0].clone();
+      subLineLoc[1] = subLineLoc[0].copy();
     }
     else  {
       subLineLoc[1] = locPt.indexOfAfter(endPt, subLineLoc[0]);

--- a/modules/core/src/main/java/org/locationtech/jts/linearref/LocationIndexedLine.java
+++ b/modules/core/src/main/java/org/locationtech/jts/linearref/LocationIndexedLine.java
@@ -207,7 +207,7 @@ public class LocationIndexedLine
    */
   public LinearLocation clampIndex(LinearLocation index)
   {
-    LinearLocation loc = (LinearLocation) index.clone();
+    LinearLocation loc = index.copy();
     loc.clamp(linearGeom);
     return loc;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/AxisPlaneCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/AxisPlaneCoordinateSequence.java
@@ -134,5 +134,9 @@ public class AxisPlaneCoordinateSequence implements CoordinateSequence {
 	{
 		throw new UnsupportedOperationException();		
 	}
-
+	
+	public AxisPlaneCoordinateSequence copy()
+	{
+		throw new UnsupportedOperationException();		
+	}
 }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlay/snap/SnapOverlayOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlay/snap/SnapOverlayOp.java
@@ -124,8 +124,8 @@ public class SnapOverlayOp
     cbr.add(geom[0]);
     cbr.add(geom[1]);
     Geometry remGeom[] = new Geometry[2];
-    remGeom[0] = cbr.removeCommonBits((Geometry) geom[0].clone());
-    remGeom[1] = cbr.removeCommonBits((Geometry) geom[1].clone());
+    remGeom[0] = cbr.removeCommonBits(geom[0].copy());
+    remGeom[1] = cbr.removeCommonBits(geom[1].copy());
     return remGeom;
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/operation/union/CascadedPolygonUnion.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/union/CascadedPolygonUnion.java
@@ -167,7 +167,7 @@ public class CascadedPolygonUnion
   	for (Iterator i = geoms.iterator(); i.hasNext(); ) {
   		Geometry g = (Geometry) i.next();
   		if (union == null)
-  			union = (Geometry) g.clone();
+  			union = g.copy();
   		else
   			union = union.union(g);
   	}
@@ -283,9 +283,9 @@ public class CascadedPolygonUnion
   		return null;
 
   	if (g0 == null)
-  		return (Geometry) g1.clone();
+  		return g1.copy();
   	if (g1 == null)
-  		return (Geometry) g0.clone();
+  		return g0.copy();
   	
   	return unionOptimized(g0, g1);
   }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/ConsistentAreaTester.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/ConsistentAreaTester.java
@@ -107,7 +107,7 @@ public class ConsistentAreaTester {
     for (Iterator nodeIt = nodeGraph.getNodeIterator(); nodeIt.hasNext(); ) {
       RelateNode node = (RelateNode) nodeIt.next();
       if (! node.getEdges().isAreaLabelsConsistent(geomGraph)) {
-        invalidPoint = (Coordinate) node.getCoordinate().clone();
+        invalidPoint = node.getCoordinate().copy();
         return false;
       }
     }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/TopologyValidationError.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/TopologyValidationError.java
@@ -123,7 +123,7 @@ public class TopologyValidationError {
   {
     this.errorType = errorType;
     if (pt != null)
-      this.pt = (Coordinate) pt.clone();
+      this.pt = pt.copy();
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/precision/CommonBitsOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/precision/CommonBitsOp.java
@@ -138,7 +138,7 @@ public class CommonBitsOp {
   {
     cbr = new CommonBitsRemover();
     cbr.add(geom0);
-    Geometry geom = cbr.removeCommonBits((Geometry) geom0.clone());
+    Geometry geom = cbr.removeCommonBits(geom0.copy());
     return geom;
   }
 
@@ -156,8 +156,8 @@ public class CommonBitsOp {
     cbr.add(geom0);
     cbr.add(geom1);
     Geometry geom[] = new Geometry[2];
-    geom[0] = cbr.removeCommonBits((Geometry) geom0.clone());
-    geom[1] = cbr.removeCommonBits((Geometry) geom1.clone());
+    geom[0] = cbr.removeCommonBits(geom0.copy());
+    geom[1] = cbr.removeCommonBits(geom1.copy());
     return geom;
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifier.java
@@ -116,7 +116,7 @@ public class DouglasPeuckerSimplifier
   public Geometry getResultGeometry()
   {
     // empty input produces an empty result
-    if (inputGeom.isEmpty()) return (Geometry) inputGeom.clone();
+    if (inputGeom.isEmpty()) return inputGeom.copy();
     
     return (new DPTransformer(isEnsureValidTopology, distanceTolerance)).transform(inputGeom);
   }

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java
@@ -111,7 +111,7 @@ public class TopologyPreservingSimplifier
   public Geometry getResultGeometry() 
   {
     // empty input produces an empty result
-    if (inputGeom.isEmpty()) return (Geometry) inputGeom.clone();
+    if (inputGeom.isEmpty()) return inputGeom.copy();
     
     linestringMap = new HashMap();
     inputGeom.apply(new LineStringMapBuilderFilter(this));

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/VWSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/VWSimplifier.java
@@ -120,7 +120,7 @@ public class VWSimplifier
   {
     // empty input produces an empty result
     if (inputGeom.isEmpty())
-      return (Geometry) inputGeom.clone();
+      return inputGeom.copy();
 
     return (new VWTransformer(isEnsureValidTopology, distanceTolerance)).transform(inputGeom);
   }

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
@@ -727,7 +727,7 @@ public class QuadEdgeSubdivision {
 		private List triList = new ArrayList();
 
 		public void visit(QuadEdge[] triEdges) {
-			triList.add(triEdges.clone());
+			triList.add(triEdges);
 		}
 
 		public List getTriangleEdges() {

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeTriangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeTriangle.java
@@ -13,6 +13,7 @@
 package org.locationtech.jts.triangulate.quadedge;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.locationtech.jts.algorithm.PointLocation;
@@ -132,11 +133,11 @@ public class QuadEdgeTriangle
 	 * @param edge an array of the edges of the triangle in CCW order
 	 */
 	public QuadEdgeTriangle(QuadEdge[] edge) {
-		this.edge = (QuadEdge[]) edge.clone();
+		this.edge = (QuadEdge[]) Arrays.copyOf(edge, edge.length);
 		// link the quadedges back to this triangle
-    for (int i = 0; i < 3; i++) {
-      edge[i].setData(this);
-    }
+		for (int i = 0; i < 3; i++) {
+			edge[i].setData(this);
+		}
 	}
 
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/geom/NormalizeTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/NormalizeTest.java
@@ -187,7 +187,7 @@ public class NormalizeTest extends TestCase {
     Geometry geom = pcsReader.read("LINESTRING (100 100, 0 0)");
     geom.normalize();
     // force PackedCoordinateSequence to be copied with empty coordinate cache
-    Geometry clone = (Geometry) geom.clone();
+    Geometry clone = (Geometry) geom.copy();
     assertEqualsExact(geom, clone);
   }
 

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/BasicCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/BasicCoordinateSequenceTest.java
@@ -32,7 +32,7 @@ public class BasicCoordinateSequenceTest extends TestCase {
     public void testClone() {
         CoordinateSequence s1 = CoordinateArraySequenceFactory.instance().create(
             new Coordinate[] { new Coordinate(1, 2), new Coordinate(3, 4)});
-        CoordinateSequence s2 = (CoordinateSequence) s1.clone();
+        CoordinateSequence s2 = (CoordinateSequence) s1.copy();
         assertTrue(s1.getCoordinate(0).equals(s2.getCoordinate(0)));
         assertTrue(s1.getCoordinate(0) != s2.getCoordinate(0));
     }
@@ -45,7 +45,7 @@ public class BasicCoordinateSequenceTest extends TestCase {
     s1.setOrdinate(1, 0, 3);
     s1.setOrdinate(1, 1, 4);
 
-    CoordinateSequence s2 = (CoordinateSequence) s1.clone();
+    CoordinateSequence s2 = (CoordinateSequence) s1.copy();
     assertTrue(s1.getDimension() == s2.getDimension());
     assertTrue(s1.getCoordinate(0).equals(s2.getCoordinate(0)));
     assertTrue(s1.getCoordinate(0) != s2.getCoordinate(0));

--- a/modules/core/src/test/java/org/locationtech/jts/geom/util/AffineTransformationTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/util/AffineTransformationTest.java
@@ -240,7 +240,7 @@ public class AffineTransformationTest
     AffineTransformation trans = AffineTransformation
         .rotationInstance(Math.PI / 2);
     AffineTransformation inv = trans.getInverse();
-    Geometry transGeom = (Geometry) geom.clone();
+    Geometry transGeom = (Geometry) geom.copy();
     transGeom.apply(trans);
     // System.out.println(transGeom);
     transGeom.apply(inv);

--- a/modules/core/src/test/java/org/locationtech/jts/operation/union/CascadedPolygonUnionTester.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/union/CascadedPolygonUnionTester.java
@@ -92,7 +92,7 @@ public class CascadedPolygonUnionTester
       Geometry geom = (Geometry) i.next();
       
       if (unionAll == null) {
-      	unionAll = (Geometry) geom.clone();
+      	unionAll = (Geometry) geom.copy();
       }
       else {
       	unionAll = unionAll.union(geom);

--- a/modules/core/src/test/java/test/jts/junit/GeometryUtils.java
+++ b/modules/core/src/test/java/test/jts/junit/GeometryUtils.java
@@ -72,7 +72,7 @@ public class GeometryUtils
   
   public static Geometry normalize(Geometry g)
   {
-  	Geometry g2 = (Geometry) g.clone();
+  	Geometry g2 = (Geometry) g.copy();
   	g2.normalize();
   	return g2;
   }

--- a/modules/core/src/test/java/test/jts/junit/MiscellaneousTest.java
+++ b/modules/core/src/test/java/test/jts/junit/MiscellaneousTest.java
@@ -53,7 +53,7 @@ public class MiscellaneousTest extends TestCase {
       Geometry a = reader.read("LINESTRING(0 0, 10 10)");
       //Envelope is lazily initialized [Jon Aquino]
       a.getEnvelopeInternal();
-      Geometry b = (Geometry)a.clone();
+      Geometry b = (Geometry)a.copy();
       assertTrue(a.getEnvelopeInternal() != b.getEnvelopeInternal());
   }
 

--- a/modules/core/src/test/java/test/jts/perf/operation/union/UnionPerfTester.java
+++ b/modules/core/src/test/java/test/jts/perf/operation/union/UnionPerfTester.java
@@ -114,7 +114,7 @@ public class UnionPerfTester
       Geometry geom = (Geometry) i.next();
       
       if (unionAll == null) {
-      	unionAll = (Geometry) geom.clone();
+      	unionAll = (Geometry) geom.copy();
       }
       else {
       	unionAll = unionAll.union(geom);

--- a/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinate.java
+++ b/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinate.java
@@ -53,6 +53,10 @@ public class ExtendedCoordinate
     super(coord);
     m = coord.m;
   }
+  
+  public ExtendedCoordinate copy() {
+    return new ExtendedCoordinate(this);
+  }
 
   /**
    * An example of extended data.

--- a/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequence.java
+++ b/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequence.java
@@ -155,10 +155,17 @@ public class ExtendedCoordinateSequence
     }
   }
 
+  /**
+   * @deprecated
+   */
   public Object clone() {
-    ExtendedCoordinate[] cloneCoordinates = new ExtendedCoordinate[size()];
+    return copy();
+  }
+  
+  public ExtendedCoordinateSequence copy() {
+	  ExtendedCoordinate[] cloneCoordinates = new ExtendedCoordinate[size()];
     for (int i = 0; i < coordinates.length; i++) {
-      cloneCoordinates[i] = (ExtendedCoordinate) coordinates[i].clone();
+      cloneCoordinates[i] = coordinates[i].copy();
     }
 
     return new ExtendedCoordinateSequence(cloneCoordinates);


### PR DESCRIPTION
The built in `Object.clone` is not suitable to rely on for portable implementation. With a original method for copying there is also the added benefit of getting the correct type instead of `Object`.