### PR TITLE
ExtendableCoordinateSequence

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/ExtendableCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/ExtendableCoordinateSequence.java
@@ -280,7 +280,7 @@ public class ExtendableCoordinateSequence implements CoordinateSequence {
    * @param x a x-ordinate
    * @param y a y-ordinate
    * @param z a z-ordinate
-   * @param m a z-ordinate
+   * @param m a m-ordinate
    */
   public void add(double x, double y, double z, double m) {
     // get the index for the new sequence
@@ -336,7 +336,7 @@ public class ExtendableCoordinateSequence implements CoordinateSequence {
    * @param x a x-ordinate
    * @param y a y-ordinate
    * @param z a z-ordinate
-   * @param m a z-ordinate
+   * @param m a m-ordinate
    */
   public void insertAt(int index, double x, double y, double z, double m) {
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/ExtendableCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/ExtendableCoordinateSequence.java
@@ -1,0 +1,244 @@
+
+/*
+ * Copyright (c) 2018 Felix Obermaier.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.geom;
+
+/**
+ * A wrapper around a coordinate sequence that always
+ * ensures that a sequence is large enough to store ordinate
+ * values.
+ */
+public class ExtendableCoordinateSequence implements CoordinateSequence {
+
+  /** The default initial capacity */
+  static final int INITIAL_CAPACITY = 12;
+
+  /** The factory to use when extending the current sequence*/
+  private final CoordinateSequenceFactory csFactory;
+  /** The current sequence */
+  private CoordinateSequence sequence;
+  /** The current size of the sequence */
+  private int size = 0;
+
+  /**
+   * Creates an instance of this class using the provided coordinate sequence factory and dimension
+   * The initial capacity is set to {@link #INITIAL_CAPACITY}.
+   *
+   * @param csFactory a coordinate sequence factory
+   * @param dimension a dimension
+   */
+  public ExtendableCoordinateSequence(CoordinateSequenceFactory csFactory, int dimension) {
+    this(csFactory, INITIAL_CAPACITY, dimension);
+  }
+
+  /**
+   * Creates an instance of this class using the provided coordinate sequence factory,
+   * initial capacity and dimension
+   *
+   * @param csFactory           a coordinate sequence factory
+   * @param initialCapacity     an initial capacity
+   * @param dimension           a dimension
+   */
+  public ExtendableCoordinateSequence(CoordinateSequenceFactory csFactory, int initialCapacity, int dimension) {
+
+    if (csFactory == null)
+      throw new IllegalArgumentException("csFactory must not be null");
+
+    if (initialCapacity < 1)
+      throw new IllegalArgumentException("initialCapacity must be > 0");
+
+    this.csFactory = csFactory;
+    this.sequence = csFactory.create(initialCapacity, dimension);
+  }
+
+  /**
+   * Creates an instance of this class using the provided coordinate sequence factory, size and coordinate sequence.
+   *
+   * @param csFactory a coordinate sequence factory
+   * @param size      a size
+   * @param sequence  a sequence
+   */
+  private ExtendableCoordinateSequence(CoordinateSequenceFactory csFactory, int size, CoordinateSequence sequence) {
+
+    /* this is private, we ensure this elsewhere
+    if (csFactory == null)
+      throw new IllegalArgumentException("csFactory must not be null");
+
+    if (sequence instanceof ExtendableCoordinateSequence)
+      throw new IllegalArgumentException("sequence must not be an ExtendableCoordinateSequence");
+     */
+    this.csFactory = csFactory;
+    this.sequence = sequence;
+    this.size = size;
+  }
+
+  /** @see CoordinateSequence#size() */
+  public int size() {
+    return this.size;
+  }
+
+  /** @see CoordinateSequence#getDimension() */
+  public int getDimension() {
+    return this.sequence.getDimension();
+  }
+
+  /** @see CoordinateSequence#getCoordinate(int) */
+  public Coordinate getCoordinate(int index) {
+    checkSize(index);
+    return this.sequence.getCoordinate(index);
+  }
+
+  /** @see CoordinateSequence#getCoordinate(int, Coordinate) */
+  public void getCoordinate(int index, Coordinate out) {
+    checkSize(index);
+    this.sequence.getCoordinate(index, out);
+  }
+
+  /** @see CoordinateSequence#getCoordinateCopy(int) */
+  public Coordinate getCoordinateCopy(int index) {
+    checkSize(index);
+    return this.sequence.getCoordinateCopy(index);
+  }
+
+  /** @see CoordinateSequence#getX(int) */
+  public double getX(int index) {
+    checkSize(index);
+    return this.sequence.getX(index);
+  }
+
+  /** @see CoordinateSequence#getY(int) */
+  public double getY(int index) {
+    checkSize(index);
+    return this.sequence.getY(index);
+  }
+
+  /** @see CoordinateSequence#getOrdinate(int, int) */
+  public double getOrdinate(int index, int ordinate) {
+    checkSize(index);
+    return this.sequence.getOrdinate(index, ordinate);
+  }
+
+  /** @see CoordinateSequence#setOrdinate(int, int, double) */
+  public void setOrdinate(int index, int ordinate, double value) {
+
+    // ensure capacity
+    ensureCapacity(index);
+
+    // set value in sequence
+    this.sequence.setOrdinate(index, ordinate, value);
+
+    // adjust size
+    if (!(index < size)) size = index + 1;
+  }
+
+  /** @see CoordinateSequence#expandEnvelope(Envelope) */
+  public Envelope expandEnvelope(Envelope env) {
+
+    for (int i = 0; i < size; i++ )
+      env.expandToInclude(sequence.getX(i), sequence.getY(i));
+    return env;
+  }
+
+  /** @see CoordinateSequence#toCoordinateArray() */
+  public Coordinate[] toCoordinateArray() {
+    Coordinate[] res = new Coordinate[this.size];
+    for (int i = 0; i < size; i++)
+      res[i] = this.sequence.getCoordinate(i);
+    return res;
+  }
+
+  /** @see CoordinateSequence#clone() */
+  public Object clone() {
+    return this.copy();
+  }
+
+  /** @see CoordinateSequence#copy() */
+  public ExtendableCoordinateSequence copy() {
+    return new ExtendableCoordinateSequence(this.csFactory, this.size, this.sequence.copy());
+  }
+
+  /**
+   * Creates a copy of the <b>used</b> portion of the underlying sequence and returns that.
+   * The underlying sequence itself is untouched.
+   * 
+   * @return A sequence
+   */
+  public CoordinateSequence truncated() {
+    CoordinateSequence res = csFactory.create(this.size, this.sequence.getDimension());
+    CoordinateSequences.copy(this.sequence, 0, res, 0, this.size);
+    return res;
+  }
+
+  /**
+   * Gets a value indicating the capacity of the underlying sequence
+   *
+   * @return the capacity
+   */
+  public int getCapacity() {
+    return this.sequence.size();
+  }
+
+  /**
+   * Tests if {@code index} is in the allowed bounds. If not, the bounds are extended.
+   * 
+   * @param index an index
+   */
+  private void ensureCapacity(int index) {
+    if (index < 0)
+      throw new IllegalArgumentException("index < 0");
+
+    int capacity = getCapacity();
+    if (index < capacity)
+      return;
+
+
+    do {
+      capacity *= 2;
+    } while (index >= capacity);
+
+    CoordinateSequence newSequence = csFactory.create(capacity, this.sequence.getDimension());
+    CoordinateSequences.copy(sequence, 0, newSequence, 0, this.sequence.size());
+    sequence = newSequence;
+    size = index + 1;
+  }
+
+  /**
+   * Checks if the size is within the allowed bounds
+   * 
+   * @param index an index
+   */
+  private void checkSize(int index) throws IllegalArgumentException {
+    if (0 <= index && index < this.size)
+      return;
+
+    throw new IllegalArgumentException(
+            String.format("index is %d and must be in the range [0, %d)", index, this.size));
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("EXT(");
+    builder.append(sequence.getClass().getSimpleName());
+    builder.append(String.format(", size=%d, dim=%d, cap=%d)", size, getDimension(), getCapacity()));
+    builder.append('[');
+    for (int i = 0; i < size; i++)
+    {
+      if (i > 0) builder.append(',');
+      builder.append(sequence.getX(i) + " " + sequence.getY(i));
+      for (int j = 2; j < sequence.getDimension(); j++)
+        builder.append(" " + sequence.getOrdinate(i, j));
+    }
+    builder.append(']');
+    return builder.toString();
+  }
+}

--- a/modules/core/src/main/java/org/locationtech/jts/geom/ExtendableCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/ExtendableCoordinateSequence.java
@@ -15,12 +15,17 @@ package org.locationtech.jts.geom;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequence;
 
+import java.io.Serializable;
+
 /**
  * A wrapper around a coordinate sequence that always
  * ensures that a sequence is large enough to store ordinate
  * values.
  */
-public class ExtendableCoordinateSequence implements CoordinateSequence {
+public class ExtendableCoordinateSequence implements CoordinateSequence, Serializable {
+
+  /** The serial version UID */
+  private static final long serialVersionUID = 1167611362034559688L;
 
   /** The default initial capacity */
   static final int INITIAL_CAPACITY = 10;
@@ -170,7 +175,10 @@ public class ExtendableCoordinateSequence implements CoordinateSequence {
     return res;
   }
 
-  /** @see CoordinateSequence#clone() */
+  /**
+   * @see CoordinateSequence#clone()
+   * @deprecated use {@link #copy()}
+   */
   public Object clone() {
     return this.copy();
   }
@@ -212,11 +220,11 @@ public class ExtendableCoordinateSequence implements CoordinateSequence {
 
     // check if the current capacity is sufficient
     int oldCapacity = getCapacity();
-    if (minCapacity < oldCapacity)
+    if (minCapacity <= oldCapacity)
       return;
 
     // compute the new capacity (see ArrayList implementation
-    int newCapacity = (oldCapacity * 3) / 2 + 1;
+    int newCapacity = oldCapacity + (oldCapacity >> 1);
     if (newCapacity < minCapacity) newCapacity = minCapacity;
 
     // create the new sequence

--- a/modules/core/src/main/java/org/locationtech/jts/geom/ExtendableCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/ExtendableCoordinateSequence.java
@@ -223,8 +223,10 @@ public class ExtendableCoordinateSequence implements CoordinateSequence, Seriali
     if (minCapacity <= oldCapacity)
       return;
 
-    // compute the new capacity (see ArrayList implementation
+    // compute the new capacity (see ArrayList implementation)
     int newCapacity = oldCapacity + (oldCapacity >> 1);
+    // to mimic GrowableCoordinateSequence use this
+    //int newCapacity = oldCapacity + 50;
     if (newCapacity < minCapacity) newCapacity = minCapacity;
 
     // create the new sequence
@@ -235,15 +237,15 @@ public class ExtendableCoordinateSequence implements CoordinateSequence, Seriali
     }
     else if (this.sequence instanceof PackedCoordinateSequence.Double) {
       // performance improvement for PackedCoordinateSequence.Double
-      System.arraycopy(((PackedCoordinateSequence.Double)this.sequence).getRawCoordinates(), 0,
-              ((PackedCoordinateSequence.Double)newSequence).getRawCoordinates(), 0,
-              this.sequence.size() * this.sequence.getDimension());
+      double[] srcSeq = ((PackedCoordinateSequence.Double)this.sequence).getRawCoordinates();
+      double[] tgtSeq = ((PackedCoordinateSequence.Double)newSequence).getRawCoordinates();
+      System.arraycopy(srcSeq, 0, tgtSeq, 0, srcSeq.length);
     }
     else if (this.sequence instanceof PackedCoordinateSequence.Float) {
       // performance improvement for PackedCoordinateSequence.Float
-      System.arraycopy(((PackedCoordinateSequence.Float)this.sequence).getRawCoordinates(), 0,
-              ((PackedCoordinateSequence.Float)newSequence).getRawCoordinates(), 0,
-              this.sequence.size() * this.sequence.getDimension());
+      float[] srcSeq = ((PackedCoordinateSequence.Float)this.sequence).getRawCoordinates();
+      float[] tgtSeq = ((PackedCoordinateSequence.Float)newSequence).getRawCoordinates();
+      System.arraycopy(srcSeq, 0, tgtSeq, 0, srcSeq.length);
     }
     else
     {
@@ -268,7 +270,13 @@ public class ExtendableCoordinateSequence implements CoordinateSequence, Seriali
    * @param y a y-ordinate
    */
   public void add(double x, double y) {
-    add(x, y, Double.NaN);
+    //add(x, y, Double.NaN);
+    // get the index for the new sequence
+    int index = this.size();
+
+    // add x- and y-ordinates
+    this.setOrdinate(index, CoordinateSequence.X, x);
+    this.setOrdinate(index, CoordinateSequence.Y, y);
   }
 
   /**
@@ -278,7 +286,15 @@ public class ExtendableCoordinateSequence implements CoordinateSequence, Seriali
    * @param z a z-ordinate
    */
   public void add(double x, double y, double z) {
-    add(x, y, z, Double.NaN);
+    //add(x, y, z, Double.NaN);
+
+    // get the index for the new sequence
+    int index = this.size();
+    // add x- and y-ordinates
+    this.setOrdinate(index, CoordinateSequence.X, x);
+    this.setOrdinate(index, CoordinateSequence.Y, y);
+    if (getDimension() == 2) return;
+    this.setOrdinate(index, CoordinateSequence.Z, z);
   }
 
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/geom/ExtendableCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/ExtendableCoordinateSequenceTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2018 Felix Obermaier.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.geom;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+import org.locationtech.jts.geom.impl.CoordinateArraySequenceFactory;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
+
+
+/**
+ * Unit test class for {@link ExtendableCoordinateSequence}
+ */
+public class ExtendableCoordinateSequenceTest extends TestCase {
+
+  public static void main(String[] args){
+    TestRunner.run(ExtendableCoordinateSequenceTest.class);
+  }
+
+  public ExtendableCoordinateSequenceTest(String name) {
+    super(name);
+  }
+
+  public void testConstructor() {
+    doTestConstructor(null, 2);
+    doTestConstructor(null, 2, 7);
+    doTestConstructor(CoordinateArraySequenceFactory.instance(), 2);
+    doTestConstructor(CoordinateArraySequenceFactory.instance(), 3);
+    doTestConstructor(CoordinateArraySequenceFactory.instance(), 3, 0);
+    doTestConstructor(CoordinateArraySequenceFactory.instance(), 3, 7);
+    doTestConstructor(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 2);
+    doTestConstructor(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 3);
+    doTestConstructor(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4, 7);
+  }
+
+  public void testExtend() {
+
+    doTestExtend(CoordinateArraySequenceFactory.instance(), 2);
+    doTestExtend(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
+
+  }
+
+  public void testTruncated() {
+
+    doTestTruncated(CoordinateArraySequenceFactory.instance(), 2);
+    doTestTruncated(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
+
+  }
+
+  public void testCopy() {
+
+    doTestCopy(CoordinateArraySequenceFactory.instance(), 2);
+    doTestCopy(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
+
+  }
+
+  public void testToCoordinateSequence() {
+
+    doTestCoordinateSequence(CoordinateArraySequenceFactory.instance(), 2);
+    doTestCoordinateSequence(CoordinateArraySequenceFactory.instance(), 3);
+    doTestCoordinateSequence(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 2);
+    doTestCoordinateSequence(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 3);
+    doTestCoordinateSequence(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
+    doTestCoordinateSequence(PackedCoordinateSequenceFactory.FLOAT_FACTORY, 4);
+  }
+  private static void doTestConstructor(CoordinateSequenceFactory csf, int dimension) {
+
+    // arrange
+    ExtendableCoordinateSequence eseq = null;
+
+    // act
+    try {
+      eseq = new ExtendableCoordinateSequence(csf, dimension);
+      if (csf == null) fail();
+    } catch (IllegalArgumentException e) {
+      // nothing to do here, this was expected!
+    }
+
+    if (csf == null) return;
+
+    // assert
+    assertNotNull(eseq);
+    assertEquals(0, eseq.size());
+    assertEquals(dimension, eseq.getDimension());
+    assertEquals(ExtendableCoordinateSequence.INITIAL_CAPACITY, eseq.getCapacity());
+
+  }
+  private static void doTestConstructor(CoordinateSequenceFactory csf, int dimension, int capacity) {
+
+    // arrange
+    ExtendableCoordinateSequence eseq = null;
+    // act
+    try {
+      eseq = new ExtendableCoordinateSequence(csf, capacity, dimension);
+      if (csf == null || capacity < 1) fail();
+    } catch (IllegalArgumentException e) {
+
+    }
+
+    // assert
+    if (csf == null || capacity < 1) {
+      assertNull(eseq);
+      return;
+    }
+
+    assertNotNull(eseq);
+    assertEquals(0, eseq.size());
+    assertEquals(dimension, eseq.getDimension());
+    assertEquals(capacity, eseq.getCapacity());
+  }
+
+  private static void doTestExtend(CoordinateSequenceFactory csf, int dimension) {
+
+    // arrange
+    ExtendableCoordinateSequence eseq = new ExtendableCoordinateSequence(csf, dimension);
+
+    int capacity = eseq.getCapacity();
+    int currentCapacity = capacity;
+    int count = (int) (2.5 * capacity);
+    for (int i = 0; i < count; i++) {
+      eseq.setOrdinate(i, CoordinateSequence.X, i * 10 + 1);
+      eseq.setOrdinate(i, CoordinateSequence.Y, i * 10 + 2);
+
+      assertEquals(i + 1, eseq.size());
+      if (i > 0 && (i % currentCapacity) == 0)
+        currentCapacity*=2;
+      assertEquals(currentCapacity, eseq.getCapacity());
+    }
+
+    assertEquals(count, eseq.size());
+    assertEquals(4*capacity, eseq.getCapacity());
+  }
+
+  private static ExtendableCoordinateSequence create(CoordinateSequenceFactory csf, int dimension, int size) {
+
+    ExtendableCoordinateSequence eseq = new ExtendableCoordinateSequence(csf, dimension);
+    for (int i = 0; i < size; i++) {
+      for (int j = 0; j < dimension; j++)
+        eseq.setOrdinate(i, j, i * 10d + j + 1);
+    }
+    return eseq;
+
+  }
+
+  private static void doTestCopy(CoordinateSequenceFactory csf, int dimension)
+  {
+    ExtendableCoordinateSequence eseq = create(csf, dimension, 6);
+
+    CoordinateSequence eseqCopy = eseq.copy();
+    assertNotNull(eseqCopy);
+    assertTrue(eseqCopy instanceof ExtendableCoordinateSequence);
+    assertEquals(eseq.size(), eseqCopy.size());
+    assertEquals(eseq.getDimension(), eseqCopy.getDimension());
+    assertEquals(eseq.getCapacity(), ((ExtendableCoordinateSequence)eseqCopy).getCapacity());
+
+    assertTrue(CoordinateSequences.isEqual(eseq, eseqCopy));
+
+    eseqCopy = (CoordinateSequence) eseq.clone();
+    assertNotNull(eseqCopy);
+    assertTrue(eseqCopy instanceof ExtendableCoordinateSequence);
+    assertEquals(eseq.size(), eseqCopy.size());
+    assertEquals(eseq.getDimension(), eseqCopy.getDimension());
+    assertEquals(eseq.getCapacity(), ((ExtendableCoordinateSequence)eseqCopy).getCapacity());
+
+    assertTrue(CoordinateSequences.isEqual(eseq, eseqCopy));
+
+  }
+
+  private static void doTestTruncated(CoordinateSequenceFactory csf, int dimension)
+  {
+    ExtendableCoordinateSequence eseq = create(csf, dimension, 8);
+
+    CoordinateSequence seqTruncated = eseq.truncated();
+    assertNotNull(seqTruncated);
+    assertEquals(8, seqTruncated.size());
+    assertEquals(eseq.getDimension(), seqTruncated.getDimension());
+
+    assertTrue(CoordinateSequences.isEqual(eseq, seqTruncated));
+  }
+
+  private static void doTestCoordinateSequence(CoordinateSequenceFactory csf, int dimension) {
+
+    final int size = 5;
+    ExtendableCoordinateSequence eseq = create(csf, dimension, size);
+
+    Coordinate[] coordinates = eseq.toCoordinateArray();
+
+    assertNotNull(coordinates);
+    assertEquals(size, coordinates.length);
+    Coordinate tmp = new Coordinate();
+    for (int i = 0; i < coordinates.length; i++)
+    {
+      assertTrue(coordinates[i].equals2D(eseq.getCoordinate(i)));
+      eseq.getCoordinate(i, tmp);
+      assertTrue(coordinates[i].equals2D(tmp));
+      assertTrue(coordinates[i].equals2D(eseq.getCoordinateCopy(i)));
+
+      assertEquals(i * 10d + 1, eseq.getX(i));
+      assertEquals(i * 10d + 1, eseq.getOrdinate(i, CoordinateSequence.X));
+      assertEquals(i * 10d + 2, eseq.getY(i));
+      assertEquals(i * 10d + 2, eseq.getOrdinate(i, CoordinateSequence.Y));
+
+      for (int j = 2; j < eseq.getDimension(); j++)
+        assertEquals(i * 10d + j+1, eseq.getOrdinate(i, j));
+    }
+
+    Envelope expEnv = new Envelope(1, (size-1)*10+1, 2, (size-1)*10+2);
+    Envelope actEnv = new Envelope();
+    eseq.expandEnvelope(actEnv);
+
+    assertEquals(expEnv, actEnv);
+    String seqText = eseq.toString();
+    assertTrue(seqText.length() > 0);
+
+    try {
+      tmp = eseq.getCoordinate(eseq.getCapacity());
+      fail();
+    } catch (IllegalArgumentException e) {
+      // This is expected
+    }
+
+    try {
+      eseq.setOrdinate(-1, CoordinateSequence.X, -1);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // This is expected
+    }
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/geom/ExtendableCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/ExtendableCoordinateSequenceTest.java
@@ -63,6 +63,26 @@ public class ExtendableCoordinateSequenceTest extends TestCase {
 
   }
 
+  public void testAdd() {
+
+    doTestAdd(CoordinateArraySequenceFactory.instance(), 2);
+    doTestAdd(CoordinateArraySequenceFactory.instance(), 3);
+    doTestAdd(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 2);
+    doTestAdd(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 3);
+    doTestAdd(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
+
+  }
+
+  public void testInsert() {
+
+    doTestInsert(CoordinateArraySequenceFactory.instance(), 2);
+    doTestInsert(CoordinateArraySequenceFactory.instance(), 3);
+    doTestInsert(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 2);
+    doTestInsert(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 3);
+    doTestInsert(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
+
+  }
+
   public void testToCoordinateSequence() {
 
     doTestCoordinateSequence(CoordinateArraySequenceFactory.instance(), 2);
@@ -185,6 +205,74 @@ public class ExtendableCoordinateSequenceTest extends TestCase {
     assertEquals(eseq.getDimension(), seqTruncated.getDimension());
 
     assertTrue(CoordinateSequences.isEqual(eseq, seqTruncated));
+  }
+
+  private static void doTestAdd(CoordinateSequenceFactory csf, int dimension) {
+
+    // arrange
+    ExtendableCoordinateSequence eseq = create(csf, dimension, 8);
+
+    // act
+    switch (dimension) {
+      case 2:
+        eseq.add(-1, -2);
+        break;
+      case 3:
+        eseq.add(-1, -2, -3);
+        break;
+      case 4:
+        eseq.add(-1, -2, -3, -4);
+        break;
+    }
+    eseq.add(new Coordinate(-11, -12));
+
+    // assert
+    assertEquals(10, eseq.size());
+    assertEquals(-1d, eseq.getOrdinate(8, CoordinateSequence.X));
+    assertEquals(-2d, eseq.getOrdinate(8, CoordinateSequence.Y));
+    if (dimension>2)
+      assertEquals(-3d, eseq.getOrdinate(8, CoordinateSequence.Z));
+    if (dimension>3)
+      assertEquals(-4d, eseq.getOrdinate(8, CoordinateSequence.M));
+
+    assertEquals(-11d, eseq.getOrdinate(9, CoordinateSequence.X));
+    assertEquals(-12d, eseq.getOrdinate(9, CoordinateSequence.Y));
+    if (dimension>2)
+      assertTrue(Double.isNaN(eseq.getOrdinate(9, CoordinateSequence.Z)));
+  }
+
+  private static void doTestInsert(CoordinateSequenceFactory csf, int dimension) {
+
+    // arrange
+    ExtendableCoordinateSequence eseq = create(csf, dimension, 8);
+
+    // act
+    switch (dimension) {
+      case 2:
+        eseq.insertAt(2, -1, -2);
+        break;
+      case 3:
+        eseq.insertAt(2,-1, -2, -3);
+        break;
+      case 4:
+        eseq.insertAt(2,-1, -2, -3, -4);
+        break;
+    }
+    eseq.insertAt(7, new Coordinate(-11, -12));
+
+    // assert
+    assertEquals(10, eseq.size());
+    assertEquals(-1d, eseq.getOrdinate(2, CoordinateSequence.X));
+    assertEquals(-2d, eseq.getOrdinate(2, CoordinateSequence.Y));
+    if (dimension>2)
+      assertEquals(-3d, eseq.getOrdinate(2, CoordinateSequence.Z));
+    if (dimension>3)
+      assertEquals(-4d, eseq.getOrdinate(2, CoordinateSequence.M));
+
+    assertEquals(-11d, eseq.getOrdinate(7, CoordinateSequence.X));
+    assertEquals(-12d, eseq.getOrdinate(7, CoordinateSequence.Y));
+    if (dimension>2)
+      assertTrue(Double.isNaN(eseq.getOrdinate(7, CoordinateSequence.Z)));
   }
 
   private static void doTestCoordinateSequence(CoordinateSequenceFactory csf, int dimension) {

--- a/modules/core/src/test/java/org/locationtech/jts/geom/ExtendableCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/ExtendableCoordinateSequenceTest.java
@@ -161,13 +161,12 @@ public class ExtendableCoordinateSequenceTest extends TestCase {
       eseq.setOrdinate(i, CoordinateSequence.Y, i * 10 + 2);
 
       assertEquals(i + 1, eseq.size());
-      if (i > 0 && (i % currentCapacity) == 0)
-        currentCapacity*=2;
+      if ((i + 1) % currentCapacity == 0)
+        currentCapacity = (currentCapacity * 3) / 2 +1;
       assertEquals(currentCapacity, eseq.getCapacity());
     }
 
     assertEquals(count, eseq.size());
-    assertEquals(4*capacity, eseq.getCapacity());
   }
 
   private static ExtendableCoordinateSequence create(CoordinateSequenceFactory csf, int dimension, int size) {

--- a/modules/core/src/test/java/org/locationtech/jts/geom/ExtendableCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/ExtendableCoordinateSequenceTest.java
@@ -31,6 +31,15 @@ public class ExtendableCoordinateSequenceTest extends TestCase {
   }
 
   public void testConstructor() {
+
+    CoordinateSequence seq =
+      new ExtendableCoordinateSequence(2);
+    assertNotNull(seq);
+    assertEquals(2, seq.getDimension());
+    assertEquals(0, seq.size());
+    assertEquals(ExtendableCoordinateSequence.INITIAL_CAPACITY,
+            ((ExtendableCoordinateSequence)seq).getCapacity());
+
     doTestConstructor(null, 2);
     doTestConstructor(null, 2, 7);
     doTestConstructor(CoordinateArraySequenceFactory.instance(), 2);
@@ -60,6 +69,7 @@ public class ExtendableCoordinateSequenceTest extends TestCase {
 
     doTestCopy(CoordinateArraySequenceFactory.instance(), 2);
     doTestCopy(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
+    doTestCopy(PackedCoordinateSequenceFactory.FLOAT_FACTORY, 4);
 
   }
 
@@ -68,7 +78,7 @@ public class ExtendableCoordinateSequenceTest extends TestCase {
     doTestAdd(CoordinateArraySequenceFactory.instance(), 2);
     doTestAdd(CoordinateArraySequenceFactory.instance(), 3);
     doTestAdd(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 2);
-    doTestAdd(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 3);
+    doTestAdd(PackedCoordinateSequenceFactory.FLOAT_FACTORY, 3);
     doTestAdd(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
 
   }
@@ -78,7 +88,7 @@ public class ExtendableCoordinateSequenceTest extends TestCase {
     doTestInsert(CoordinateArraySequenceFactory.instance(), 2);
     doTestInsert(CoordinateArraySequenceFactory.instance(), 3);
     doTestInsert(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 2);
-    doTestInsert(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 3);
+    doTestInsert(PackedCoordinateSequenceFactory.FLOAT_FACTORY, 3);
     doTestInsert(PackedCoordinateSequenceFactory.DOUBLE_FACTORY, 4);
 
   }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
@@ -109,7 +109,7 @@ public abstract class CoordinateSequenceTestBase
     assertTrue(isEqual(seq2, coords));
   }
   
-  private static byte[] serialize(CoordinateSequence seq) throws IOException {
+  public static byte[] serialize(CoordinateSequence seq) throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     ObjectOutputStream oos = new ObjectOutputStream(bos);
     oos.writeObject(seq);
@@ -117,7 +117,7 @@ public abstract class CoordinateSequenceTestBase
     return bos.toByteArray();
   }
 
-  private static CoordinateSequence deserialize(byte[] data) throws IOException, ClassNotFoundException {
+  public static CoordinateSequence deserialize(byte[] data) throws IOException, ClassNotFoundException {
     ByteArrayInputStream bais = new ByteArrayInputStream(data);
     ObjectInputStream ois = new ObjectInputStream(bais);
     Object o = ois.readObject();

--- a/modules/core/src/test/java/test/jts/perf/PerformanceTestCase.java
+++ b/modules/core/src/test/java/test/jts/perf/PerformanceTestCase.java
@@ -126,7 +126,7 @@ public abstract class PerformanceTestCase
     
   }
 
-  void setTime(int runNum, long time) {
+  protected void setTime(int runNum, long time) {
     runTime[runNum] = time;
   }
   

--- a/modules/core/src/test/java/test/jts/perf/PerformanceTestRunner.java
+++ b/modules/core/src/test/java/test/jts/perf/PerformanceTestRunner.java
@@ -64,13 +64,13 @@ public class PerformanceTestRunner
         int size = runSize[runNum];
         test.startRun(size);
         for (int i = 0; i < runMethod.length; i++) {
-          Stopwatch sw = new Stopwatch();
+          long start = System.nanoTime();
           for (int iter = 0; iter < runIter; iter++) {
             runMethod[i].invoke(test);
           }
-          long time = sw.getTime();
+          long time = System.nanoTime() - start;
           System.out.println(runMethod[i].getName()
-              + " : " + sw.getTimeString());
+              + " : " + getTimeString(time));
           test.setTime(runNum, time);
         }
         test.endRun();
@@ -85,7 +85,14 @@ public class PerformanceTestRunner
     }
   }
   
-  
+  public static String getTimeString(long nanoSeconds) {
+    if (nanoSeconds < 1000)
+      return nanoSeconds + " nanosec";
+    if (nanoSeconds < 1000000)
+      return (nanoSeconds/1000) + " microsec";
+    return (nanoSeconds/1000000) + " millisec";
+  }
+
   private static Method[] findMethods(Class clz, String methodPrefix)
   {
     List runMeths = new ArrayList();

--- a/modules/core/src/test/java/test/jts/perf/PerformanceTestRunner.java
+++ b/modules/core/src/test/java/test/jts/perf/PerformanceTestRunner.java
@@ -16,6 +16,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import org.locationtech.jts.util.Stopwatch;
@@ -93,6 +95,15 @@ public class PerformanceTestRunner
         runMeths.add(meth[i]);
       }
     }
-    return (Method[]) runMeths.toArray(new Method[0]);
+
+    // sort method by name
+    Method[] methods = (Method[])runMeths.toArray(new Method[0]);
+    Arrays.sort(methods, new Comparator<Method>() {
+      public int compare(Method o1, Method o2) {
+        return o1.getName().compareTo(o2.getName());
+      }
+    });
+
+    return methods;
   }
 }

--- a/modules/core/src/test/java/test/jts/perf/PerformanceTestRunner.java
+++ b/modules/core/src/test/java/test/jts/perf/PerformanceTestRunner.java
@@ -93,6 +93,14 @@ public class PerformanceTestRunner
     return (nanoSeconds/1000000) + " millisec";
   }
 
+  public static String getTimeString(double nanoSeconds) {
+    if (nanoSeconds < 1000)
+      return String.format("%.1f nanosec", nanoSeconds);
+    if (nanoSeconds < 1000000)
+      return String.format("%.1f microsec", (nanoSeconds/1000));
+    return String.format("%.1f millisec", (nanoSeconds/1000000));
+  }
+
   private static Method[] findMethods(Class clz, String methodPrefix)
   {
     List runMeths = new ArrayList();

--- a/modules/core/src/test/java/test/jts/perf/geom/ExtendableCoordinateSequencePerfTest.java
+++ b/modules/core/src/test/java/test/jts/perf/geom/ExtendableCoordinateSequencePerfTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2018 Felix Obermaier.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package test.jts.perf.geom;
+
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.CoordinateSequences;
+import org.locationtech.jts.geom.ExtendableCoordinateSequence;
+import org.locationtech.jts.geom.impl.CoordinateArraySequenceFactory;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
+import org.locationtech.jts.util.Assert;
+import test.jts.perf.PerformanceTestCase;
+import test.jts.perf.PerformanceTestRunner;
+
+import java.util.ArrayList;
+import java.util.Random;
+
+public class ExtendableCoordinateSequencePerfTest extends PerformanceTestCase {
+
+  private static final int RANDOM_SEED = 13;
+  private long durationExtend;
+  private long durationMerge;
+
+  private CoordinateSequenceFactory currentFactory;
+  private int currentSize;
+  private int currentDimension;
+
+  public ExtendableCoordinateSequencePerfTest(String name) {
+    super(name);
+    setRunSize(new int[] {10, 10, 15, 16, 25, 48, 50, 96, 192, 200, 500, 1000, 1500, 1537});
+    setRunIterations(100);
+  }
+
+
+  public static void main(String[] args) {
+    PerformanceTestRunner.run(ExtendableCoordinateSequencePerfTest.class);
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+  }
+
+  @Override
+  public void startRun(int size) throws Exception {
+    super.startRun(size);
+    currentSize = size;
+    durationExtend = 0;
+    durationMerge = 0;
+    System.out.println(
+            "======================================================================================================");
+    System.out.println("Testing with size of " + size);
+  }
+
+  @Override
+  public void endRun() throws Exception {
+    super.endRun();
+    System.out.println("\n");
+  }
+
+  @Override
+  protected void setTime(int runNum, long time) {
+    super.setTime(runNum, time);
+
+    System.out.println(reportTime("Extend", this.currentFactory, this.currentSize,
+            this.currentDimension, durationExtend / getRunIterations()));
+    System.out.println(reportTime("Merge ", this.currentFactory, this.currentSize,
+            this.currentDimension, durationMerge / getRunIterations()));
+    System.out.println(
+            "------------------------------------------------------------------------------------------------------");
+
+  }
+
+  private String reportTime(String approach, CoordinateSequenceFactory csf, int size, int dimension, long ms) {
+    return String.format("%s with %s (size=%d, dim=%d) took average %d (nanotime()).",
+            approach, csf.getClass().getSimpleName(), size, dimension, ms);
+  }
+
+  public void runCoordinateArraySequenceDim2() {
+    this.currentFactory = CoordinateArraySequenceFactory.instance();
+    this.currentDimension = 2;
+    performExtendableVsMerge(currentFactory, currentDimension);
+  }
+
+  public void runCoordinateArraySequenceDim3() {
+    this.currentFactory = CoordinateArraySequenceFactory.instance();
+    this.currentDimension = 3;
+    performExtendableVsMerge(currentFactory, currentDimension);
+  }
+
+  public void runPackedCoordinateSequenceDim2() {
+    this.currentFactory = PackedCoordinateSequenceFactory.DOUBLE_FACTORY;
+    this.currentDimension = 2;
+    performExtendableVsMerge(currentFactory, currentDimension);
+  }
+
+  public void runPackedCoordinateSequenceDim4() {
+    this.currentFactory = PackedCoordinateSequenceFactory.DOUBLE_FACTORY;
+    this.currentDimension = 4;
+    performExtendableVsMerge(currentFactory, currentDimension);
+  }
+
+  private void performExtendableVsMerge(CoordinateSequenceFactory csf, int dimension) {
+
+    long start, duration;
+
+    start = System.nanoTime();
+    CoordinateSequence seq1 = createUsingExtendable(csf, dimension, this.currentSize, RANDOM_SEED);
+    duration = System.nanoTime() - start;
+    durationExtend += duration;
+
+    start = System.nanoTime();
+    CoordinateSequence seq2 = createUsingMerge(csf, dimension, this.currentSize, RANDOM_SEED);
+    duration = System.nanoTime() - start;
+    durationMerge += duration;
+
+    Assert.isTrue(CoordinateSequences.isEqual(seq1, seq2));
+  }
+
+
+  private static CoordinateSequence mergeSequences(CoordinateSequenceFactory factory, ArrayList sequences) {
+
+    int dimension = ((CoordinateSequence)sequences.get(0)).getDimension();
+    CoordinateSequence res = factory.create(sequences.size(), dimension);
+
+    for (int i = 0; i < sequences.size(); i++) {
+      CoordinateSequence coord = (CoordinateSequence) sequences.get(i);
+      for (int j = 0; j < res.getDimension(); j++) {
+        res.setOrdinate(i, j, coord.getOrdinate(0, j));
+      }
+    }
+    return res;
+  }
+
+  private static CoordinateSequence createUsingExtendable(CoordinateSequenceFactory factory, int dimension, int size, int seed) {
+
+    final ExtendableCoordinateSequence eseq = new ExtendableCoordinateSequence(factory, dimension);
+    final Random rnd = new Random(seed);
+
+    for (int i = 0; i < size; i++) {
+      eseq.setOrdinate(i, CoordinateSequence.X, rnd.nextDouble() * 640);
+      eseq.setOrdinate(i, CoordinateSequence.Y, rnd.nextDouble() * 480);
+      for (int j = 2; j < dimension; j++)
+        eseq.setOrdinate(i, j, rnd.nextDouble() * 10);
+    }
+
+    return eseq;//.truncated();
+  }
+
+  private static CoordinateSequence createUsingMerge(CoordinateSequenceFactory factory, int dimension, int size, int seed) {
+
+    final ArrayList sequences = new ArrayList();
+    final Random rnd = new Random(seed);
+
+    for (int i = 0; i < size; i++) {
+      CoordinateSequence seq = factory.create(1, dimension);
+      seq.setOrdinate(0, CoordinateSequence.X, rnd.nextDouble() * 640);
+      seq.setOrdinate(0, CoordinateSequence.Y, rnd.nextDouble() * 480);
+      for (int j = 2; j < dimension; j++)
+        seq.setOrdinate(0, j, rnd.nextDouble() * 10);
+      sequences.add(seq);
+    }
+
+    return mergeSequences(factory, sequences);
+  }
+}

--- a/modules/core/src/test/java/test/jts/perf/geom/ExtendableCoordinateSequencePerfTest.java
+++ b/modules/core/src/test/java/test/jts/perf/geom/ExtendableCoordinateSequencePerfTest.java
@@ -68,8 +68,7 @@ public class ExtendableCoordinateSequencePerfTest extends PerformanceTestCase {
       this.currentSize *= 10;
       run001_GrowableVsExtendableFloat();
       run002_GrowableVsExtendableDouble();
-      //run003_GrowableVsExtendableCoordinateArray();
-      run003_GrowableVsExtendableFloatToCoordinateArray();
+      run003_GrowableVsExtendableCoordinateArray();
       /*
       run01_CoordinateArraySequenceDim2();
       run02_PackedCoordinateSequenceFloatDim2();
@@ -194,12 +193,6 @@ public class ExtendableCoordinateSequencePerfTest extends PerformanceTestCase {
     this.currentFactory = CoordinateArraySequenceFactory.instance();
     this.currentDimension = 2;
     //((PackedCoordinateSequenceFactory) this.currentFactory).setDimension(this.currentDimension);
-    performGrowableVsExtendable(currentFactory);
-  }
-  public void run003_GrowableVsExtendableFloatToCoordinateArray() {
-    this.currentFactory = PackedCoordinateSequenceFactory.FLOAT_FACTORY;
-    this.currentDimension = 2;
-    ((PackedCoordinateSequenceFactory) this.currentFactory).setDimension(this.currentDimension);
     performGrowableVsExtendable(currentFactory);
   }
   /*

--- a/modules/core/src/test/java/test/jts/perf/geom/impl/GrowableCoordinateSequence.java
+++ b/modules/core/src/test/java/test/jts/perf/geom/impl/GrowableCoordinateSequence.java
@@ -1,0 +1,269 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+//package org.geogig.geoserver.gwc;
+package test.jts.perf.geom.impl;
+// The following has been reimplemented or copied from https://github.com/google/guava
+// Licensed under Apache v2.0
+//import static com.google.common.base.Preconditions.checkArgument;
+//import com.google.common.primitives.Floats;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
+
+/**
+ * A {@link CoordinateSequence} that grows as needed when coordinates are {@link #add(double,
+ * double) added}, and stores all coordinates in a single {@code float[]}
+ *
+ * <p>A subset of this coordinate sequence can be obtained as a view sharing internal state using
+ * {@link #subSequence(int, int)}
+ */
+public class GrowableCoordinateSequence implements CoordinateSequence {
+
+  private float[] ordinates;
+
+  private int size;
+
+  public GrowableCoordinateSequence() {
+    this(new float[100], 0);
+  }
+
+  private GrowableCoordinateSequence(float[] ordinates, int size) {
+    this.ordinates = ordinates;
+    this.size = size;
+  }
+
+  /**
+   * Adds the {@code x,y} coordinate to this coordinate sequence, increasing the internal buffer
+   * as necessary to acommodate for the expanded size if needed.
+   */
+  public void add(double x, double y) {
+    final int index = this.size;
+    this.size++;
+    ensureCapacity(size);
+    setOrdinate(index, 0, x);
+    setOrdinate(index, 1, y);
+  }
+
+  /**
+   * @return a "view" of this coordinate sequence limited by {@code fromIndex} and {@code toIndex}
+   */
+  public CoordinateSequence subSequence(int fromIndex, int toIndex) {
+    return new SubSequence(this, fromIndex, toIndex);
+  }
+
+  private void ensureCapacity(int size) {
+    int minLength = 2 * size;
+
+    //original:
+    //int padding = 100;
+    int padding = ordinates.length >> 1;
+
+    ordinates = /*Floats.*/ensureCapacity(ordinates, minLength, padding);
+  }
+
+  //@Override
+  public int getDimension() {
+    return 2;
+  }
+
+  //@Override
+  public Coordinate getCoordinate(int i) {
+    return new Coordinate(getX(i), getY(i));
+  }
+
+  //@Override
+  public Coordinate getCoordinateCopy(int i) {
+    return getCoordinate(i);
+  }
+
+  //@Override
+  public void getCoordinate(int index, Coordinate coord) {
+    coord.x = getX(index);
+    coord.y = getY(index);
+    coord.z = 0D;
+  }
+
+  //@Override
+  public double getX(int index) {
+    return getOrdinate(index, 0);
+  }
+
+  //@Override
+  public double getY(int index) {
+    return getOrdinate(index, 1);
+  }
+
+  //@Override
+  public double getOrdinate(int index, int ordinateIndex) {
+    return ordinates[index * getDimension() + ordinateIndex];
+  }
+
+  //@Override
+  public int size() {
+    return size;
+  }
+
+  //@Override
+  public void setOrdinate(int index, int ordinateIndex, double value) {
+    if (index >= size) {
+      throw new IndexOutOfBoundsException();
+    }
+    ordinates[index * getDimension() + ordinateIndex] = (float) value;
+  }
+
+  //@Override
+  public Coordinate[] toCoordinateArray() {
+    Coordinate[] coords = new Coordinate[size()];
+    for (int i = 0; i < coords.length; i++) {
+      coords[i] = getCoordinate(i);
+    }
+    return coords;
+  }
+
+  //@Override
+  public Envelope expandEnvelope(Envelope env) {
+    final int size = size();
+    final int dimension = getDimension();
+    for (int i = 0; i < size; i += dimension) {
+      env.expandToInclude(getX(i), getY(i));
+    }
+    return env;
+  }
+
+  //@Override
+  public GrowableCoordinateSequence clone() {
+    return new GrowableCoordinateSequence(ordinates.clone(), size);
+  }
+
+  private static class SubSequence implements CoordinateSequence {
+
+    private CoordinateSequence orig;
+
+    private int toIndex;
+
+    private int fromIndex;
+
+    public SubSequence(CoordinateSequence orig, int fromIndex, int toIndex) {
+      checkArgument(fromIndex > -1);
+      checkArgument(toIndex >= fromIndex);
+      checkArgument(toIndex < orig.size());
+      this.orig = orig;
+      this.fromIndex = fromIndex;
+      this.toIndex = toIndex;
+    }
+
+    //@Override
+    public int getDimension() {
+      return orig.getDimension();
+    }
+
+    //@Override
+    public Coordinate getCoordinate(int i) {
+      return orig.getCoordinate(fromIndex + i);
+    }
+
+    //@Override
+    public Coordinate getCoordinateCopy(int i) {
+      return orig.getCoordinateCopy(fromIndex + i);
+    }
+
+    //@Override
+    public void getCoordinate(int index, Coordinate coord) {
+      orig.getCoordinate(fromIndex + index, coord);
+    }
+
+    //@Override
+    public double getX(int index) {
+      return orig.getX(fromIndex + index);
+    }
+
+    //@Override
+    public double getY(int index) {
+      return orig.getY(fromIndex + index);
+    }
+
+    //@Override
+    public double getOrdinate(int index, int ordinateIndex) {
+      return orig.getOrdinate(fromIndex + index, ordinateIndex);
+    }
+
+    //@Override
+    public int size() {
+      return 1 + (toIndex - fromIndex);
+    }
+
+    //@Override
+    public void setOrdinate(int index, int ordinateIndex, double value) {
+      orig.setOrdinate(fromIndex + index, ordinateIndex, value);
+    }
+
+    //@Override
+    public Coordinate[] toCoordinateArray() {
+      final int size = size();
+      Coordinate[] coords = new Coordinate[size];
+      for (int i = 0; i < size; i++) {
+        coords[i] = getCoordinate(i);
+      }
+      return coords;
+    }
+
+    //@Override
+    public Envelope expandEnvelope(Envelope env) {
+      final int size = size();
+      for (int i = 0; i < size; i++) {
+        env.expandToInclude(getOrdinate(i, 0), getOrdinate(i, 1));
+      }
+      return env;
+    }
+
+    //@Override
+    public Object clone() {
+      return new SubSequence(orig, fromIndex, toIndex);
+    }
+
+    //@Override
+    public CoordinateSequence copy() {
+      return new SubSequence(orig.copy(), fromIndex, toIndex);
+    }
+  }
+
+  //@Override
+  public CoordinateSequence copy() {
+    return new GrowableCoordinateSequence(ordinates.clone(), size());
+  }
+
+// The following has been reimplemented or copied from https://github.com/google/guava
+// Licensed under Apache v2.0
+
+  /**
+   * Returns an array containing the same values as {@code array}, but guaranteed to be of a
+   * specified minimum length. If {@code array} already has a length of at least {@code minLength},
+   * it is returned directly. Otherwise, a new array of size {@code minLength + padding} is
+   * returned, containing the values of {@code array}, and zeroes in the remaining places.
+   *
+   * @param array the source array
+   * @param minLength the minimum length the returned array must guarantee
+   * @param padding an extra amount to "grow" the array by if growth is necessary
+   * @throws IllegalArgumentException if {@code minLength} or {@code padding} is negative
+   * @return an array containing the values of {@code array}, with guaranteed minimum length {@code
+   *     minLength}
+   */
+  /*public*/static float[] ensureCapacity(float[] array, int minLength, int padding) {
+    checkArgument(minLength >= 0, "Invalid minLength: %s", minLength);
+    checkArgument(padding >= 0, "Invalid padding: %s", padding);
+    return (array.length < minLength) ? java.util.Arrays.copyOf(array, minLength + padding) : array;
+  }
+
+  private static void checkArgument(boolean chkResult) {
+    checkArgument(chkResult, null, null);
+  }
+  private static void checkArgument(boolean chkResult, String message, Object a1) {
+    if (!chkResult) {
+      if (message == null)
+        throw new IllegalArgumentException();
+      throw new IllegalArgumentException(String.format(message, a1));
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit-version>3.7</junit-version>
+        <junit-version>3.8</junit-version>
         <jdom-version>2.0.6</jdom-version>
         <jump.version>1.2</jump.version>
         <json-simple-version>1.1.1</json-simple-version>


### PR DESCRIPTION
This is a wrapper around the `CoordinateSequence` interface.   

Internally it has access to a `CoordinatSequenceFactory` that it uses to create a buffer sequence in which it stores the ordinate values. If the capacity of the sequence is used up, a new sequence with extended capacity is created and the present values are stored in it.

Extensions to the public interface
* several `add` methods
* several `insertAt` methods
* `getCapacity` function
* `truncated` function

This PR comes with a unit test and a performance comparing `ExtendableCoordinateSequence` to creating several 1-coordinate sequences and merging those into one.

This class is convenient wherever the final size of a `CoordinateSequence` is not known, e.g. when parsing WKT (WKTReader) or when building buffers. It might help with issue #188.

I am not sure if the wording is correct, maybe `GrowableCoordinateSequence` or `BufferedCoordinateSequence` is a better name.