### PR TITLE
Expose ordinal constants and use instead of reflection

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -155,16 +155,25 @@ public abstract class Geometry
     implements Cloneable, Comparable, Serializable
 {
   private static final long serialVersionUID = 8763622679187376702L;
-
-  static final int SORTINDEX_POINT = 0;
-  static final int SORTINDEX_MULTIPOINT = 1;
-  static final int SORTINDEX_LINESTRING = 2;
-  static final int SORTINDEX_LINEARRING = 3;
-  static final int SORTINDEX_MULTILINESTRING = 4;
-  static final int SORTINDEX_POLYGON = 5;
-  static final int SORTINDEX_MULTIPOLYGON = 6;
-  static final int SORTINDEX_GEOMETRYCOLLECTION = 7;
-
+    
+  protected static final int TYPECODE_POINT = 0;
+  protected static final int TYPECODE_MULTIPOINT = 1;
+  protected static final int TYPECODE_LINESTRING = 2;
+  protected static final int TYPECODE_LINEARRING = 3;
+  protected static final int TYPECODE_MULTILINESTRING = 4;
+  protected static final int TYPECODE_POLYGON = 5;
+  protected static final int TYPECODE_MULTIPOLYGON = 6;
+  protected static final int TYPECODE_GEOMETRYCOLLECTION = 7;
+  
+  public static final String TYPENAME_POINT = "Point";
+  public static final String TYPENAME_MULTIPOINT = "MultiPoint";
+  public static final String TYPENAME_LINESTRING = "LineString";
+  public static final String TYPENAME_LINEARRING = "LinearRing";
+  public static final String TYPENAME_MULTILINESTRING = "MultiLineString";
+  public static final String TYPENAME_POLYGON = "Polygon";
+  public static final String TYPENAME_MULTIPOLYGON = "MultiPolygon";
+  public static final String TYPENAME_GEOMETRYCOLLECTION = "GeometryCollection";
+  
   private final static GeometryComponentFilter geometryChangedFilter = new GeometryComponentFilter() {
     public void filter(Geometry geom) {
       geom.geometryChangedAction();
@@ -1722,8 +1731,8 @@ public abstract class Geometry
    */
   public int compareTo(Object o) {
     Geometry other = (Geometry) o;
-    if (getSortIndex() != other.getSortIndex()) {
-      return getSortIndex() - other.getSortIndex();
+    if (getTypeCode() != other.getTypeCode()) {
+      return getTypeCode() - other.getTypeCode();
     }
     if (isEmpty() && other.isEmpty()) {
       return 0;
@@ -1769,8 +1778,8 @@ public abstract class Geometry
    */
   public int compareTo(Object o, CoordinateSequenceComparator comp) {
     Geometry other = (Geometry) o;
-    if (getSortIndex() != other.getSortIndex()) {
-      return getSortIndex() - other.getSortIndex();
+    if (getTypeCode() != other.getTypeCode()) {
+      return getTypeCode() - other.getTypeCode();
     }
     if (isEmpty() && other.isEmpty()) {
       return 0;
@@ -1822,7 +1831,7 @@ public abstract class Geometry
    */
   protected boolean isGeometryCollection()
   {
-    return getSortIndex() == SORTINDEX_GEOMETRYCOLLECTION;
+    return getTypeCode() == TYPECODE_GEOMETRYCOLLECTION;
   }
 
   /**
@@ -1901,7 +1910,7 @@ public abstract class Geometry
     return a.distance(b) <= tolerance;
   }
 
-  abstract protected int getSortIndex();
+  abstract protected int getTypeCode();
 
   private Point createPointFromInternalCoord(Coordinate coord, Geometry exemplar)
   {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
@@ -129,7 +129,7 @@ public class GeometryCollection extends Geometry {
   }
 
   public String getGeometryType() {
-    return "GeometryCollection";
+    return Geometry.TYPENAME_GEOMETRYCOLLECTION;
   }
 
   public Geometry getBoundary() {
@@ -268,9 +268,9 @@ public class GeometryCollection extends Geometry {
     return 0;
 
   }
-
-  protected int getSortIndex() {
-    return Geometry.SORTINDEX_GEOMETRYCOLLECTION;
+  
+  protected int getTypeCode() {
+    return Geometry.TYPECODE_GEOMETRYCOLLECTION;
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
@@ -150,7 +150,7 @@ public class LineString
   }
 
   public String getGeometryType() {
-    return "LineString";
+    return Geometry.TYPENAME_LINESTRING;
   }
 
   /**
@@ -326,9 +326,9 @@ public class LineString
     LineString line = (LineString) o;
     return comp.compare(this.points, line.points);
   }
-
-  protected int getSortIndex() {
-    return Geometry.SORTINDEX_LINESTRING;
+  
+  protected int getTypeCode() {
+    return Geometry.TYPECODE_LINESTRING;
   }
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
@@ -121,11 +121,11 @@ public class LinearRing extends LineString
 
 
   public String getGeometryType() {
-    return "LinearRing";
+    return Geometry.TYPENAME_LINEARRING;
   }
-
-  protected int getSortIndex() {
-    return Geometry.SORTINDEX_LINEARRING;
+  
+  protected int getTypeCode() {
+    return Geometry.TYPECODE_LINEARRING;
   }
 
   protected LinearRing copyInternal() {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
@@ -67,7 +67,7 @@ public class MultiLineString
   }
 
   public String getGeometryType() {
-    return "MultiLineString";
+    return Geometry.TYPENAME_MULTILINESTRING;
   }
 
   public boolean isClosed() {
@@ -123,8 +123,8 @@ public class MultiLineString
     return super.equalsExact(other, tolerance);
   }
 
-  protected int getSortIndex() {
-    return Geometry.SORTINDEX_MULTILINESTRING;
+  protected int getTypeCode() {
+    return Geometry.TYPECODE_MULTILINESTRING;
   }
 }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
@@ -61,7 +61,7 @@ public class MultiPoint
   }
 
   public String getGeometryType() {
-    return "MultiPoint";
+    return Geometry.TYPENAME_MULTIPOINT;
   }
 
   /**
@@ -106,8 +106,8 @@ public class MultiPoint
     return new MultiPoint(points, factory);
   }
   
-  protected int getSortIndex() {
-    return Geometry.SORTINDEX_MULTIPOINT;
+  protected int getTypeCode() {
+    return Geometry.TYPECODE_MULTIPOINT;
   }
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
@@ -75,7 +75,7 @@ public class MultiPolygon
   }
 
   public String getGeometryType() {
-    return "MultiPolygon";
+    return Geometry.TYPENAME_MULTIPOLYGON;
   }
 
   /*
@@ -133,8 +133,8 @@ public class MultiPolygon
     return new MultiPolygon(polygons, factory);
   }
 
-  protected int getSortIndex() {
-    return Geometry.SORTINDEX_MULTIPOLYGON;
+  protected int getTypeCode() {
+    return Geometry.TYPECODE_MULTIPOLYGON;
   }
 }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
@@ -116,7 +116,7 @@ public class Point
   }
 
   public String getGeometryType() {
-    return "Point";
+    return Geometry.TYPENAME_POINT;
   }
 
   /**
@@ -215,9 +215,9 @@ public class Point
     Point point = (Point) other;
     return comp.compare(this.coordinates, point.coordinates);
   }
-
-  protected int getSortIndex() {
-    return Geometry.SORTINDEX_POINT;
+  
+  protected int getTypeCode() {
+    return Geometry.TYPECODE_POINT;
   }
 
   public CoordinateSequence getCoordinateSequence() {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -221,7 +221,7 @@ public class Polygon
   }
 
   public String getGeometryType() {
-    return "Polygon";
+    return Geometry.TYPENAME_POLYGON;
   }
 
   /**
@@ -394,9 +394,9 @@ public class Polygon
     if (i < nHole2) return -1;
     return 0;
   }
-
-  protected int getSortIndex() {
-    return Geometry.SORTINDEX_POLYGON;
+  
+  protected int getTypeCode() {
+    return Geometry.TYPECODE_POLYGON;
   }
 
   private LinearRing normalized(LinearRing ring, boolean clockwise) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryExtracter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryExtracter.java
@@ -40,6 +40,7 @@ public class GeometryExtracter
    * 
    * @param geom the geometry from which to extract
    * @param list the list to add the extracted elements to
+   * @deprecated Use {@link GeometryExtracter#extract(Geometry, String, List)}
    */
   public static List extract(Geometry geom, Class clz, List list)
   {
@@ -97,7 +98,7 @@ public class GeometryExtracter
    * and returns them in a {@link List}.
    * 
    * @param geom the geometry from which to extract
-   * @deprecated Use {@link GeometryExtracter#extract(Geometry, String, List)}
+   * @deprecated Use {@link GeometryExtracter#extract(Geometry, String)}
    */
   public static List extract(Geometry geom, Class clz)
   {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryExtracter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryExtracter.java
@@ -18,6 +18,13 @@ import java.util.List;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFilter;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 /**
  * Extracts the components of a given type from a {@link Geometry}.
@@ -27,13 +34,6 @@ import org.locationtech.jts.geom.GeometryFilter;
 public class GeometryExtracter
   implements GeometryFilter
 {
-	
-	protected static boolean isOfClass(Object o, Class clz)
-	{
-		return clz.isAssignableFrom(o.getClass());
-//		return o.getClass() == clz;
-	}
-	
   /**
    * Extracts the components of type <tt>clz</tt> from a {@link Geometry}
    * and adds them to the provided {@link List}.
@@ -43,11 +43,49 @@ public class GeometryExtracter
    */
   public static List extract(Geometry geom, Class clz, List list)
   {
-  	if (isOfClass(geom, clz)) {
+  	return extract(geom, toGeometryType(clz), list);
+  }
+  
+  /**
+   * @deprecated
+   */
+  private static String toGeometryType(Class clz) {
+	if (clz == null)
+	  return null;
+	else if (clz.isAssignableFrom(Point.class))
+	  return Geometry.TYPENAME_POINT;
+	else if (clz.isAssignableFrom(LineString.class))
+	  return Geometry.TYPENAME_LINESTRING;
+	else if (clz.isAssignableFrom(LinearRing.class))
+	  return Geometry.TYPENAME_LINEARRING;
+	else if (clz.isAssignableFrom(Polygon.class))
+	  return Geometry.TYPENAME_POLYGON;
+	else if (clz.isAssignableFrom(MultiPoint.class))
+	  return Geometry.TYPENAME_MULTIPOINT;
+	else if (clz.isAssignableFrom(MultiLineString.class))
+	  return Geometry.TYPENAME_MULTILINESTRING;
+	else if (clz.isAssignableFrom(MultiPolygon.class))
+	  return Geometry.TYPENAME_MULTIPOLYGON;
+	else if (clz.isAssignableFrom(GeometryCollection.class))
+	  return Geometry.TYPENAME_GEOMETRYCOLLECTION;
+	throw new RuntimeException("Unsupported class");
+  }
+  
+  /**
+   * Extracts the components of <tt>geometryType</tt> from a {@link Geometry}
+   * and adds them to the provided {@link List}.
+   * 
+   * @param geom the geometry from which to extract
+   * @param geometryType Geometry type to extract (null means all types)
+   * @param list the list to add the extracted elements to
+   */
+  public static List extract(Geometry geom, String geometryType, List list)
+  {
+  	if (geom.getGeometryType() == geometryType) {
   		list.add(geom);
   	}
   	else if (geom instanceof GeometryCollection) {
-  		geom.apply(new GeometryExtracter(clz, list));
+  		geom.apply(new GeometryExtracter(geometryType, list));
   	}
   	// skip non-LineString elemental geometries
   	
@@ -59,13 +97,19 @@ public class GeometryExtracter
    * and returns them in a {@link List}.
    * 
    * @param geom the geometry from which to extract
+   * @deprecated Use {@link GeometryExtracter#extract(Geometry, String, List)}
    */
   public static List extract(Geometry geom, Class clz)
   {
     return extract(geom, clz, new ArrayList());
   }
+  
+  public static List extract(Geometry geom, String geometryType)
+  {
+    return extract(geom, geometryType, new ArrayList());
+  }
 
-  private Class clz;
+  private String geometryType;
   private List comps;
   
   /**
@@ -73,16 +117,36 @@ public class GeometryExtracter
    * 
    * @param clz the class of the components to extract (null means all types)
    * @param comps the list to extract into
+   * @deprecated
    */
   public GeometryExtracter(Class clz, List comps)
   {
-  	this.clz = clz;
+  	this.geometryType = toGeometryType(clz);
     this.comps = comps;
   }
-
-  public void filter(Geometry geom)
+  
+  /**
+   * Constructs a filter with a list in which to store the elements found.
+   * 
+   * @param geometryType Geometry type to extract (null means all types)
+   * @param comps the list to extract into
+   */
+  public GeometryExtracter(String geometryType, List comps)
   {
-    if (clz == null || isOfClass(geom, clz)) comps.add(geom);
+  	this.geometryType = geometryType;
+    this.comps = comps;
+  }
+  
+  protected static boolean isOfType(Geometry geom, String geometryType) {
+    if (geom.getGeometryType() == geometryType) return true;
+    if (geometryType == Geometry.TYPENAME_LINESTRING
+      && geom.getGeometryType() == Geometry.TYPENAME_LINEARRING) return true;
+    return false;
+  }
+
+  public void filter(Geometry geom) {
+    if (geometryType == null || isOfType(geom, geometryType))
+      comps.add(geom);
   }
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryExtracterTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryExtracterTest.java
@@ -1,0 +1,35 @@
+package org.locationtech.jts.geom.util;
+
+import java.util.List;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+import junit.framework.TestCase;
+
+public class GeometryExtracterTest extends TestCase {
+
+	static WKTReader reader = new WKTReader();
+	
+	public GeometryExtracterTest(String name) {
+		super(name);
+	}
+	
+	public void testExtract() throws ParseException {
+		Geometry gc = reader.read("GEOMETRYCOLLECTION ( POINT (1 1), LINESTRING (0 0, 10 10), LINESTRING (10 10, 20 20), LINEARRING (10 10, 20 20, 15 15, 10 10), POLYGON ((0 0, 100 0, 100 100, 0 100, 0 0)), GEOMETRYCOLLECTION ( POINT (1 1) ) )");
+		
+		// verify that LinearRings are included when extracting LineStrings
+		List lineStringsAndLinearRings = GeometryExtracter.extract(gc, Geometry.TYPENAME_LINESTRING);
+		assertEquals(3, lineStringsAndLinearRings.size());
+		
+		// verify that only LinearRings are extracted
+		List linearRings = GeometryExtracter.extract(gc, Geometry.TYPENAME_LINEARRING);
+		assertEquals(1, linearRings.size());
+		
+		// verify that nested geometries are extracted
+		List points = GeometryExtracter.extract(gc, Geometry.TYPENAME_POINT);
+		assertEquals(2, points.size());
+	}
+
+}


### PR DESCRIPTION
Primary goal of this PR is to avoid use of reflection in GeometryExtracter. Keeps existing API as deprecated.

The rename of SORTINDEX_* to ORDINAL_* is a suggestion from previous discussion.