### PR TITLE
Introduce no args create methods for empty geometries

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
@@ -85,7 +85,7 @@ public class ConvexHull
   public Geometry getConvexHull() {
 
     if (inputPts.length == 0) {
-      return geomFactory.createGeometryCollection(null);
+      return geomFactory.createGeometryCollection();
     }
     if (inputPts.length == 1) {
       return geomFactory.createPoint(inputPts[0]);
@@ -394,7 +394,7 @@ public class ConvexHull
 //          geometry.getPrecisionModel(), geometry.getSRID());
     }
     LinearRing linearRing = geomFactory.createLinearRing(coordinates);
-    return geomFactory.createPolygon(linearRing, null);
+    return geomFactory.createPolygon(linearRing);
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumBoundingCircle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumBoundingCircle.java
@@ -93,7 +93,7 @@ public class MinimumBoundingCircle
 		
 		compute();
 		if (centre == null)
-			return input.getFactory().createPolygon(null, null);
+			return input.getFactory().createPolygon();
 		Point centrePoint = input.getFactory().createPoint(centre);
 		if (radius == 0.0)
 			return centrePoint;
@@ -114,7 +114,7 @@ public class MinimumBoundingCircle
     compute();
     switch (extremalPts.length) {
     case 0:
-      return input.getFactory().createLineString((CoordinateSequence) null);
+      return input.getFactory().createLineString();
     case 1:
       return input.getFactory().createPoint(centre);
     }
@@ -135,7 +135,7 @@ public class MinimumBoundingCircle
     compute();
     switch (extremalPts.length) {
     case 0:
-      return input.getFactory().createLineString((CoordinateSequence) null);
+      return input.getFactory().createLineString();
     case 1:
       return input.getFactory().createPoint(centre);
     }

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
@@ -145,7 +145,7 @@ public class MinimumDiameter
 
     // return empty linestring if no minimum width calculated
     if (minWidthPt == null)
-      return inputGeom.getFactory().createLineString((Coordinate[])null);
+      return inputGeom.getFactory().createLineString();
 
     Coordinate basePt = minBaseSeg.project(minWidthPt);
     return inputGeom.getFactory().createLineString(new Coordinate[] { basePt, minWidthPt } );
@@ -312,7 +312,7 @@ public class MinimumDiameter
     
     LinearRing shell = inputGeom.getFactory().createLinearRing(
         new Coordinate[] { p0, p1, p2, p3, p0 });
-    return inputGeom.getFactory().createPolygon(shell, null);
+    return inputGeom.getFactory().createPolygon(shell);
 
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -517,7 +517,7 @@ public abstract class Geometry
   public Point getCentroid()
   {
     if (isEmpty()) 
-      return factory.createPoint((Coordinate) null);
+      return factory.createPoint();
     Coordinate centPt = Centroid.getCentroid(this);
     return createPointFromInternalCoord(centPt, this);
   }
@@ -535,7 +535,7 @@ public abstract class Geometry
   public Point getInteriorPoint()
   {
     if (isEmpty()) 
-      return factory.createPoint((Coordinate) null);
+      return factory.createPoint();
     Coordinate interiorPt = null;
     int dim = getDimension();
     if (dim == 0) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
@@ -215,7 +215,7 @@ public class GeometryFactory
   {
   	// null envelope - return empty point geometry
     if (envelope.isNull()) {
-      return createPoint((CoordinateSequence)null);
+      return createPoint();
     }
     
     // point?
@@ -252,6 +252,10 @@ public class GeometryFactory
     return precisionModel;
   }
 
+  public Point createPoint() {
+	return createPoint(getCoordinateSequenceFactory().create(new Coordinate[]{}));
+  }
+  
   /**
    * Creates a Point using the given Coordinate.
    * A null Coordinate creates an empty Geometry.
@@ -273,6 +277,10 @@ public class GeometryFactory
   public Point createPoint(CoordinateSequence coordinates) {
   	return new Point(coordinates, this);
   }
+  
+  public MultiLineString createMultiLineString() {
+    return new MultiLineString(null, this);
+  }
 
   /**
    * Creates a MultiLineString using the given LineStrings; a null or empty
@@ -284,6 +292,10 @@ public class GeometryFactory
   public MultiLineString createMultiLineString(LineString[] lineStrings) {
   	return new MultiLineString(lineStrings, this);
   }
+  
+  public GeometryCollection createGeometryCollection() {
+    return new GeometryCollection(null, this);
+  }
 
   /**
    * Creates a GeometryCollection using the given Geometries; a null or empty
@@ -294,6 +306,10 @@ public class GeometryFactory
    */
   public GeometryCollection createGeometryCollection(Geometry[] geometries) {
   	return new GeometryCollection(geometries, this);
+  }
+  
+  public MultiPolygon createMultiPolygon() {
+    return new MultiPolygon(null, this);
   }
 
   /**
@@ -309,6 +325,10 @@ public class GeometryFactory
    */
   public MultiPolygon createMultiPolygon(Polygon[] polygons) {
     return new MultiPolygon(polygons, this);
+  }
+  
+  public LinearRing createLinearRing() {
+    return createLinearRing(getCoordinateSequenceFactory().create(new Coordinate[]{}));
   }
 
   /**
@@ -334,6 +354,10 @@ public class GeometryFactory
    */
   public LinearRing createLinearRing(CoordinateSequence coordinates) {
     return new LinearRing(coordinates, this);
+  }
+  
+  public MultiPoint createMultiPoint() {
+    return new MultiPoint(null, this);
   }
 
   /**
@@ -438,6 +462,10 @@ public class GeometryFactory
   public Polygon createPolygon(LinearRing shell) {
     return createPolygon(shell, null);
   }
+  
+  public Polygon createPolygon() {
+    return createPolygon(null, null);
+  }
 
   /**
    *  Build an appropriate <code>Geometry</code>, <code>MultiGeometry</code>, or
@@ -492,7 +520,7 @@ public class GeometryFactory
      */
     // for the empty geometry, return an empty GeometryCollection
     if (geomClass == null) {
-      return createGeometryCollection(null);
+      return createGeometryCollection();
     }
     if (isHeterogeneous || hasGeometryCollection) {
       return createGeometryCollection(toGeometryArray(geomList));
@@ -515,6 +543,10 @@ public class GeometryFactory
       Assert.shouldNeverReachHere("Unhandled class: " + geom0.getClass().getName());
     }
     return geom0;
+  }
+  
+  public LineString createLineString() {
+    return createLineString(getCoordinateSequenceFactory().create(new Coordinate[]{}));
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
@@ -73,7 +73,7 @@ public class MultiPoint
    * @see Geometry#getBoundary
    */
   public Geometry getBoundary() {
-    return getFactory().createGeometryCollection(null);
+    return getFactory().createGeometryCollection();
   }
 
   public boolean isValid() {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
@@ -92,7 +92,7 @@ public class MultiPolygon
    */
   public Geometry getBoundary() {
     if (isEmpty()) {
-      return getFactory().createMultiLineString(null);
+      return getFactory().createMultiLineString();
     }
     ArrayList allRings = new ArrayList();
     for (int i = 0; i < geometries.length; i++) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/OctagonalEnvelope.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/OctagonalEnvelope.java
@@ -292,7 +292,7 @@ public class OctagonalEnvelope
   public Geometry toGeometry(GeometryFactory geomFactory)
   {
     if (isNull()) {
-      return geomFactory.createPoint((CoordinateSequence)null);
+      return geomFactory.createPoint();
     }
 
     Coordinate px00 = new Coordinate(minX, minA - minX);
@@ -337,7 +337,7 @@ public class OctagonalEnvelope
     // must be a polygon, so add closing point
     coordList.add(px00, false);
     Coordinate[] pts = coordList.toCoordinateArray();
-    return geomFactory.createPolygon(geomFactory.createLinearRing(pts), null);
+    return geomFactory.createPolygon(geomFactory.createLinearRing(pts));
   }
 
   private static class BoundingOctagonComponentFilter

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
@@ -128,7 +128,7 @@ public class Point
    * @see Geometry#getBoundary
    */
   public Geometry getBoundary() {
-    return getFactory().createGeometryCollection(null);
+    return getFactory().createGeometryCollection();
   }
 
   protected Envelope computeEnvelopeInternal() {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -274,7 +274,7 @@ public class Polygon
    */
   public Geometry getBoundary() {
     if (isEmpty()) {
-      return getFactory().createMultiLineString(null);
+      return getFactory().createMultiLineString();
     }
     LinearRing[] rings = new LinearRing[holes.length + 1];
     rings[0] = shell;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryCombiner.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryCombiner.java
@@ -151,7 +151,7 @@ public class GeometryCombiner
     if (elems.size() == 0) {
     	if (geomFactory != null) {
       // return an empty GC
-    		return geomFactory.createGeometryCollection(null);
+    		return geomFactory.createGeometryCollection();
     	}
     	return null;
     }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryEditor.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryEditor.java
@@ -169,7 +169,7 @@ public class GeometryEditor
     Polygon newPolygon = (Polygon) operation.edit(polygon, factory);
     // create one if needed
     if (newPolygon == null)
-      newPolygon = factory.createPolygon((CoordinateSequence) null);
+      newPolygon = factory.createPolygon();
     if (newPolygon.isEmpty()) {
       //RemoveSelectedPlugIn relies on this behaviour. [Jon Aquino]
       return newPolygon;
@@ -178,7 +178,7 @@ public class GeometryEditor
     LinearRing shell = (LinearRing) edit(newPolygon.getExteriorRing(), operation);
     if (shell == null || shell.isEmpty()) {
       //RemoveSelectedPlugIn relies on this behaviour. [Jon Aquino]
-      return factory.createPolygon(null, null);
+      return factory.createPolygon();
     }
 
     ArrayList holes = new ArrayList();

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryTransformer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryTransformer.java
@@ -246,7 +246,6 @@ public class GeometryTransformer
         || ! (shell instanceof LinearRing)
         || shell.isEmpty() )
       isAllValidLinearRings = false;
-//return factory.createPolygon(null, null);
 
     ArrayList holes = new ArrayList();
     for (int i = 0; i < geom.getNumInteriorRing(); i++) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/SineStarFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/SineStarFactory.java
@@ -124,7 +124,7 @@ public class SineStarFactory
     pts[iPt] = new Coordinate(pts[0]);
 
     LinearRing ring = geomFact.createLinearRing(pts);
-    Polygon poly = geomFact.createPolygon(ring, null);
+    Polygon poly = geomFact.createPolygon(ring);
     return poly;
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
@@ -523,7 +523,7 @@ public class WKTReader
   private Point readPointText() throws IOException, ParseException {
     String nextToken = getNextEmptyOrOpener();
     if (nextToken.equals(EMPTY)) {
-      return geometryFactory.createPoint((Coordinate)null);
+      return geometryFactory.createPoint();
     }
     Point point = geometryFactory.createPoint(getPreciseCoordinate());
     getNextCloser();
@@ -698,7 +698,7 @@ public class WKTReader
   private MultiPolygon readMultiPolygonText() throws IOException, ParseException {
     String nextToken = getNextEmptyOrOpener();
     if (nextToken.equals(EMPTY)) {
-      return geometryFactory.createMultiPolygon(new Polygon[]{});
+      return geometryFactory.createMultiPolygon();
     }
     ArrayList polygons = new ArrayList();
     Polygon polygon = readPolygonText();

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/BufferBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/BufferBuilder.java
@@ -319,7 +319,7 @@ class BufferBuilder
    */
   private Geometry createEmptyResultGeometry()
   {
-    Geometry emptyGeom = geomFact.createPolygon(null, null);
+    Geometry emptyGeom = geomFact.createPolygon();
     return emptyGeom;
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlay/OverlayOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlay/OverlayOp.java
@@ -642,16 +642,16 @@ public class OverlayOp
   	Geometry result = null;
   	switch (resultDimension(overlayOpCode, a, b)) {
   	case -1:
-  		result = geomFact.createGeometryCollection(new Geometry[0]);
+  		result = geomFact.createGeometryCollection();
   		break;
   	case 0:
-  		result =  geomFact.createPoint((Coordinate) null);
+  		result =  geomFact.createPoint();
   		break;
   	case 1:
-  		result =  geomFact.createLineString((Coordinate[]) null);
+  		result =  geomFact.createLineString();
   		break;
   	case 2:
-  		result =  geomFact.createPolygon(null, null);
+  		result =  geomFact.createPolygon();
   		break;
   	}
 		return result;

--- a/modules/core/src/main/java/org/locationtech/jts/operation/union/UnaryUnionOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/union/UnaryUnionOp.java
@@ -230,7 +230,7 @@ public class UnaryUnionOp
 			union = PointGeometryUnion.union((Puntal) unionPoints, unionLA);
 		
 		if (union == null)
-			return geomFact.createGeometryCollection(null);
+			return geomFact.createGeometryCollection();
 		
 		return union;
 	}
@@ -271,7 +271,7 @@ public class UnaryUnionOp
    */
 	private Geometry unionNoOpt(Geometry g0)
 	{
-    Geometry empty = geomFact.createPoint((Coordinate) null);
+    Geometry empty = geomFact.createPoint();
 		return SnapIfNeededOverlayOp.overlayOp(g0, empty, OverlayOp.UNION);
 	}
 	

--- a/modules/core/src/main/java/org/locationtech/jts/precision/MinimumClearance.java
+++ b/modules/core/src/main/java/org/locationtech/jts/precision/MinimumClearance.java
@@ -178,7 +178,7 @@ public class MinimumClearance
     compute();
     // return empty line string if no min pts where found
     if (minClearancePts == null || minClearancePts[0] == null)
-      return inputGeom.getFactory().createLineString((Coordinate[]) null);
+      return inputGeom.getFactory().createLineString();
     return inputGeom.getFactory().createLineString(minClearancePts);
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
@@ -852,7 +852,7 @@ public class QuadEdgeSubdivision {
 		for (Iterator it = triPtsList.iterator(); it.hasNext();) {
 			Coordinate[] triPt = (Coordinate[]) it.next();
 			tris[i++] = geomFact
-					.createPolygon(geomFact.createLinearRing(triPt), null);
+					.createPolygon(geomFact.createLinearRing(triPt));
 		}
 		return geomFact.createGeometryCollection(tris);
 	}
@@ -940,7 +940,7 @@ public class QuadEdgeSubdivision {
     }
     
     Coordinate[] pts = coordList.toCoordinateArray();
-    Polygon cellPoly = geomFact.createPolygon(geomFact.createLinearRing(pts), null);
+    Polygon cellPoly = geomFact.createPolygon(geomFact.createLinearRing(pts));
     
     Vertex v = startQE.orig();
     cellPoly.setUserData(v.getCoordinate());

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeTriangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeTriangle.java
@@ -99,7 +99,7 @@ public class QuadEdgeTriangle
 				v[1].getCoordinate(), v[2].getCoordinate(), v[0].getCoordinate() };
 		GeometryFactory fact = new GeometryFactory();
 		LinearRing ring = fact.createLinearRing(ringPts);
-		Polygon tri = fact.createPolygon(ring, null);
+		Polygon tri = fact.createPolygon(ring);
 		return tri;
 	}
 
@@ -109,7 +109,7 @@ public class QuadEdgeTriangle
 				e[0].orig().getCoordinate() };
 		GeometryFactory fact = new GeometryFactory();
 		LinearRing ring = fact.createLinearRing(ringPts);
-		Polygon tri = fact.createPolygon(ring, null);
+		Polygon tri = fact.createPolygon(ring);
 		return tri;
 	}
 
@@ -249,7 +249,7 @@ public class QuadEdgeTriangle
 
 	public Polygon getGeometry(GeometryFactory fact) {
 		LinearRing ring = fact.createLinearRing(getCoordinates());
-		Polygon tri = fact.createPolygon(ring, null);
+		Polygon tri = fact.createPolygon(ring);
 		return tri;
 	}
 

--- a/modules/core/src/main/java/org/locationtech/jts/util/GeometricShapeFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/util/GeometricShapeFactory.java
@@ -186,7 +186,7 @@ public class GeometricShapeFactory
     pts[ipt++] = new Coordinate(pts[0]);
 
     LinearRing ring = geomFact.createLinearRing(pts);
-    Polygon poly = geomFact.createPolygon(ring, null);
+    Polygon poly = geomFact.createPolygon(ring);
     return (Polygon) rotate(poly);
   }
 
@@ -229,7 +229,7 @@ public class GeometricShapeFactory
     pts[iPt] = new Coordinate(pts[0]);
 
     LinearRing ring = geomFact.createLinearRing(pts);
-    Polygon poly = geomFact.createPolygon(ring, null);
+    Polygon poly = geomFact.createPolygon(ring);
     return (Polygon) rotate(poly);
   }
   /**
@@ -293,7 +293,7 @@ public class GeometricShapeFactory
     pts[pts.length-1] = new Coordinate(pts[0]);
 
     LinearRing ring = geomFact.createLinearRing(pts);
-    Polygon poly = geomFact.createPolygon(ring, null);
+    Polygon poly = geomFact.createPolygon(ring);
     return (Polygon) rotate(poly);
   }
 
@@ -372,7 +372,7 @@ public class GeometricShapeFactory
     }
     pts[iPt++] = coord(centreX, centreY);
     LinearRing ring = geomFact.createLinearRing(pts);
-    Polygon poly = geomFact.createPolygon(ring, null);
+    Polygon poly = geomFact.createPolygon(ring);
     return (Polygon) rotate(poly);
   }
 


### PR DESCRIPTION
Because overloading on null is problematic, especially when transpiling to JavaScript.