### PR TITLE
Add module names for better Java 9/Jigsaw support

### DIFF
--- a/USING.md
+++ b/USING.md
@@ -82,3 +82,18 @@ Older versions of JTS are available on Maven Central.
     <version>1.13</version>
 </dependency>
 ```
+
+## Using JTS with Jigsaw
+
+JTS uses [#ModuleNameInManifest](http://openjdk.java.net/projects/jigsaw/spec/issues/#ModuleNameInManifest) to export a module name for each of the JARs published for use as a library. In this way, you can depend on the various JTS modules in your `module-info.java` in the following way:
+
+```java
+// module-info.java for project org.foo.baz
+
+module org.foo.baz {
+  requires org.locationtech.jts;            // jts-core
+  requires org.locationtech.jts.io;         // jts-io-common
+  requires org.locationtech.jts.io.oracle;  // jts-io-ora
+  requires org.locationtech.jts.io.sde;     // jts-io-sde
+}
+```

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -13,9 +13,12 @@
         <plugins>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
-                <!--configuration>
+		<version>3.0.2</version>
+                <configuration>
                   <archive>
+                    <manifestEntries>
+                      <Automatic-Module-Name>org.locationtech.jts</Automatic-Module-Name>
+                    </manifestEntries>
                     <manifestSections>
                       <manifestSection>
                         <name>org.locationtech.jts</name>
@@ -23,9 +26,9 @@
                           <Sealed>true</Sealed>
                         </manifestEntries>
                       </manifestSection>
-                     </manifestSections>
+                    </manifestSections>
                   </archive>
-                </configuration-->
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/modules/io/common/pom.xml
+++ b/modules/io/common/pom.xml
@@ -9,6 +9,31 @@
     <artifactId>jts-io-common</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                  <archive>
+                    <manifestEntries>
+                      <Automatic-Module-Name>org.locationtech.jts.io</Automatic-Module-Name>
+                    </manifestEntries>
+                    <manifestSections>
+                      <manifestSection>
+                        <name>org.locationtech.jts.io</name>
+                        <manifestEntries>
+                          <Sealed>true</Sealed>
+                        </manifestEntries>
+                      </manifestSection>
+                    </manifestSections>
+                  </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
     <dependencies>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>

--- a/modules/io/ora/pom.xml
+++ b/modules/io/ora/pom.xml
@@ -10,6 +10,30 @@
     <artifactId>jts-io-ora</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                  <archive>
+                    <manifestEntries>
+                      <Automatic-Module-Name>org.locationtech.jts.io.oracle</Automatic-Module-Name>
+                    </manifestEntries>
+                    <manifestSections>
+                      <manifestSection>
+                        <name>org.locationtech.jts.io.oracle</name>
+                        <manifestEntries>
+                          <Sealed>true</Sealed>
+                        </manifestEntries>
+                      </manifestSection>
+                    </manifestSections>
+                  </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
        <dependency>
           <groupId>com.oracle</groupId>

--- a/modules/io/sde/pom.xml
+++ b/modules/io/sde/pom.xml
@@ -10,17 +10,40 @@
     <artifactId>jts-io-sde</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>jar</packaging>
-    
+
     <properties>
       <!--
          Default SDE version is 9.1. To use newer version (that has been installed
          in your local repository) run maven with:
-         
+
              mvn -Parcsde -Dsde.version={desired version}
       -->
       <sde.version>9.1</sde.version>
     </properties>
-  
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                  <archive>
+                    <manifestEntries>
+                      <Automatic-Module-Name>org.locationtech.jts.io.sde</Automatic-Module-Name>
+                    </manifestEntries>
+                    <manifestSections>
+                      <manifestSection>
+                        <name>org.locationtech.jts.io.sde</name>
+                        <manifestEntries>
+                          <Sealed>true</Sealed>
+                        </manifestEntries>
+                      </manifestSection>
+                    </manifestSections>
+                  </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
       <dependency>
         <groupId>com.esri</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
 
     Setup for eclipse development:
        mvn eclipse:eclipse
-       
+
     To build with jts-ora:
        mvn install -Poracle
 
     To build with jts-sde:
        mvn install -Parcsde
-       
+
     To build the release (for Maven Central; committers only)
        mvn install -Drelease
     -->
@@ -38,6 +38,10 @@
         <jump.version>1.2</jump.version>
         <json-simple-version>1.1.1</json-simple-version>
         <sde-version>9.1</sde-version>
+
+        <!-- maven compiler target versions -->
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
     </properties>
 
     <!-- PROJECT INFORMATION -->


### PR DESCRIPTION
The Jigsaw module system requires that downstream users of JTS using the module system declare JTS as a module requirement. JTS acts as an [automatic module](http://openjdk.java.net/projects/jigsaw/spec/sotms/#automatic-modules), since it is not compiled with a `module-info.java`. Without this change, module users would have to reference the requirement for JTS by specifying the JAR name with the fully qualified version; this is unwieldy, will trigger necessary updates when updating the JTS version, and could cause errors when transitive dependencies rely on other versions of JTS.

This change utilizes the technique of putting the [module name in the manifest](http://openjdk.java.net/projects/jigsaw/spec/issues/#ModuleNameInManifest), so that libraries declaring modules can refer to JTS with more friendly, version-less names, e.g.:

```java
// module-info.java for project org.foo.baz

module org.foo.baz {
  requires org.locationtech.jts;            // jts-core
  requires org.locationtech.jts.io;         // jts-io-common
  requires org.locationtech.jts.io.oracle;  // jts-io-ora
  requires org.locationtech.jts.io.sde;     // jts-io-sde
}
```

## Testing Instructions

To verify this work, I defined a Foo.java file and a manifest-info.java file, as follows:

```java
// Foo.java

package org.foo.baz;

import org.locationtech.jts.JTSVersion;
import org.locationtech.jts.io.ParseException;
import org.locationtech.jts.algorithm.distance.DistanceToPoint;
import org.locationtech.jts.io.geojson.GeoJsonConstants;

public class Foo {
  public static void main(String[] args)
  {
    ParseException e = new ParseException("asdf");
    DistanceToPoint d = new DistanceToPoint();
    System.out.println(JTSVersion.CURRENT_VERSION);
    System.out.println(GeoJsonConstants.NAME_GEOMETRIES);
  }
}

```

```java
// module-info.java

module org.foo.baz {
  requires org.locationtech.jts;
  requires org.locationtech.jts.io;
}
```

I then compiled and ran Foo as a module:

```shell
> mkdir mods
> javac --module-path ./modules/core/target/jts-core-1.15.1-SNAPSHOT.jar:./modules/io/common/target/jts-io-common-1.15.1-SNAPSHOT.jar \
        -d mods/foo \
        module-info.java \
        Foo.java
> java --module-path mods:./modules/core/target/jts-core-1.15.1-SNAPSHOT.jar:./modules/io/common/target/jts-io-common-1.15.1-SNAPSHOT.jar -m org.foo.baz/org.foo.baz.Foo
```

Expected output:
```shell
1.15.0
geometries
```

This is building JTS with java 8 against commit 3fb74b65e142bc166f58c9105f9dc43e911c7d72