### PR TITLE
Updates to allow for publishing to Maven central.

### DIFF
--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -20,10 +20,24 @@
 
     <modules>
         <module>core</module>
-        <module>example</module>
         <module>io</module>
-        <module>tests</module>
-        <module>app</module>
     </modules>
-    
+
+    <profiles>
+        <profile>
+            <id>all</id>
+            <activation>
+                <property>
+                    <name>!release</name>
+                </property>
+            </activation>
+
+            <modules>
+                <module>example</module>
+                <module>tests</module>
+                <module>app</module>
+            </modules>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
     To build with jts-sde:
        mvn install -Parcsde
        
-    To build everything:
-       mvn install -Dall
+    To build the release (for Maven Central; committers only)
+       mvn install -Drelease
     -->
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.locationtech.jts</groupId>
     <artifactId>jts</artifactId>
@@ -43,18 +42,14 @@
 
     <!-- PROJECT INFORMATION -->
     <licenses>
-      <license>
-        <name>Eclipse Publish License, Version 1.0</name>
-        <url>https://github.com/dr-jts/jts/blob/master/LICENSE_EPLv1.txt</url>
-      </license>
-      <license>
-        <name>Martin Davis Distribution License (BSD 3 Clause)</name>
-        <url>https://github.com/dr-jts/jts/blob/master/LICENSE_MDAVIS_BSDv3.txt</url>
-      </license>
-      <license>
-        <name>Vivid Solutions Distribution License (BSD 3 Clause)</name>
-        <url>https://github.com/dr-jts/jts/blob/master/LICENSE_VSI_BSDv3.txt</url>
-      </license>
+        <license>
+            <name>Eclipse Publish License, Version 1.0</name>
+            <url>https://github.com/locationtech/jts/blob/master/LICENSE_EPLv1.txt</url>
+        </license>
+        <license>
+            <name>Eclipse Distribution License - v 1.0</name>
+            <url>https://github.com/locationtech/jts/blob/master/LICENSE_EDLv1.txt</url>
+        </license>
     </licenses>
     <developers>
         <developer>
@@ -69,131 +64,198 @@
             <organization>Individual</organization>
             <organizationUrl>http://tsusiatsoftware.net</organizationUrl>
         </developer>
-     </developers>
+    </developers>
 
-     <scm>
-        <connection>scm:git:https://github.com/locationtech/jts.git</connection>
-        <developerConnection>scm:https://github.com/locationtech/jts.git</developerConnection>
+    <scm>
+        <connection>scm:git::git@github.com:locationtech/jts.git</connection>
+        <developerConnection>scm:git:git@github.com:locationtech/jts.git</developerConnection>
         <url>https://github.com/locationtech/jts</url>
-     </scm>
+        <tag>HEAD</tag>
+    </scm>
 
-    <!-- PUBLISHING -->
     <distributionManagement>
-        <repository>
-            <id>repo.locationtech.org</id>
-            <name>JTS Repository - Releases</name>
-            <url>https://repo.locationtech.org/content/repositories/jts-releases/</url>
-        </repository>
         <snapshotRepository>
             <id>repo.locationtech.org</id>
             <name>JTS Repository - Snapshots</name>
             <url>https://repo.locationtech.org/content/repositories/jts-snapshots/</url>
         </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
-    
+
     <dependencyManagement>
