### PR TITLE
Add specifically named create for MultiPoint from coords

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
@@ -384,6 +384,12 @@ public class GeometryFactory
                               : null);
   }
 
+  public MultiPoint createMultiPointFromCoords(Coordinate[] coordinates) {
+      return createMultiPoint(coordinates != null
+                              ? getCoordinateSequenceFactory().create(coordinates)
+                              : null);
+  }
+
   /**
    * Creates a {@link MultiPoint} using the 
    * points in the given {@link CoordinateSequence}.

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
@@ -377,6 +377,7 @@ public class GeometryFactory
    *
    * @param coordinates an array (without null elements), or an empty array, or <code>null</code>
    * @return a MultiPoint object
+   * @deprecated Use {@link GeometryFactory#createMultiPointFromCoords} instead
    */
   public MultiPoint createMultiPoint(Coordinate[] coordinates) {
       return createMultiPoint(coordinates != null
@@ -384,6 +385,13 @@ public class GeometryFactory
                               : null);
   }
 
+  /**
+   * Creates a {@link MultiPoint} using the given {@link Coordinate}s.
+   * A null or empty array will create an empty MultiPoint.
+   *
+   * @param coordinates an array (without null elements), or an empty array, or <code>null</code>
+   * @return a MultiPoint object
+   */
   public MultiPoint createMultiPointFromCoords(Coordinate[] coordinates) {
       return createMultiPoint(coordinates != null
                               ? getCoordinateSequenceFactory().create(coordinates)

--- a/modules/core/src/main/java/org/locationtech/jts/operation/BoundaryOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/BoundaryOp.java
@@ -80,7 +80,7 @@ public class BoundaryOp
 
   private MultiPoint getEmptyMultiPoint()
   {
-    return geomFact.createMultiPoint((CoordinateSequence) null);
+    return geomFact.createMultiPoint();
   }
 
   private Geometry boundaryMultiLineString(MultiLineString mLine)
@@ -96,7 +96,7 @@ public class BoundaryOp
       return geomFact.createPoint(bdyPts[0]);
     }
     // this handles 0 points case as well
-    return geomFact.createMultiPoint(bdyPts);
+    return geomFact.createMultiPointFromCoords(bdyPts);
   }
 
 /*

--- a/modules/core/src/main/java/org/locationtech/jts/operation/union/PointGeometryUnion.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/union/PointGeometryUnion.java
@@ -77,7 +77,7 @@ public class PointGeometryUnion
 			ptComp = geomFact.createPoint(coords[0]);
 		}
 		else {
-			ptComp = geomFact.createMultiPoint(coords);
+			ptComp = geomFact.createMultiPointFromCoords(coords);
 		}
 		
 		// add point component to the other geometry

--- a/modules/core/src/main/java/org/locationtech/jts/shape/random/RandomPointsBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/shape/random/RandomPointsBuilder.java
@@ -80,7 +80,7 @@ extends GeometricShapeBuilder
   			continue;
   		pts[i++] = p;
   	}
-  	return geomFactory.createMultiPoint(pts);
+  	return geomFactory.createMultiPointFromCoords(pts);
   }
   
   protected boolean isInExtent(Coordinate p)

--- a/modules/core/src/main/java/org/locationtech/jts/shape/random/RandomPointsInGridBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/shape/random/RandomPointsInGridBuilder.java
@@ -110,7 +110,7 @@ extends GeometricShapeBuilder
         pts[index++] = randomPointInCell(orgX, orgY, cellDX, cellDY);
       }
     }
-    return geomFactory.createMultiPoint(pts);
+    return geomFactory.createMultiPointFromCoords(pts);
   }
   
   private Coordinate randomPointInCell(double orgX, double orgY, double xLen, double yLen)


### PR DESCRIPTION
This one is problematic for overload resolution when transpiling to JSTS because there are two variants taking array input with different types, but that information is erased and the arrays might be empty.

Not breaking API for Java as the existing methods are kept. in JSTS createMultiPoint will only work with Point arrays and `createMultiPointFromCoords` is needed for Coordinate arrays.

Also removes one more case of createMultiPoint with null argument.