### PR TITLE
Rename coordinate edit method

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/geom/GeometryBoxDeleter.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/geom/GeometryBoxDeleter.java
@@ -106,7 +106,7 @@ public class GeometryBoxDeleter
     
     public boolean isEdited() { return isEdited; }
   
-    public Coordinate[] edit(Coordinate[] coords,
+    public Coordinate[] editCoordinates(Coordinate[] coords,
         Geometry geometry)
     {
       if (isEdited) return coords;

--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/geom/GeometryVertexDeleter.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/geom/GeometryVertexDeleter.java
@@ -41,7 +41,7 @@ public class GeometryVertexDeleter
       this.vertexIndex = vertexIndex;
     }
     
-    public Coordinate[] edit(Coordinate[] coords,
+    public Coordinate[] editCoordinates(Coordinate[] coords,
         Geometry geometry)
     {
       if (geometry != line) return coords;

--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/geom/GeometryVertexInserter.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/geom/GeometryVertexInserter.java
@@ -41,7 +41,7 @@ public class GeometryVertexInserter
       this.newVertex = newVertex;
     }
     
-    public Coordinate[] edit(Coordinate[] coords,
+    public Coordinate[] editCoordinates(Coordinate[] coords,
         Geometry geometry)
     {
       if (geometry != line) return coords;

--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/geom/GeometryVertexMover.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/geom/GeometryVertexMover.java
@@ -37,7 +37,7 @@ public class GeometryVertexMover
       this.toLoc = toLoc;
     }
     
-    public Coordinate[] edit(Coordinate[] coords,
+    public Coordinate[] editCoordinates(Coordinate[] coords,
         Geometry geometry)
     {
       Coordinate[] newPts = new Coordinate[coords.length];

--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/topostretch/GeometryVerticesMover.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/topostretch/GeometryVerticesMover.java
@@ -59,7 +59,7 @@ public class GeometryVerticesMover
     }
     
     
-    public Coordinate[] edit(Coordinate[] coords,
+    public Coordinate[] editCoordinates(Coordinate[] coords,
         Geometry geometry)
     {
       Coordinate[] newPts = new Coordinate[coords.length];

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryEditor.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryEditor.java
@@ -279,17 +279,17 @@ public class GeometryEditor
   {
     public final Geometry edit(Geometry geometry, GeometryFactory factory) {
       if (geometry instanceof LinearRing) {
-        return factory.createLinearRing(edit(geometry.getCoordinates(),
+        return factory.createLinearRing(editCoordinates(geometry.getCoordinates(),
             geometry));
       }
 
       if (geometry instanceof LineString) {
-        return factory.createLineString(edit(geometry.getCoordinates(),
+        return factory.createLineString(editCoordinates(geometry.getCoordinates(),
             geometry));
       }
 
       if (geometry instanceof Point) {
-        Coordinate[] newCoordinates = edit(geometry.getCoordinates(),
+        Coordinate[] newCoordinates = editCoordinates(geometry.getCoordinates(),
             geometry);
 
         return factory.createPoint((newCoordinates.length > 0)
@@ -310,7 +310,7 @@ public class GeometryEditor
      * @param geometry the geometry containing the coordinate list
      * @return an edited coordinate array (which may be the same as the input)
      */
-    public abstract Coordinate[] edit(Coordinate[] coordinates,
+    public abstract Coordinate[] editCoordinates(Coordinate[] coordinates,
                                       Geometry geometry);
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/precision/PrecisionReducerCoordinateOperation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/precision/PrecisionReducerCoordinateOperation.java
@@ -31,7 +31,7 @@ public class PrecisionReducerCoordinateOperation extends
 		this.removeCollapsed = removeCollapsed;
 	}
 	
-	public Coordinate[] edit(Coordinate[] coordinates, Geometry geom) {
+	public Coordinate[] editCoordinates(Coordinate[] coordinates, Geometry geom) {
 		if (coordinates.length == 0)
 			return null;
 

--- a/modules/core/src/main/java/org/locationtech/jts/precision/SimpleGeometryPrecisionReducer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/precision/SimpleGeometryPrecisionReducer.java
@@ -109,7 +109,7 @@ public class SimpleGeometryPrecisionReducer
   private class PrecisionReducerCoordinateOperation
       extends GeometryEditor.CoordinateOperation
   {
-    public Coordinate[] edit(Coordinate[] coordinates, Geometry geom)
+    public Coordinate[] editCoordinates(Coordinate[] coordinates, Geometry geom)
     {
       if (coordinates.length == 0) return null;
 


### PR DESCRIPTION
This is to solve a difficult overload situation that I haven't been able to solve in transpiling. It's a case of relying on inheritance and method overload at the same time.

As this is a breaking change so I understand if it's not acceptable. Wanted to suggest it anyway if it's known that this API is rarely used and could perhaps be changed.