-      <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jdom</groupId>
-            <artifactId>jdom2</artifactId>
-            <version>${jdom-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>${json-simple-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
-        </dependency>
-        <dependency>
-          <groupId>com.oracle</groupId>
-          <artifactId>ojdbc7</artifactId>
-          <version>11.1.0.7.0</version>
-        </dependency>
-      </dependencies>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jdom</groupId>
+                <artifactId>jdom2</artifactId>
+                <version>${jdom-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.json-simple</groupId>
+                <artifactId>json-simple</artifactId>
+                <version>${json-simple-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.7</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle</groupId>
+                <artifactId>ojdbc7</artifactId>
+                <version>11.1.0.7.0</version>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 
     <!-- Repositories for Dependencies -->
     <repositories>
-      <repository>
-        <id>central.maven.org</id>
-        <name>Central Maven repository</name>
-        <url>http://central.maven.org/maven2</url>
-        <snapshots>
-          <enabled>false</enabled>
-        </snapshots>
-      </repository>
+        <repository>
+            <id>central.maven.org</id>
+            <name>Central Maven repository</name>
+            <url>http://central.maven.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.7</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <!-- =========================================================== -->
     <!--     Build Configuration                                     -->
     <!-- =========================================================== -->
     <build>
-      <plugins>
-         <!-- test configuration -->
-         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.15</version>
-          <configuration>
-            <includes>
-              <include>**/*Test.java</include>
-            </includes>
-            <excludes>
-              <exclude>**/*PerfTest.java</exclude>
-              <exclude>**/*StressTest.java</exclude>
-              <exclude>**/jts/perf/**/*.java</exclude>
-            </excludes>
-          </configuration>
-        </plugin>
+        <plugins>
+            <!-- test configuration -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.15</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*PerfTest.java</exclude>
+                        <exclude>**/*StressTest.java</exclude>
+                        <exclude>**/jts/perf/**/*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <configuration>
+                    <show>public</show>
+                    <header>${project.name} ${project.version}</header>
+                    <footer>${project.name} ${project.version}</footer>
+                    <overview>${basedir}/modules/core/src/main/javadoc/overview.html</overview>
 
-		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-javadoc-plugin</artifactId>
-			<version>2.10.4</version>
-			<configuration>
-				<show>public</show>
-				<header>${project.name} ${project.version}</header>
-				<footer>${project.name} ${project.version}</footer>
-				<overview>${basedir}/modules/core/src/main/javadoc/overview.html</overview>
-				
-				<excludePackageNames>org.locationtech.jtsexample.*,org.locationtech.jtstest,org.locationtech.jtstest.*</excludePackageNames>
-				
-				<groups>
-					<group>
-					  <title>Core - Geometry</title>
-					  <packages>org.locationtech.jts.geom:org.locationtech.jts.geom.*</packages>
-					</group>
-					<group>
-					  <title>Core - I/O</title>
-					  <packages>org.locationtech.jts.io</packages>
-					</group>
-					<group>
-					  <title>Core - Algorithms</title>
-					  <packages>org.locationtech.jts.algorithm:org.locationtech.jts.algorithm.*:org.locationtech.jts.densify:org.locationtech.jts.dissolve:org.locationtech.jts.linearref:org.locationtech.jts.operation.*:org.locationtech.jts.simplify:org.locationtech.jts.triangulate</packages>
-					</group>
-					<group>
-					  <title>Core - Other</title>
-					  <packages>org.locationtech.jts:org.locationtech.jts.*</packages>
-					</group>
-					<group>
-					  <title>I/O - Common</title>
-					  <packages>org.locationtech.jts.io.*</packages>
-					</group>
-				</groups>
-				
-			</configuration>
-		</plugin>
-
-      </plugins>
+                    <excludePackageNames>org.locationtech.jtsexample.*,org.locationtech.jtstest,org.locationtech.jtstest.*</excludePackageNames>
+                    <failOnError>false</failOnError>
+                    <groups>
+                        <group>
+                            <title>Core - Geometry</title>
+                            <packages>org.locationtech.jts.geom:org.locationtech.jts.geom.*</packages>
+                        </group>
+                        <group>
+                            <title>Core - I/O</title>
+                            <packages>org.locationtech.jts.io</packages>
+                        </group>
+                        <group>
+                            <title>Core - Algorithms</title>
+                            <packages>org.locationtech.jts.algorithm:org.locationtech.jts.algorithm.*:org.locationtech.jts.densify:org.locationtech.jts.dissolve:org.locationtech.jts.linearref:org.locationtech.jts.operation.*:org.locationtech.jts.simplify:org.locationtech.jts.triangulate</packages>
+                        </group>
+                        <group>
+                            <title>Core - Other</title>
+                            <packages>org.locationtech.jts:org.locationtech.jts.*</packages>
+                        </group>
+                        <group>
+                            <title>I/O - Common</title>
+                            <packages>org.locationtech.jts.io.*</packages>
+                        </group>
+                    </groups>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <!-- Modules to build in appropriate dependency order -->


### PR DESCRIPTION
* Creates 'release' profile and ties it to a 'release' property.

To release, call 'mvn clean install -Drelease'.

Normal, non-release builds will build the app, tests, and example modules.