### PR TITLE
Fix Overlay polygon building

### DIFF
--- a/modules/tests/src/test/resources/testxml/general/TestFunctionAA.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestFunctionAA.xml
@@ -630,4 +630,34 @@
 </test>
 </case>
 
+<case>
+  <desc>AA - Polygons which stress hole assignment</desc>
+  <a>
+POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 1 2, 2 1, 1 1), (1 2, 1 3, 2 3, 1 2), (2 3, 3 3, 3 2, 2 3))
+  </a>
+  <b>
+POLYGON ((2 1, 3 1, 3 2, 2 1))
+  </b>
+<test>
+  <op name="intersection" arg1="A" arg2="B">
+POLYGON ((3 2, 3 1, 2 1, 3 2))
+  </op>
+</test>
+<test>
+  <op name="union" arg1="A" arg2="B">
+POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0), (1 2, 1 1, 2 1, 1 2), (1 2, 2 3, 1 3, 1 2), (2 3, 3 2, 3 3, 2 3))
+  </op>
+</test>
+<test>
+  <op name="difference" arg1="A" arg2="B">
+MULTIPOLYGON (((0 0, 0 4, 4 4, 4 0, 0 0), (1 2, 1 1, 2 1, 3 1, 3 2, 3 3, 2 3, 1 3, 1 2)), ((2 1, 1 2, 2 3, 3 2, 2 1)))
+  </op>
+</test>
+<test>
+  <op name="symdifference" arg1="A" arg2="B">
+MULTIPOLYGON (((0 0, 0 4, 4 4, 4 0, 0 0), (1 2, 1 1, 2 1, 3 1, 3 2, 3 3, 2 3, 1 3, 1 2)), ((2 1, 1 2, 2 3, 3 2, 2 1)))
+  </op>
+</test>
+</case>
+
 </run>


### PR DESCRIPTION
This fix handles a subtle situation during the polygon topology build phase of the Overlay algorithm (specifically, during free hole assignment).  It copies correct logic which had already been implemented in the Polygonizer code, but never applied back to overlay.

This has been fairly extensively tested, and has a unit test to capture the original failure case.

Fixes #255.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>