### PR TITLE
Upgrade commons-lang3 (3.5 -> 3.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.5</version>
+            <version>3.7</version>
         </dependency>
         <dependency>
           <groupId>com.oracle</groupId>


### PR DESCRIPTION
Note that newer than 3.5 versions require java 7

see also: http://commons.apache.org/proper/commons-lang/release-notes/RELEASE-NOTES-3.7.txt
