### PR TITLE
Specify source and target Java versions in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
         <jump.version>1.2</jump.version>
         <json-simple-version>1.1.1</json-simple-version>
         <sde-version>9.1</sde-version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <!-- PROJECT INFORMATION -->


### PR DESCRIPTION
Since the POM does not specify the source or target Java versions, Maven [defaults to 1.5](https://maven.apache.org/plugins/maven-compiler-plugin/), which is [not supported by JDK 9](http://openjdk.java.net/jeps/182) and causes the following error on `mvn compile`:

```
[ERROR] Source option 1.5 is no longer supported. Use 1.6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.

```
This PR specifies the source and target versions as 1.7, per the discussion in #145.