### PR TITLE
Explicit CoordinateSequence support for XYZM

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/io/shapefile/MultiLineHandler.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/io/shapefile/MultiLineHandler.java
@@ -112,7 +112,7 @@ public class MultiLineHandler implements ShapeHandler{
             
             for (int t =0;t<numPoints; t++)
             {
-              coords[t].z =   file.readDoubleLE(); //z value
+              coords[t].setZ(file.readDoubleLE()); //z value
 		   	  actualReadWords += 4;
             }
         }
@@ -227,7 +227,7 @@ public class MultiLineHandler implements ShapeHandler{
         
         for (int t=0;t<cs.length; t++)
         {
-            z= cs[t].z ;
+            z= cs[t].getZ() ;
             if (!(Double.isNaN( z ) ))
             {
                 if (validZFound)

--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/io/shapefile/MultiPointHandler.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/io/shapefile/MultiPointHandler.java
@@ -96,7 +96,7 @@ public class MultiPointHandler  implements ShapeHandler  {
             { 
                        double z =  file.readDoubleLE();//z
 						actualReadWords += 4;
-                       coords[t].z = z;
+                       coords[t].setZ(z);
             }
         }
         
@@ -152,7 +152,7 @@ public class MultiPointHandler  implements ShapeHandler  {
         
         for (int t=0;t<cs.length; t++)
         {
-            z= cs[t].z ;
+            z= cs[t].getZ();
             if (!(Double.isNaN( z ) ))
             {
                 if (validZFound)

--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/io/shapefile/PolygonHandler.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/io/shapefile/PolygonHandler.java
@@ -68,7 +68,7 @@ public class PolygonHandler implements ShapeHandler{
         {
             p = pointList[t];
             if ( (testPoint.x == p.x) && (testPoint.y == p.y) &&
-                    ((testPoint.z == p.z) || (!(testPoint.z == testPoint.z))  )  //nan test; x!=x iff x is nan
+                    ((testPoint.getZ() == p.getZ()) || (!(testPoint.getZ() == testPoint.getZ()))  )  //nan test; x!=x iff x is nan
                     )
             {
                 return true;
@@ -138,7 +138,7 @@ public class PolygonHandler implements ShapeHandler{
 			actualReadWords += 8;
              for(int t=0;t<numPoints;t++)
             {
-                coords[t].z = file.readDoubleLE();
+                coords[t].setZ(file.readDoubleLE());
 				actualReadWords += 4;
             }
         }
@@ -339,7 +339,7 @@ public class PolygonHandler implements ShapeHandler{
         
         for (int t=0;t<cs.length; t++)
         {
-            z= cs[t].z ;
+            z= cs[t].getZ() ;
             if (!(Double.isNaN( z ) ))
             {
                 if (validZFound)

--- a/modules/app/src/main/java/org/locationtech/jtstest/util/io/SVGWriter.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/util/io/SVGWriter.java
@@ -372,9 +372,9 @@ public class SVGWriter
     throws IOException
   {
     writer.write(writeNumber(coordinate.x) + " " + writeNumber(coordinate.y));
-    if (outputDimension >= 3 && ! Double.isNaN(coordinate.z)) {
+    if (outputDimension >= 3 && ! Double.isNaN(coordinate.getZ())) {
       writer.write(" ");
-      writer.write(writeNumber(coordinate.z));
+      writer.write(writeNumber(coordinate.getZ()));
     }
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/CGAlgorithms3D.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/CGAlgorithms3D.java
@@ -29,12 +29,12 @@ public class CGAlgorithms3D
 	public static double distance(Coordinate p0, Coordinate p1)
 	{
 		// default to 2D distance if either Z is not set
-		if (Double.isNaN(p0.z) || Double.isNaN(p1.z))
+		if (Double.isNaN(p0.getZ()) || Double.isNaN(p1.getZ()))
 			return p0.distance(p1);
 		
 	    double dx = p0.x - p1.x;
 	    double dy = p0.y - p1.y;
-	    double dz = p0.z - p1.z;
+	    double dz = p0.getZ() - p1.getZ();
 	    return Math.sqrt(dx * dx + dy * dy + dz * dz);
 	}
 
@@ -58,10 +58,10 @@ public class CGAlgorithms3D
 	     *   0<r<1 P is interior to AB
 	     */
 
-	    double len2 = (B.x - A.x) * (B.x - A.x) + (B.y - A.y) * (B.y - A.y) + (B.z - A.z) * (B.z - A.z);
+	    double len2 = (B.x - A.x) * (B.x - A.x) + (B.y - A.y) * (B.y - A.y) + (B.getZ() - A.getZ()) * (B.getZ() - A.getZ());
 	    if (Double.isNaN(len2))
 	    	throw new IllegalArgumentException("Ordinates must not be NaN");
-	    double r = ((p.x - A.x) * (B.x - A.x) + (p.y - A.y) * (B.y - A.y) + (p.z - A.z) * (B.z - A.z))
+	    double r = ((p.x - A.x) * (B.x - A.x) + (p.y - A.y) * (B.y - A.y) + (p.getZ() - A.getZ()) * (B.getZ() - A.getZ()))
 	        / len2;
 
 	    if (r <= 0.0)
@@ -72,11 +72,11 @@ public class CGAlgorithms3D
 	    // compute closest point q on line segment
 	    double qx = A.x + r * (B.x - A.x);
 	    double qy = A.y + r * (B.y - A.y);
-	    double qz = A.z + r * (B.z - A.z);
+	    double qz = A.getZ() + r * (B.getZ() - A.getZ());
 	    // result is distance from p to q
 	    double dx = p.x - qx;
 	    double dy = p.y - qy;
-	    double dz = p.z - qz;
+	    double dz = p.getZ() - qz;
 	    return Math.sqrt(dx*dx + dy*dy + dz*dz);
 	}
 	
@@ -149,11 +149,11 @@ public class CGAlgorithms3D
 		 */
 		double x1 = A.x + s * (B.x - A.x);
 		double y1 = A.y + s * (B.y - A.y);
-		double z1 = A.z + s * (B.z - A.z);
+		double z1 = A.getZ() + s * (B.getZ() - A.getZ());
 
 		double x2 = C.x + t * (D.x - C.x);
 		double y2 = C.y + t * (D.y - C.y);
-		double z2 = C.z + t * (D.z - C.z);
+		double z2 = C.getZ() + t * (D.getZ() - C.getZ());
 		
 		// length (p1-p2)
 		return distance(new Coordinate(x1, y1, z1), new Coordinate(x2, y2, z2));

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
@@ -37,7 +37,7 @@ import org.locationtech.jts.util.NumberUtil;
  *
  *@version 1.7
  */
-public class Coordinate implements Comparable, Cloneable, Serializable {
+public class Coordinate implements Comparable<Coordinate>, Cloneable, Serializable {
   private static final long serialVersionUID = 6683108902428366910L;
   
   /**
@@ -258,7 +258,7 @@ public class Coordinate implements Comparable, Cloneable, Serializable {
    *@return    -1, zero, or 1 as this <code>Coordinate</code>
    *      is less than, equal to, or greater than the specified <code>Coordinate</code>
    */
-  public int compareTo(Object o) {
+  public int compareTo(Coordinate o) {
     Coordinate other = (Coordinate) o;
 
     if (x < other.x) return -1;
@@ -350,7 +350,7 @@ public class Coordinate implements Comparable, Cloneable, Serializable {
    * or 3-dimensional comparison, and handling NaN values correctly.
    */
   public static class DimensionalComparator
-      implements Comparator
+      implements Comparator<Coordinate>
   {
     /**
      * Compare two <code>double</code>s, allowing for NaN values.
@@ -407,11 +407,8 @@ public class Coordinate implements Comparable, Cloneable, Serializable {
      * equal to, or greater than 02
      *
      */
-    public int compare(Object o1, Object o2)
+    public int compare(Coordinate c1, Coordinate c2)
     {
-      Coordinate c1 = (Coordinate) o1;
-      Coordinate c2 = (Coordinate) o2;
-
       int compX = compare(c1.x, c2.x);
       if (compX != 0) return compX;
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
@@ -99,7 +99,7 @@ public class Coordinate implements Comparable<Coordinate>, Cloneable, Serializab
   public Coordinate(double x, double y, double z) {
     this.x = x;
     this.y = y;
-    this.setZ(z);
+    this.z = z;
   }
 
   /**
@@ -137,7 +137,7 @@ public class Coordinate implements Comparable<Coordinate>, Cloneable, Serializab
   public void setCoordinate(Coordinate other) {
     x = other.x;
     y = other.y;
-    setZ(other.getZ());
+    z = other.getZ();
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
@@ -25,18 +25,21 @@ import org.locationtech.jts.util.NumberUtil;
  * Unlike objects of type {@link Point} (which contain additional
  * information such as an envelope, a precision model, and spatial reference
  * system information), a <code>Coordinate</code> only contains ordinate values
- * and accessor methods. <P>
+ * and accessor methods. </p>
  * <p>
- *
  * <code>Coordinate</code>s are two-dimensional points, with an additional Z-ordinate. 
  * If an Z-ordinate value is not specified or not defined, 
  * constructed coordinates have a Z-ordinate of <code>NaN</code>
  * (which is also the value of <code>NULL_ORDINATE</code>).  
  * The standard comparison functions ignore the Z-ordinate.
  * Apart from the basic accessor functions, JTS supports
- * only specific operations involving the Z-ordinate. 
+ * only specific operations involving the Z-ordinate.</p> 
+ * <p>
+ * Implementations may optionally support Z-ordiante and M-measure values
+ * as appropriate for a CoordinateSeqeunce. Use of {@link #getZ()} and {@link #getM()}
+ * accessors, or {@link #getOrdinate(int)} are recommended.</p> 
  *
- * @version 1.7
+ * @version 1.16
  */
 public class Coordinate implements Comparable<Coordinate>, Cloneable, Serializable {
   private static final long serialVersionUID = 6683108902428366910L;
@@ -175,7 +178,16 @@ public class Coordinate implements Comparable<Coordinate>, Cloneable, Serializab
    *  The m-measure, if available.
    */  
   public double getM() {
-      return Double.NaN;     
+    return Double.NaN;     
+  }
+  
+  /**
+   * The m-measure, if supported.
+   *
+   * @param m
+   */
+  public void setM(double m) {
+    throw new IllegalArgumentException("Invalid ordinate index: " + M);
   }
   
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Vivid Solutions, and others.
+ * Copyright (c) 2018 Vivid Solutions
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateArrays.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateArrays.java
@@ -28,7 +28,40 @@ public class CoordinateArrays {
   private final static Coordinate[] coordArrayType = new Coordinate[0];
 
   private CoordinateArrays() {}
-
+  
+  /**
+   * Determine dimension based on subclass of {@link Coordinate}.
+   * 
+   * @param pts supplied coordinates
+   * @return number of ordinates recorded
+   */
+  public static int dimension(Coordinate[] pts) {
+    if( pts == null || pts.length == 0) {
+      return 3; // unknown, assume default
+    }
+    Coordinate first = pts[0];
+    if( first == null ) {
+      return 3; // unknown, assume default
+    }
+    return Coordinates.dimension(first);
+  }
+  /**
+   * Determine number of measures based on subclass of {@link Coordinate}.
+   * 
+   * @param pts supplied coordinates
+   * @return number of measures recorded
+   */
+  public static int measures(Coordinate[] pts) {
+    if( pts == null || pts.length == 0) {
+      return 0; // unknown, assume default
+    }
+    Coordinate first = pts[0];
+    if( first == null ) {
+      return 0; // unknown, assume default
+    }
+    return Coordinates.measures(first);
+  }
+  
   /**
    * Tests whether an array of {@link Coordinate}s forms a ring,
    * by checking length and closure. 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateArrays.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateArrays.java
@@ -25,7 +25,6 @@ import org.locationtech.jts.math.MathUtil;
  * @version 1.7
  */
 public class CoordinateArrays {
-
   private final static Coordinate[] coordArrayType = new Coordinate[0];
 
   private CoordinateArrays() {}

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateList.java
@@ -25,9 +25,10 @@ import java.util.Iterator;
  * @version 1.7
  */
 public class CoordinateList
-  extends ArrayList
+  extends ArrayList<Coordinate>
 {
-  //With contributions from Markus Schaber [schabios@logi-track.com]
+  private static final long serialVersionUID = -1626110935756089896L;
+//With contributions from Markus Schaber [schabios@logi-track.com]
   //[Jon Aquino 2004-03-25]
   private final static Coordinate[] coordArrayType = new Coordinate[0];
 
@@ -64,8 +65,8 @@ public class CoordinateList
     add(coord, allowRepeated);
   }
 
-  public void add(Coordinate coord) {
-	super.add(coord);
+  public boolean add(Coordinate coord) {
+	return super.add(coord);
   }
 
   public Coordinate getCoordinate(int i) { return (Coordinate) get(i); }
@@ -186,11 +187,11 @@ public class CoordinateList
    * @param allowRepeated if set to false, repeated coordinates are collapsed
    * @return true (as by general collection contract)
    */
-  public boolean addAll(Collection coll, boolean allowRepeated)
+  public boolean addAll(Collection<? extends Coordinate> coll, boolean allowRepeated)
   {
     boolean isChanged = false;
-    for (Iterator i = coll.iterator(); i.hasNext(); ) {
-      add((Coordinate) i.next(), allowRepeated);
+    for (Iterator<? extends Coordinate> i = coll.iterator(); i.hasNext(); ) {
+      add(i.next(), allowRepeated);
       isChanged = true;
     }
     return isChanged;
@@ -201,8 +202,10 @@ public class CoordinateList
    */
   public void closeRing()
   {
-    if (size() > 0)
-      add(new Coordinate((Coordinate) get(0)), false);
+    if (size() > 0) {
+      Coordinate duplicate = get(0).copy();
+      add(duplicate, false);
+    }
   }
 
   /** Returns the Coordinates in this collection.
@@ -221,8 +224,8 @@ public class CoordinateList
    */
   public Object clone() {
       CoordinateList clone = (CoordinateList) super.clone();
-      for (int i = 0; i < this.size(); i++) {
-          clone.add(i, ((Coordinate) this.get(i)).clone());
+      for (int i = 0; i < this.size(); i++) {	  
+          clone.add(i, (Coordinate) this.get(i).clone());
       }
       return clone;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
@@ -60,6 +60,14 @@ public interface CoordinateSequence
    * @return the dimension of the sequence.
    */
   int getDimension();
+  
+  /**
+   * Returns the number of measures in each coordinate for this sequence.
+   * @return
+   */
+  default int getNumberOfMeasures() {
+	  return 0;
+  }
 
   /**
    * Returns (possibly a copy of) the i'th coordinate in this sequence.
@@ -119,7 +127,7 @@ public interface CoordinateSequence
    * (for instance, they may contain other dimensions or measure values).
    *
    * @param index  the coordinate index in the sequence
-   * @param ordinateIndex the ordinate index in the coordinate (in range [0, dimension-1])
+   * @param ordinateIndex the ordinate index in the coordinate (in range [0, dimension-numberOfMeasures-1])
    */
   double getOrdinate(int index, int ordinateIndex);
 
@@ -133,7 +141,7 @@ public interface CoordinateSequence
    * Sets the value for a given ordinate of a coordinate in this sequence.
    *
    * @param index  the coordinate index in the sequence
-   * @param ordinateIndex the ordinate index in the coordinate (in range [0, dimension-1])
+   * @param ordinateIndex the ordinate index in the coordinate (in range [0, dimension-numberOfMeasures1])
    * @param value  the new ordinate value
    */
   void setOrdinate(int index, int ordinateIndex, double value);
@@ -164,7 +172,7 @@ public interface CoordinateSequence
    * Called by Geometry#clone.
    *
    * @return a copy of the coordinate sequence containing copies of all points
-   * @deprecated
+   * @deprecated Recommend {@link #copy()} 
    */
   Object clone();
   

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
@@ -116,6 +116,18 @@ public interface CoordinateSequence
   }
 
   /**
+   * Creates a coordinate for use in this sequence.
+   * <p>
+   * The coordinate is created supporting the same number of {@link #getDimension()} and {@link #getMeasures()}
+   * as this sequence and is suitable for use with {@link #getCoordinate(int, Coordinate)}.
+   * </p>
+   * @return coordinate for use with this sequence
+   */
+  default Coordinate createCoordinate() {
+    return Coordinates.create(getDimension(), getMeasures());
+  }
+  
+  /**
    * Returns (possibly a copy of) the i'th coordinate in this sequence.
    * Whether or not the Coordinate returned is the actual underlying
    * Coordinate or merely a copy depends on the implementation.

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
@@ -94,6 +94,26 @@ public interface CoordinateSequence
   default int getMeasures() {
     return 0;
   }
+  
+  /**
+   * Checks {@link #getDimension()} and {@link #getMeasures()} to determine if {@link #getZ(int)}
+   * is supported.
+   * 
+   * @return true if {@link #getZ(int)} is supported.
+   */
+  default boolean hasZ() {
+      return (getDimension()-getMeasures()) > 2;
+  }
+  
+  /**
+   * Checks {@link #getMeasures()} to determine if {@link #getM(int)}
+   * is supported.
+   * 
+   * @return true if {@link #getM(int)} is supported.
+   */
+  default boolean hasM() {
+      return getDimension()>2 && getMeasures() > 0;
+  }
 
   /**
    * Returns (possibly a copy of) the i'th coordinate in this sequence.
@@ -152,13 +172,13 @@ public interface CoordinateSequence
    * @param index
    * @return the value of the Z ordinate in the index'th coordinate, or Double.NaN if not defined.
    */
-  default double getZ(int index) {
-     if( (getDimension()-getMeasures()) > 2 ) {
-	 return getOrdinate( index, 2 );
-     }
-     else {
-         return Double.NaN;
-     }
+  default double getZ(int index)
+  {
+    if (hasZ()) {
+        return getOrdinate(index, 2);
+    } else {
+        return Double.NaN;
+    }
   }
 
   /**
@@ -167,14 +187,15 @@ public interface CoordinateSequence
    * @param index
    * @return the value of the Z ordinate in the index'th coordinate, or Double.NaN if not defined.
    */
-  default double getM(int index) {
-     if( getDimension() > 2 && getMeasures() > 0 ) {
-	 final int mIndex = getDimension()-getDimension();
-	 return getOrdinate( index, mIndex );
-     }
-     else {
-         return Double.NaN;
-     }
+  default double getM(int index)
+  {
+    if (hasM()) {
+      final int mIndex = getDimension()-getMeasures();
+      return getOrdinate( index, mIndex );
+    }
+    else {
+        return Double.NaN;
+    }
   }
   
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Vivid Solutions, and others.
+ * Copyright (c) 2018 Vivid Solutions
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -219,7 +219,7 @@ public interface CoordinateSequence
    * values as described by {@link #getDimension()} and {@link #getMeasures()}).
    *
    * @param index  the coordinate index in the sequence
-   * @param ordinateIndex the ordinate index in the coordinate (in range [0, dimension-numberOfMeasures-1])
+   * @param ordinateIndex the ordinate index in the coordinate (in range [0, dimension-1])
    */
   double getOrdinate(int index, int ordinateIndex);
 
@@ -233,7 +233,7 @@ public interface CoordinateSequence
    * Sets the value for a given ordinate of a coordinate in this sequence.
    *
    * @param index  the coordinate index in the sequence
-   * @param ordinateIndex the ordinate index in the coordinate (in range [0, dimension-numberOfMeasures1])
+   * @param ordinateIndex the ordinate index in the coordinate (in range [0, dimension-1])
    * @param value  the new ordinate value
    */
   void setOrdinate(int index, int ordinateIndex, double value);

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequenceFactory.java
@@ -67,7 +67,7 @@ public interface CoordinateSequenceFactory
    * @param size the number of coordinates in the sequence
    * @param dimension the dimension of the coordinates in the sequence (if user-specifiable,
    * otherwise ignored)
-   * @param measures the number of measures of the coordiantes in the sequence (if user-specifiable,
+   * @param measures the number of measures of the coordinates in the sequence (if user-specifiable,
    * otherwise ignored)
    */
   default CoordinateSequence create(int size, int dimension, int measures) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateSequenceFactory.java
@@ -55,4 +55,22 @@ public interface CoordinateSequenceFactory
    */
   CoordinateSequence create(int size, int dimension);
 
+  /**
+   * Creates a {@link CoordinateSequence} of the specified size and dimension with measure support.
+   * For this to be useful, the {@link CoordinateSequence} implementation must
+   * be mutable.
+   * <p>
+   * If the requested dimension or measures are larger than the CoordinateSequence implementation
+   * can provide, then a sequence of maximum possible dimension should be created.
+   * An error should not be thrown.
+   *
+   * @param size the number of coordinates in the sequence
+   * @param dimension the dimension of the coordinates in the sequence (if user-specifiable,
+   * otherwise ignored)
+   * @param measures the number of measures of the coordiantes in the sequence (if user-specifiable,
+   * otherwise ignored)
+   */
+  default CoordinateSequence create(int size, int dimension, int measures) {
+      return create(size, dimension);
+  }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 Vivid Solutions, and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.geom;
+
+/**
+ * Coordinate subclass supporting XY ordinate.
+ * <p>
+ * This data object is suitable for use with coordinate sequences dimension 3, measures 1.
+ * The {@link Coordinate#Z} field is visible, but intended to be ignored.
+ *
+ * @since 1.16
+ */
+public class CoordinateXY extends Coordinate {
+  private static final long serialVersionUID = 3532307803472313082L;
+
+/** Standard ordinate index value for, where X is 0 */
+  public static final int X = 0;
+
+  /** Standard ordinate index value for, where Y is 1 */
+  public static final int Y = 1;
+
+  /** CoordianteXY does not support Z values. */
+  public static final int Z = -1;
+
+  /** CoordianteXY does not support M measures. */
+   
+  public static final int M = -1;
+
+  /** Default constructor */
+  public CoordinateXY() {
+    super();
+  }
+
+  public CoordinateXY(double x, double y) {
+    super(x, y, Coordinate.NULL_ORDINATE);
+  }
+
+  public CoordinateXY(Coordinate coord) {
+    super(coord.x,coord.y);
+  }
+
+  public CoordinateXY(CoordinateXY coord) {
+    super(coord.x,coord.y);  
+  }
+
+  public CoordinateXY copy() {
+    return new CoordinateXY(this);
+  }
+    
+  /** The z-ordinate is not supported */
+  @Override
+  public double getZ() {
+      return NULL_ORDINATE;
+  }
+
+  /** The z-ordinate is not supported */
+  @Override
+  public void setZ(double z) {
+      throw new IllegalArgumentException("CoordianteXY dimension 2 does not support z-ordinate");
+  }  
+  
+  @Override
+  public double getOrdinate(int ordinateIndex) {
+      switch (ordinateIndex) {
+      case X: return x;
+      case Y: return y;
+      }
+      throw new IllegalArgumentException("Invalid ordinate index: " + ordinateIndex);
+  }
+  
+  @Override
+  public void setOrdinate(int ordinateIndex, double value) {
+      switch (ordinateIndex) {
+      case X:
+        x = value;
+        break;
+      case Y:
+        y = value;
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid ordinate index: " + ordinateIndex);
+    }
+  }
+  
+  public String toString() {
+    String stringRep = x + " " + y;
+    return stringRep;
+  }
+}

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java
@@ -28,10 +28,10 @@ public class CoordinateXY extends Coordinate {
   /** Standard ordinate index value for, where Y is 1 */
   public static final int Y = 1;
 
-  /** CoordianteXY does not support Z values. */
+  /** CoordinateXY does not support Z values. */
   public static final int Z = -1;
 
-  /** CoordianteXY does not support M measures. */
+  /** CoordinateXY does not support M measures. */
    
   public static final int M = -1;
 
@@ -65,7 +65,7 @@ public class CoordinateXY extends Coordinate {
   /** The z-ordinate is not supported */
   @Override
   public void setZ(double z) {
-      throw new IllegalArgumentException("CoordianteXY dimension 2 does not support z-ordinate");
+      throw new IllegalArgumentException("CoordinateXY dimension 2 does not support z-ordinate");
   }  
   
   @Override
@@ -92,7 +92,6 @@ public class CoordinateXY extends Coordinate {
   }
   
   public String toString() {
-    String stringRep = x + " " + y;
-    return stringRep;
+    return "(" + x + ", " + y + ")";
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Vivid Solutions, and others.
+ * Copyright (c) 2018 Vivid Solutions
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
@@ -75,9 +75,16 @@ public class CoordinateXYM extends Coordinate {
     this.m = m;
   }
   
+  /** The z-ordinate is not supported */
   @Override
   public double getZ() {
-    return NULL_ORDINATE;
+      return NULL_ORDINATE;
+  }
+
+  /** The z-ordinate is not supported */
+  @Override
+  public void setZ(double z) {
+      throw new IllegalArgumentException("CoordianteXY dimension 2 does not support z-ordinate");
   }
   
   @Override

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018 Vivid Solutions, and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.geom;
+
+/**
+ * Coordinate subclass supporting XYM ordinate.
+ * <p>
+ * This data object is suitable for use with coordinate sequences dimension 3, measures 1.
+ *
+ * @since 1.16
+ */
+public class CoordinateXYM extends Coordinate {
+  private static final long serialVersionUID = 2842127537691165613L;
+
+/** Standard ordinate index value for, where X is 0 */
+  public static final int X = 0;
+
+  /** Standard ordinate index value for, where Y is 1 */
+  public static final int Y = 1;
+
+  /** CoordianteXYM does not support Z values. */
+  public static final int Z = -1;
+
+  /**
+   * Standard ordinate index value for, where M is 3.
+   *
+   * <p>This constant assumes XYM coordinate sequence definition, please check this assumption using
+   * {@link #getDimension()} and {@link #getMeasures()} before use.
+   */
+  public static final int M = 2;
+
+  /** Default constructor */
+  public CoordinateXYM() {
+    super();
+    this.m = 0.0;
+  }
+
+  public CoordinateXYM(double x, double y, double m) {
+    super(x, y, Coordinate.NULL_ORDINATE);
+    this.m = m;
+  }
+
+  public CoordinateXYM(Coordinate coord) {
+    super(coord.x,coord.y);
+    m = getM();
+  }
+
+  public CoordinateXYM(CoordinateXYM coord) {
+    super(coord.x,coord.y);
+    m = coord.m;
+  }
+
+  public CoordinateXYM copy() {
+    return new CoordinateXYM(this);
+  }
+    
+  /** The m-measure. */
+  private double m;
+
+  /** The m-measure, if available. */
+  public double getM() {
+    return m;
+  }
+
+  public void setM(double m) {
+    this.m = m;
+  }
+  
+  @Override
+  public double getZ() {
+    return NULL_ORDINATE;
+  }
+  
+  @Override
+  public double getOrdinate(int ordinateIndex) {
+      switch (ordinateIndex) {
+      case X: return x;
+      case Y: return y;
+      case M: return m;
+      }
+      throw new IllegalArgumentException("Invalid ordinate index: " + ordinateIndex);
+  }
+  
+  @Override
+  public void setOrdinate(int ordinateIndex, double value) {
+      switch (ordinateIndex) {
+      case X:
+        x = value;
+        break;
+      case Y:
+        y = value;
+        break;
+      case M:
+        m = value;
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid ordinate index: " + ordinateIndex);
+    }
+  }
+  
+  public String toString() {
+    String stringRep = x + " " + y + " m=" + m;
+    return stringRep;
+  }
+}

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
@@ -27,7 +27,7 @@ public class CoordinateXYM extends Coordinate {
   /** Standard ordinate index value for, where Y is 1 */
   public static final int Y = 1;
 
-  /** CoordianteXYM does not support Z values. */
+  /** CoordinateXYM does not support Z values. */
   public static final int Z = -1;
 
   /**
@@ -64,7 +64,7 @@ public class CoordinateXYM extends Coordinate {
   }
     
   /** The m-measure. */
-  private double m;
+  protected double m;
 
   /** The m-measure, if available. */
   public double getM() {
@@ -84,7 +84,7 @@ public class CoordinateXYM extends Coordinate {
   /** The z-ordinate is not supported */
   @Override
   public void setZ(double z) {
-      throw new IllegalArgumentException("CoordianteXY dimension 2 does not support z-ordinate");
+      throw new IllegalArgumentException("CoordinateXY dimension 2 does not support z-ordinate");
   }
   
   @Override
@@ -115,7 +115,6 @@ public class CoordinateXYM extends Coordinate {
   }
   
   public String toString() {
-    String stringRep = x + " " + y + " m=" + m;
-    return stringRep;
+    return "(" + x + ", " + y + " m=" + getM() + ")";
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Vivid Solutions, and others.
+ * Copyright (c) 2018 Vivid Solutions
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
@@ -69,6 +69,25 @@ public class CoordinateXYZM extends Coordinate {
     throw new IllegalArgumentException("Invalid ordinate index: " + ordinateIndex);
   }
   
+  @Override
+  public void setOrdinate(int ordinateIndex, double value) {
+      switch (ordinateIndex) {
+      case X:
+        x = value;
+        break;
+      case Y:
+        y = value;
+        break;
+      case Z:
+        z = value;
+        break;
+      case M:
+        m = value;
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid ordinate index: " + ordinateIndex);
+    }
+  }
   
   public String toString() {
     String stringRep = x + " " + y + " " + getZ() + " m=" + m;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
@@ -90,7 +90,6 @@ public class CoordinateXYZM extends Coordinate {
   }
   
   public String toString() {
-    String stringRep = x + " " + y + " " + getZ() + " m=" + m;
-    return stringRep;
+    return "(" + x + ", " + y + ", " + getZ() + " m="+getM()+")";
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.geom;
+
+/**
+ * Coordinate subclass supporting XYZM ordinate.
+ * <p>
+ * This data object is suitable for use with coordinate sequences dimension 4, measures 1.
+ *
+ * @since 1.16
+ */
+public class CoordinateXYZM extends Coordinate {
+  private static final long serialVersionUID = -8763329985881823442L;
+
+/** Default constructor */
+  public CoordinateXYZM() {
+    super();
+    this.m = 0.0;
+  }
+
+  public CoordinateXYZM(double x, double y, double z, double m) {
+    super(x, y, z);
+    this.m = m;
+  }
+
+  public CoordinateXYZM(Coordinate coord) {
+    super(coord);
+    m = getM();
+  }
+
+  public CoordinateXYZM(CoordinateXYZM coord) {
+    super(coord);
+    m = coord.m;
+  }
+
+  public CoordinateXYZM copy() {
+    return new CoordinateXYZM(this);
+  }
+
+  /** The m-measure. */
+  private double m;
+
+  /** The m-measure, if available. */
+  public double getM() {
+    return m;
+  }
+
+  public void setM(double m) {
+    this.m = m;
+  }
+
+  public String toString() {
+    String stringRep = x + " " + y + " " + getZ() + " m=" + m;
+    return stringRep;
+  }
+}

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
@@ -58,6 +58,18 @@ public class CoordinateXYZM extends Coordinate {
     this.m = m;
   }
 
+  public double getOrdinate(int ordinateIndex)
+  {
+    switch (ordinateIndex) {
+    case X: return x;
+    case Y: return y;
+    case Z: return getZ(); // sure to delegate to subclass rather than offer direct field access
+    case M: return getM(); // sure to delegate to subclass rather than offer direct field access
+    }
+    throw new IllegalArgumentException("Invalid ordinate index: " + ordinateIndex);
+  }
+  
+  
   public String toString() {
     String stringRep = x + " " + y + " " + getZ() + " m=" + m;
     return stringRep;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Vivid Solutions
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
@@ -47,27 +47,25 @@ public class Coordinates {
 	return new Coordinate();
     }
     
-    /**
-     * Determine dimension based on subclass of {@link Coordinate}.
-     * 
-     * @param coordiante supplied coordinate
-     * @return number of ordinates recorded
-     */
-    public static int getDimension(Coordinate coordinate) {
-	if(coordinate instanceof CoordinateXY) {
-	    return 2;
-	}
-	else if(coordinate instanceof CoordinateXYM) {
-	    return 2;
-	}
-	else if(coordinate instanceof Coordinate) {
-	    return 3;
-	}
-	else if(coordinate instanceof CoordinateXYZM) {
-	    return 4;
-	}
-	return 3;
+  /**
+   * Determine dimension based on subclass of {@link Coordinate}.
+   * 
+   * @param coordiante supplied coordinate
+   * @return number of ordinates recorded
+   */
+  public static int getDimension(Coordinate coordinate)
+  {
+    if (coordinate instanceof CoordinateXY) {
+      return 2;
+    } else if (coordinate instanceof CoordinateXYM) {
+      return 3;
+    } else if (coordinate instanceof Coordinate) {
+      return 3;
+    } else if (coordinate instanceof CoordinateXYZM) {
+      return 4;
     }
+    return 3;
+  }
     /**
      * Determine number of measures based on subclass of {@link Coordinate}.
      * 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Vivid Solutions and others.
+ * Copyright (c) 2016 Vivid Solutions
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -50,7 +50,7 @@ public class Coordinates {
   /**
    * Determine dimension based on subclass of {@link Coordinate}.
    * 
-   * @param coordiante supplied coordinate
+   * @param coordinate supplied coordinate
    * @return number of ordinates recorded
    */
   public static int dimension(Coordinate coordinate)
@@ -70,7 +70,7 @@ public class Coordinates {
   /**
    * Determine number of measures based on subclass of {@link Coordinate}.
    * 
-   * @param coordiante supplied coordinate
+   * @param coordinate supplied coordinate
    * @return number of measures recorded
    */
   public static int measures(Coordinate coordinate)

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.geom;
+
+/**
+ * Useful utility functions for handling Coordinate objects.
+ */
+public class Coordinates {
+    /**
+     * Factory method providing access to common Coordinate implementations.
+     * 
+     * @param dimension
+     * @return created coordinate 
+     */
+    public static Coordinate create( int dimension) {
+	return create(dimension,0);
+    }
+    /**
+     * Factory method providing access to common Coordinate implementations.
+     * 
+     * @param dimension
+     * @param measures
+     * @return created coordinate 
+     */
+    public static Coordinate create( int dimension, int measures) {
+	if( dimension == 2) {
+	    return new CoordinateXY();
+	}
+	else if( dimension == 3 && measures==0) {
+	    return new Coordinate();
+	}
+	else if( dimension == 3 && measures==1) {
+	    return new CoordinateXYM();
+	}
+	else if( dimension == 4 && measures==1) {
+	    return new CoordinateXYZM();
+	}
+	return new Coordinate();
+    }
+    
+    /**
+     * Determine dimension based on subclass of {@link Coordinate}.
+     * 
+     * @param coordiante
+     * @return dimension 
+     */
+    public static int getDimension(Coordinate coordiante) {
+	if(coordiante instanceof CoordinateXY) {
+	    return 2;
+	}
+	else if(coordiante instanceof CoordinateXYM) {
+	    return 2;
+	}
+	else if(coordiante instanceof Coordinate) {
+	    return 3;
+	}
+	else if(coordiante instanceof CoordinateXYZM) {
+	    return 4;
+	}
+	return 3;
+    }
+    /**
+     * Determine dimension based on subclass of {@link Coordinate}.
+     * 
+     * @param coordiante
+     * @return dimension 
+     */
+    public static int getMeasures(Coordinate coordiante) {
+	if(coordiante instanceof CoordinateXY) {
+	    return 0;
+	}
+	else if(coordiante instanceof CoordinateXYM) {
+	    return 1;
+	}
+	else if(coordiante instanceof Coordinate) {
+	    return 0;
+	}
+	else if(coordiante instanceof CoordinateXYZM) {
+	    return 1;
+	}
+	return 0;
+    }
+    
+}

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
@@ -50,41 +50,41 @@ public class Coordinates {
     /**
      * Determine dimension based on subclass of {@link Coordinate}.
      * 
-     * @param coordiante
-     * @return dimension 
+     * @param coordiante supplied coordinate
+     * @return number of ordinates recorded
      */
-    public static int getDimension(Coordinate coordiante) {
-	if(coordiante instanceof CoordinateXY) {
+    public static int getDimension(Coordinate coordinate) {
+	if(coordinate instanceof CoordinateXY) {
 	    return 2;
 	}
-	else if(coordiante instanceof CoordinateXYM) {
+	else if(coordinate instanceof CoordinateXYM) {
 	    return 2;
 	}
-	else if(coordiante instanceof Coordinate) {
+	else if(coordinate instanceof Coordinate) {
 	    return 3;
 	}
-	else if(coordiante instanceof CoordinateXYZM) {
+	else if(coordinate instanceof CoordinateXYZM) {
 	    return 4;
 	}
 	return 3;
     }
     /**
-     * Determine dimension based on subclass of {@link Coordinate}.
+     * Determine number of measures based on subclass of {@link Coordinate}.
      * 
-     * @param coordiante
-     * @return dimension 
+     * @param coordiante supplied coordinate
+     * @return number of measures recorded 
      */
-    public static int getMeasures(Coordinate coordiante) {
-	if(coordiante instanceof CoordinateXY) {
+    public static int getMeasures(Coordinate coordinate) {
+	if(coordinate instanceof CoordinateXY) {
 	    return 0;
 	}
-	else if(coordiante instanceof CoordinateXYM) {
+	else if(coordinate instanceof CoordinateXYM) {
 	    return 1;
 	}
-	else if(coordiante instanceof Coordinate) {
+	else if(coordinate instanceof Coordinate) {
 	    return 0;
 	}
-	else if(coordiante instanceof CoordinateXYZM) {
+	else if(coordinate instanceof CoordinateXYZM) {
 	    return 1;
 	}
 	return 0;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
@@ -15,37 +15,37 @@ package org.locationtech.jts.geom;
  * Useful utility functions for handling Coordinate objects.
  */
 public class Coordinates {
-    /**
-     * Factory method providing access to common Coordinate implementations.
-     * 
-     * @param dimension
-     * @return created coordinate 
-     */
-    public static Coordinate create( int dimension) {
-	return create(dimension,0);
+  /**
+   * Factory method providing access to common Coordinate implementations.
+   * 
+   * @param dimension
+   * @return created coordinate
+   */
+  public static Coordinate create(int dimension)
+  {
+    return create(dimension, 0);
+  }
+
+  /**
+   * Factory method providing access to common Coordinate implementations.
+   * 
+   * @param dimension
+   * @param measures
+   * @return created coordinate
+   */
+  public static Coordinate create(int dimension, int measures)
+  {
+    if (dimension == 2) {
+      return new CoordinateXY();
+    } else if (dimension == 3 && measures == 0) {
+      return new Coordinate();
+    } else if (dimension == 3 && measures == 1) {
+      return new CoordinateXYM();
+    } else if (dimension == 4 && measures == 1) {
+      return new CoordinateXYZM();
     }
-    /**
-     * Factory method providing access to common Coordinate implementations.
-     * 
-     * @param dimension
-     * @param measures
-     * @return created coordinate 
-     */
-    public static Coordinate create( int dimension, int measures) {
-	if( dimension == 2) {
-	    return new CoordinateXY();
-	}
-	else if( dimension == 3 && measures==0) {
-	    return new Coordinate();
-	}
-	else if( dimension == 3 && measures==1) {
-	    return new CoordinateXYM();
-	}
-	else if( dimension == 4 && measures==1) {
-	    return new CoordinateXYZM();
-	}
-	return new Coordinate();
-    }
+    return new Coordinate();
+  }
     
   /**
    * Determine dimension based on subclass of {@link Coordinate}.
@@ -53,7 +53,7 @@ public class Coordinates {
    * @param coordiante supplied coordinate
    * @return number of ordinates recorded
    */
-  public static int getDimension(Coordinate coordinate)
+  public static int dimension(Coordinate coordinate)
   {
     if (coordinate instanceof CoordinateXY) {
       return 2;
@@ -66,26 +66,25 @@ public class Coordinates {
     }
     return 3;
   }
-    /**
-     * Determine number of measures based on subclass of {@link Coordinate}.
-     * 
-     * @param coordiante supplied coordinate
-     * @return number of measures recorded 
-     */
-    public static int getMeasures(Coordinate coordinate) {
-	if(coordinate instanceof CoordinateXY) {
-	    return 0;
-	}
-	else if(coordinate instanceof CoordinateXYM) {
-	    return 1;
-	}
-	else if(coordinate instanceof Coordinate) {
-	    return 0;
-	}
-	else if(coordinate instanceof CoordinateXYZM) {
-	    return 1;
-	}
-	return 0;
+
+  /**
+   * Determine number of measures based on subclass of {@link Coordinate}.
+   * 
+   * @param coordiante supplied coordinate
+   * @return number of measures recorded
+   */
+  public static int measures(Coordinate coordinate)
+  {
+    if (coordinate instanceof CoordinateXY) {
+      return 0;
+    } else if (coordinate instanceof CoordinateXYM) {
+      return 1;
+    } else if (coordinate instanceof Coordinate) {
+      return 0;
+    } else if (coordinate instanceof CoordinateXYZM) {
+      return 1;
     }
+    return 0;
+  }
     
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/DefaultCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/DefaultCoordinateSequence.java
@@ -122,7 +122,7 @@ class DefaultCoordinateSequence
     switch (ordinateIndex) {
       case CoordinateSequence.X:  return coordinates[index].x;
       case CoordinateSequence.Y:  return coordinates[index].y;
-      case CoordinateSequence.Z:  return coordinates[index].z;
+      case CoordinateSequence.Z:  return coordinates[index].getZ();
     }
     return Double.NaN;
   }
@@ -134,7 +134,7 @@ class DefaultCoordinateSequence
     switch (ordinateIndex) {
       case CoordinateSequence.X:  coordinates[index].x = value; break;
       case CoordinateSequence.Y:  coordinates[index].y = value; break;
-      case CoordinateSequence.Z:  coordinates[index].z = value; break;
+      case CoordinateSequence.Z:  coordinates[index].setZ(value); break;
     }
   }
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/PrecisionModel.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/PrecisionModel.java
@@ -323,7 +323,7 @@ public class PrecisionModel implements Serializable, Comparable
       internal.x = makePrecise(external.x);
       internal.y = makePrecise(external.y);
     }
-    internal.z = external.z;
+    internal.setZ(external.getZ());
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Triangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Triangle.java
@@ -343,11 +343,11 @@ public class Triangle
     // side vectors u and v
     double ux = b.x - a.x;
     double uy = b.y - a.y;
-    double uz = b.z - a.z;
+    double uz = b.getZ() - a.getZ();
 
     double vx = c.x - a.x;
     double vy = c.y - a.y;
-    double vz = c.z - a.z;
+    double vz = c.getZ() - a.getZ();
 
     // cross-product = u x v
     double crossx = uy * vz - uz * vy;
@@ -394,7 +394,7 @@ public class Triangle
     double dy = p.y - y0;
     double t = (d * dx - b * dy) / det;
     double u = (-c * dx + a * dy) / det;
-    double z = v0.z + t * (v1.z - v0.z) + u * (v2.z - v0.z);
+    double z = v0.getZ() + t * (v1.getZ() - v0.getZ()) + u * (v2.getZ() - v0.getZ());
     return z;
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
@@ -144,7 +144,7 @@ public class CoordinateArraySequence
    * @return a copy of the requested Coordinate
    */
   public Coordinate getCoordinateCopy(int i) {
-    return new Coordinate(coordinates[i]);
+    return coordinates[i].copy();
   }
 
   /**
@@ -153,7 +153,7 @@ public class CoordinateArraySequence
   public void getCoordinate(int index, Coordinate coord) {
     coord.x = coordinates[index].x;
     coord.y = coordinates[index].y;
-    coord.z = coordinates[index].z;
+    coord.setZ(coordinates[index].getZ());
   }
 
   /**
@@ -178,9 +178,9 @@ public class CoordinateArraySequence
     switch (ordinateIndex) {
       case CoordinateSequence.X:  return coordinates[index].x;
       case CoordinateSequence.Y:  return coordinates[index].y;
-      case CoordinateSequence.Z:  return coordinates[index].z;
+      default:
+	return coordinates[index].getOrdinate(ordinateIndex);
     }
-    return Double.NaN;
   }
 
   /**
@@ -226,7 +226,7 @@ public class CoordinateArraySequence
         coordinates[index].y = value;
         break;
       case CoordinateSequence.Z:
-        coordinates[index].z = value;
+        coordinates[index].setZ(value);
         break;
       default:
           throw new IllegalArgumentException("invalid ordinateIndex");

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
@@ -14,7 +14,9 @@ package org.locationtech.jts.geom.impl;
 import java.io.Serializable;
 
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateArrays;
 import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Coordinates;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 
@@ -39,9 +41,14 @@ public class CoordinateArraySequence
 
   /**
    * The actual dimension of the coordinates in the sequence.
-   * Allowable values are 2 or 3.
+   * Allowable values are 2, 3 or 4.
    */
   private int dimension = 3;
+  /**
+   * The number of measures of the coordinates in the sequence.
+   * Allowable values are 0 or 1.
+   */
+  private int measures = 0;
   
   private Coordinate[] coordinates;
 
@@ -53,8 +60,9 @@ public class CoordinateArraySequence
    *
    * @param coordinates the coordinate array that will be referenced.
    */
-  public CoordinateArraySequence(Coordinate[] coordinates) {
-    this(coordinates, 3);
+  public CoordinateArraySequence(Coordinate[] coordinates)
+  {
+    this(coordinates, CoordinateArrays.dimension(coordinates), CoordinateArrays.measures(coordinates));
   }
 
   /**
@@ -66,10 +74,25 @@ public class CoordinateArraySequence
    * @param dimension the dimension of the coordinates
    */
   public CoordinateArraySequence(Coordinate[] coordinates, int dimension) {
+    this(coordinates, dimension, CoordinateArrays.measures(coordinates));    
+  }
+  
+  /**
+   * Constructs a sequence based on the given array 
+   * of {@link Coordinate}s (the
+   * array is not copied).
+   *
+   * @param coordinates the coordinate array that will be referenced.
+   * @param dimension the dimension of the coordinates
+   */
+  public CoordinateArraySequence(Coordinate[] coordinates, int dimension, int measures)
+  {
     this.coordinates = coordinates;
     this.dimension = dimension;
-    if (coordinates == null)
+    this.measures = measures;
+    if (coordinates == null) {
       this.coordinates = new Coordinate[0];
+    }
   }
 
   /**
@@ -96,7 +119,22 @@ public class CoordinateArraySequence
     coordinates = new Coordinate[size];
     this.dimension = dimension;
     for (int i = 0; i < size; i++) {
-      coordinates[i] = new Coordinate();
+      coordinates[i] = Coordinates.create(dimension);
+    }
+  }
+  /**
+   * Constructs a sequence of a given size, populated
+   * with new {@link Coordinate}s.
+   *
+   * @param size the size of the sequence to create
+   * @param dimension the dimension of the coordinates
+   */
+  public CoordinateArraySequence(int size, int dimension,int measures) {
+    coordinates = new Coordinate[size];
+    this.dimension = dimension;
+    this.measures = measures;
+    for (int i = 0; i < size; i++) {
+      coordinates[i] = Coordinates.create(dimension,measures);
     }
   }
 
@@ -114,6 +152,7 @@ public class CoordinateArraySequence
       return;
     }
     dimension = coordSeq.getDimension();
+    measures = coordSeq.getMeasures();    
     coordinates = new Coordinate[coordSeq.size()];
 
     for (int i = 0; i < coordinates.length; i++) {
@@ -124,7 +163,16 @@ public class CoordinateArraySequence
   /**
    * @see org.locationtech.jts.geom.CoordinateSequence#getDimension()
    */
-  public int getDimension() { return dimension; }
+  public int getDimension()
+  {
+    return dimension;
+  }
+  
+  @Override
+  public int getMeasures()
+  {
+    return measures;
+  }
 
   /**
    * Get the Coordinate with index i.
@@ -153,7 +201,12 @@ public class CoordinateArraySequence
   public void getCoordinate(int index, Coordinate coord) {
     coord.x = coordinates[index].x;
     coord.y = coordinates[index].y;
-    coord.setZ(coordinates[index].getZ());
+    if( hasZ()) {
+      coord.setZ(coordinates[index].getZ());
+    }
+    if( hasM()) {
+      coord.setM(coordinates[index].getM());
+    }    
   }
 
   /**
@@ -171,6 +224,31 @@ public class CoordinateArraySequence
   }
 
   /**
+   * @see org.locationtech.jts.geom.CoordinateSequence#getZ(int)
+   */
+  public double getZ(int index)
+  {
+    if (hasZ()) {
+      return coordinates[index].getZ();
+    } else {
+      return Double.NaN;
+    }
+
+  }
+  
+  /**
+   * @see org.locationtech.jts.geom.CoordinateSequence#getM(int)
+   */
+  public double getM(int index) {
+    if (hasM()) {
+      return coordinates[index].getM();
+    }
+    else {
+        return Double.NaN;
+    }    
+  }
+  
+  /**
    * @see org.locationtech.jts.geom.CoordinateSequence#getOrdinate(int, int)
    */
   public double getOrdinate(int index, int ordinateIndex)
@@ -179,7 +257,7 @@ public class CoordinateArraySequence
       case CoordinateSequence.X:  return coordinates[index].x;
       case CoordinateSequence.Y:  return coordinates[index].y;
       default:
-	return coordinates[index].getOrdinate(ordinateIndex);
+	      return coordinates[index].getOrdinate(ordinateIndex);
     }
   }
 
@@ -202,7 +280,7 @@ public class CoordinateArraySequence
     for (int i = 0; i < coordinates.length; i++) {
       cloneCoordinates[i] = coordinates[i].copy();
     }
-    return new CoordinateArraySequence(cloneCoordinates, dimension);
+    return new CoordinateArraySequence(cloneCoordinates, dimension, measures);
   }
   /**
    * Returns the size of the coordinate sequence
@@ -225,11 +303,8 @@ public class CoordinateArraySequence
       case CoordinateSequence.Y:
         coordinates[index].y = value;
         break;
-      case CoordinateSequence.Z:
-        coordinates[index].setZ(value);
-        break;
       default:
-          throw new IllegalArgumentException("invalid ordinateIndex");
+        coordinates[index].setOrdinate(ordinateIndex, value);
     }
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
@@ -134,7 +134,7 @@ public class CoordinateArraySequence
     this.dimension = dimension;
     this.measures = measures;
     for (int i = 0; i < size; i++) {
-      coordinates[i] = Coordinates.create(dimension,measures);
+      coordinates[i] = createCoordinate();
     }
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceFactory.java
@@ -78,4 +78,21 @@ public final class CoordinateArraySequenceFactory
       return new CoordinateArraySequence(size);
     return new CoordinateArraySequence(size, dimension);
   }
+  
+  public CoordinateSequence create(int size, int dimension, int measures) {
+    if (dimension > 4) {
+      dimension = 4;
+      //throw new IllegalArgumentException("dimension must be <= 4");
+    }
+    if (measures > 1) {
+      measures = 1;
+      //throw new IllegalArgumentException("measures must be <= 1");
+    }
+    if (dimension < 2)
+      dimension = 2; // handle bogus dimension
+    if (dimension - measures < 2) {
+      throw new IllegalArgumentException("max spatial dimension 2 required");
+    }
+    return new CoordinateArraySequence(size, dimension, measures);
+  }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceFactory.java
@@ -91,7 +91,8 @@ public final class CoordinateArraySequenceFactory
     if (dimension < 2)
       dimension = 2; // handle bogus dimension
     if (dimension - measures < 2) {
-      throw new IllegalArgumentException("max spatial dimension 2 required");
+      throw new IllegalArgumentException("Minimum spatial dimension of 2 required. Input was dimension " + dimension
+          + "and number of measures " + measures + ".");
     }
     return new CoordinateArraySequence(size, dimension, measures);
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
@@ -100,7 +100,12 @@ public abstract class PackedCoordinateSequence
   public void getCoordinate(int i, Coordinate coord) {
     coord.x = getOrdinate(i, 0);
     coord.y = getOrdinate(i, 1);
-    if (dimension > 2) coord.setZ(getOrdinate(i, 2));
+    if (hasZ()) {
+      coord.setZ(getZ(i));
+    }
+    if (hasM()) {
+      coord.setM(getM(i));
+    }
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
@@ -20,6 +20,9 @@ import java.util.Arrays;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequences;
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.CoordinateXYM;
+import org.locationtech.jts.geom.CoordinateXYZM;
 import org.locationtech.jts.geom.Envelope;
 
 /**
@@ -40,15 +43,28 @@ public abstract class PackedCoordinateSequence
 {
   private static final long serialVersionUID = -3151899011275603L;
   /**
-   * The dimensions of the coordinates hold in the packed array
+   * The dimensions of the coordinates held in the packed array
    */
-  protected int dimension;
-
+  final protected int dimension;
+  
+  /**
+   * The number of measures of the coordinates held in the packed array.
+   */
+  final protected int measures;
+  
+  protected PackedCoordinateSequence(int dimension, int measures ) {
+      if (dimension - measures < 2) {
+         throw new IllegalArgumentException("Must have at least 2 spatial dimensions");
+      }
+      this.dimension = dimension;
+      this.measures = measures;
+  }
+  
   /**
    * A soft reference to the Coordinate[] representation of this sequence.
    * Makes repeated coordinate array accesses more efficient.
    */
-  protected transient SoftReference coordRef;
+  protected transient SoftReference<Coordinate[]> coordRef;
 
   /**
    * @see org.locationtech.jts.geom.CoordinateSequence#getDimension()
@@ -57,6 +73,10 @@ public abstract class PackedCoordinateSequence
     return this.dimension;
   }
 
+  @Override
+  public int getMeasures() {
+    return this.measures;
+  }
   /**
    * @see org.locationtech.jts.geom.CoordinateSequence#getCoordinate(int)
    */
@@ -80,7 +100,7 @@ public abstract class PackedCoordinateSequence
   public void getCoordinate(int i, Coordinate coord) {
     coord.x = getOrdinate(i, 0);
     coord.y = getOrdinate(i, 1);
-    if (dimension > 2) coord.z = getOrdinate(i, 2);
+    if (dimension > 2) coord.setZ(getOrdinate(i, 2));
   }
 
   /**
@@ -96,7 +116,7 @@ public abstract class PackedCoordinateSequence
     for (int i = 0; i < coords.length; i++) {
       coords[i] = getCoordinateInternal(i);
     }
-    coordRef = new SoftReference(coords);
+    coordRef = new SoftReference<Coordinate[]>(coords);
 
     return coords;
   }
@@ -209,7 +229,7 @@ public abstract class PackedCoordinateSequence
    * Packed coordinate sequence implementation based on doubles
    */
   public static class Double extends PackedCoordinateSequence {
-
+    private static final long serialVersionUID = 5777450686367912719L;
     /**
      * The packed coordinate array
      */
@@ -219,17 +239,15 @@ public abstract class PackedCoordinateSequence
      * Builds a new packed coordinate sequence
      *
      * @param coords
-     * @param dimensions
+     * @param dimension
+     * @param measures
      */
-    public Double(double[] coords, int dimensions) {
-      if (dimensions < 2) {
-        throw new IllegalArgumentException("Must have at least 2 dimensions");
-      }
-      if (coords.length % dimensions != 0) {
+    public Double(double[] coords, int dimension, int measures) {
+      super(dimension,measures);
+      if (coords.length % dimension != 0) {
         throw new IllegalArgumentException("Packed array does not contain "
             + "an integral number of coordinates");
       }
-      this.dimension = dimensions;
       this.coords = coords;
     }
 
@@ -237,10 +255,12 @@ public abstract class PackedCoordinateSequence
      * Builds a new packed coordinate sequence out of a float coordinate array
      *
      * @param coordinates
+     * @param dimensions
+     * @param measures
      */
-    public Double(float[] coordinates, int dimensions) {
+    public Double(float[] coordinates, int dimension, int measures) {
+      super(dimension,measures);
       this.coords = new double[coordinates.length];
-      this.dimension = dimensions;
       for (int i = 0; i < coordinates.length; i++) {
         this.coords[i] = coordinates[i];
       }
@@ -250,19 +270,23 @@ public abstract class PackedCoordinateSequence
      * Builds a new packed coordinate sequence out of a coordinate array
      *
      * @param coordinates
+     * @param dimensions
+     * @param measures
      */
-    public Double(Coordinate[] coordinates, int dimension) {
+    public Double(Coordinate[] coordinates, int dimension, int measures) {
+      super(dimension,measures);
       if (coordinates == null)
         coordinates = new Coordinate[0];
-      this.dimension = dimension;
-
+      
       coords = new double[coordinates.length * this.dimension];
       for (int i = 0; i < coordinates.length; i++) {
         coords[i * this.dimension] = coordinates[i].x;
         if (this.dimension >= 2)
           coords[i * this.dimension + 1] = coordinates[i].y;
         if (this.dimension >= 3)
-          coords[i * this.dimension + 2] = coordinates[i].z;
+          coords[i * this.dimension + 2] = coordinates[i].getOrdinate(2); // Z or M
+        if (this.dimension >= 4)
+            coords[i * this.dimension + 2] = coordinates[i].getOrdinate(3); // M
       }
     }
     /**
@@ -271,14 +295,14 @@ public abstract class PackedCoordinateSequence
      * @param coordinates
      */
     public Double(Coordinate[] coordinates) {
-      this(coordinates, 3);
+      this(coordinates, 3,0);
     }
 
     /**
      * Builds a new empty packed coordinate sequence of a given size and dimension
      */
-    public Double(int size, int dimension) {
-      this.dimension = dimension;
+    public Double(int size, int dimension, int measures) {
+      super(dimension,measures);	
       coords = new double[size * this.dimension];
     }
 
@@ -288,8 +312,23 @@ public abstract class PackedCoordinateSequence
     public Coordinate getCoordinateInternal(int i) {
       double x = coords[i * dimension];
       double y = coords[i * dimension + 1];
-      double z = dimension == 2 ? Coordinate.NULL_ORDINATE : coords[i * dimension + 2];
-      return new Coordinate(x, y, z);
+      if( dimension == 2 && measures == 0 ) {
+	  return new CoordinateXY(x,y);  
+      }
+      else if (dimension == 3 && measures == 0) {
+          double z = coords[i * dimension + 2];
+          return new Coordinate(x,y,z);
+      }
+      else if (dimension == 3 && measures == 1) {
+	  double m = coords[i * dimension + 2];     
+          return new CoordinateXYM(x,y,m);          
+      }
+      else if (dimension == 4 && measures == 1) {
+	  double z = coords[i * dimension + 2];
+	  double m = coords[i * dimension + 3];
+	  return new CoordinateXYZM(x,y,z,m);
+      }
+      return new Coordinate(x, y);
     }
 
     /**
@@ -319,7 +358,7 @@ public abstract class PackedCoordinateSequence
     
     public Double copy() {
       double[] clone = Arrays.copyOf(coords, coords.length);
-      return new Double(clone, dimension);
+      return new Double(clone, dimension, measures);
     }
     
     /**
@@ -354,7 +393,7 @@ public abstract class PackedCoordinateSequence
    * Packed coordinate sequence implementation based on floats
    */
   public static class Float extends PackedCoordinateSequence {
-
+    private static final long serialVersionUID = -2902252401427938986L;
     /**
      * The packed coordinate array
      */
@@ -366,15 +405,12 @@ public abstract class PackedCoordinateSequence
      * @param coords
      * @param dimensions
      */
-    public Float(float[] coords, int dimensions) {
-      if (dimensions < 2) {
-        throw new IllegalArgumentException("Must have at least 2 dimensions");
-      }
-      if (coords.length % dimensions != 0) {
+    public Float(float[] coords, int dimension,int measures) {
+	super(dimension,measures);
+      if (coords.length % dimension != 0) {
         throw new IllegalArgumentException("Packed array does not contain "
             + "an integral number of coordinates");
       }
-      this.dimension = dimensions;
       this.coords = coords;
     }
 
@@ -384,9 +420,10 @@ public abstract class PackedCoordinateSequence
      * @param coordinates
      * @param dimension
      */
-    public Float(double[] coordinates, int dimension) {
-      this.coords = new float[coordinates.length];
-      this.dimension = dimension;
+    public Float(double[] coordinates, int dimension, int measures) {
+	super(dimension,measures);
+	this.coords = new float[coordinates.length];
+      
       for (int i = 0; i < coordinates.length; i++) {
         this.coords[i] = (float) coordinates[i];
       }
@@ -397,26 +434,26 @@ public abstract class PackedCoordinateSequence
      *
      * @param coordinates
      */
-    public Float(Coordinate[] coordinates, int dimension) {
+    public Float(Coordinate[] coordinates, int dimension, int measures) {
+	super(dimension,measures);
       if (coordinates == null)
         coordinates = new Coordinate[0];
-      this.dimension = dimension;
-
+      
       coords = new float[coordinates.length * this.dimension];
       for (int i = 0; i < coordinates.length; i++) {
         coords[i * this.dimension] = (float) coordinates[i].x;
         if (this.dimension >= 2)
           coords[i * this.dimension + 1] = (float) coordinates[i].y;
         if (this.dimension >= 3)
-          coords[i * this.dimension + 2] = (float) coordinates[i].z;
+          coords[i * this.dimension + 2] = (float) coordinates[i].getZ();
       }
     }
 
     /**
      * Constructs an empty packed coordinate sequence of a given size and dimension
      */
-    public Float(int size, int dimension) {
-      this.dimension = dimension;
+    public Float(int size, int dimension,int measures) {
+	super(dimension,measures);
       coords = new float[size * this.dimension];
     }
 
@@ -426,8 +463,23 @@ public abstract class PackedCoordinateSequence
     public Coordinate getCoordinateInternal(int i) {
       double x = coords[i * dimension];
       double y = coords[i * dimension + 1];
-      double z = dimension == 2 ? Coordinate.NULL_ORDINATE : coords[i * dimension + 2];
-      return new Coordinate(x, y, z);
+      if( dimension == 2 && measures == 0 ) {
+	  return new CoordinateXY(x,y);  
+      }
+      else if (dimension == 3 && measures == 0) {
+          double z = coords[i * dimension + 2];
+          return new Coordinate(x,y,z);
+      }
+      else if (dimension == 3 && measures == 1) {
+	  double m = coords[i * dimension + 2];     
+          return new CoordinateXYM(x,y,m);          
+      }
+      else if (dimension == 4 && measures == 1) {
+	  double z = coords[i * dimension + 2];
+	  double m = coords[i * dimension + 3];
+	  return new CoordinateXYZM(x,y,z,m);
+      }
+      return new Coordinate(x, y);
     }
 
     /**
@@ -457,7 +509,7 @@ public abstract class PackedCoordinateSequence
     
     public Float copy() {
       float[] clone = Arrays.copyOf(coords, coords.length);
-      return new Float(clone, dimension);
+      return new Float(clone, dimension,measures);
     }
 
     /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
@@ -291,7 +291,7 @@ public abstract class PackedCoordinateSequence
         if (this.dimension >= 3)
           coords[i * this.dimension + 2] = coordinates[i].getOrdinate(2); // Z or M
         if (this.dimension >= 4)
-            coords[i * this.dimension + 2] = coordinates[i].getOrdinate(3); // M
+          coords[i * this.dimension + 3] = coordinates[i].getOrdinate(3); // M
       }
     }
     /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
@@ -300,7 +300,7 @@ public abstract class PackedCoordinateSequence
      * @param coordinates
      */
     public Double(Coordinate[] coordinates) {
-      this(coordinates, 3,0);
+      this(coordinates, 3, 0);
     }
 
     /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
@@ -72,10 +72,10 @@ public class PackedCoordinateSequenceFactory implements
   public CoordinateSequence create(Coordinate[] coordinates) {
     int dimension = 3;
     int measures = 0;
-    if( coordinates.length > 1 && coordinates[0] != null ) {
-	Coordinate first = coordinates[0];
-	dimension = Coordinates.getDimension(first);
-	measures = Coordinates.getMeasures(first);
+    if (coordinates != null && coordinates.length > 1 && coordinates[0] != null) {
+      Coordinate first = coordinates[0];
+      dimension = Coordinates.getDimension(first);
+      measures = Coordinates.getMeasures(first);
     }
     if (type == DOUBLE) {
       return new PackedCoordinateSequence.Double(coordinates, dimension, measures);

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
@@ -74,8 +74,8 @@ public class PackedCoordinateSequenceFactory implements
     int measures = 0;
     if (coordinates != null && coordinates.length > 1 && coordinates[0] != null) {
       Coordinate first = coordinates[0];
-      dimension = Coordinates.getDimension(first);
-      measures = Coordinates.getMeasures(first);
+      dimension = Coordinates.dimension(first);
+      measures = Coordinates.measures(first);
     }
     if (type == DOUBLE) {
       return new PackedCoordinateSequence.Double(coordinates, dimension, measures);

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
@@ -102,7 +102,7 @@ public class PackedCoordinateSequenceFactory implements
    * 
    * @param packedCoordinates 
    * @param dimension
-   * @return Packaged coordiante seqeunce of the requested type
+   * @return Packaged coordinate seqeunce of the requested type
    */
   public CoordinateSequence create(double[] packedCoordinates, int dimension, int measures) {
     if (type == DOUBLE) {
@@ -115,7 +115,7 @@ public class PackedCoordinateSequenceFactory implements
    * @param packedCoordinates
    * @param dimension
    * @param measures
-   * @return Packaged coordiante seqeunce of the requested type
+   * @return Packaged coordinate seqeunce of the requested type
    */
   public CoordinateSequence create(float[] packedCoordinates, int dimension, int measures) {
     if (type == DOUBLE) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.Coordinates;
 
 /**
  * Builds packed array coordinate sequences. The array data type can be either
@@ -31,18 +32,17 @@ public class PackedCoordinateSequenceFactory implements
 
   public static final PackedCoordinateSequenceFactory DOUBLE_FACTORY =
       new PackedCoordinateSequenceFactory(DOUBLE);
+  
   public static final PackedCoordinateSequenceFactory FLOAT_FACTORY =
       new PackedCoordinateSequenceFactory(FLOAT);
 
   private int type = DOUBLE;
-  private int dimension = 3;
 
   /**
    * Creates a new PackedCoordinateSequenceFactory
    * of type DOUBLE.
    */
-  public PackedCoordinateSequenceFactory()
-  {
+  public PackedCoordinateSequenceFactory(){
     this(DOUBLE);
   }
 
@@ -53,21 +53,8 @@ public class PackedCoordinateSequenceFactory implements
    * {@linkplain PackedCoordinateSequenceFactory#Float}or
    * {@linkplain PackedCoordinateSequenceFactory#Double}
    */
-  public PackedCoordinateSequenceFactory(int type)
-  {
-    this(type, 3);
-  }
-  /**
-   * Creates a new PackedCoordinateSequenceFactory
-   * of the given type.
-   * Acceptable type values are
-   * {@linkplain PackedCoordinateSequenceFactory#FLOAT}or
-   * {@linkplain PackedCoordinateSequenceFactory#DOUBLE}
-   */
-  public PackedCoordinateSequenceFactory(int type, int dimension)
-  {
-    setType(type);
-    setDimension(dimension);
+  public PackedCoordinateSequenceFactory(int type){
+    this.type = type;
   }
 
   /**
@@ -80,29 +67,20 @@ public class PackedCoordinateSequenceFactory implements
   }
 
   /**
-   * Sets the type of packed coordinate sequences this factory builds,
-   * acceptable values are {@linkplain PackedCoordinateSequenceFactory#Float}or
-   * {@linkplain PackedCoordinateSequenceFactory#Double}
-   */
-  public void setType(int type) {
-    if (type != DOUBLE && type != FLOAT)
-      throw new IllegalArgumentException("Unknown type " + type);
-    this.type = type;
-  }
-
-
-  public int getDimension() { return dimension; }
-
-  public void setDimension(int dimension) { this.dimension = dimension; }
-
-  /**
    * @see org.locationtech.jts.geom.CoordinateSequenceFactory#create(org.locationtech.jts.geom.Coordinate[])
    */
   public CoordinateSequence create(Coordinate[] coordinates) {
+    int dimension = 3;
+    int measures = 0;
+    if( coordinates.length > 1 && coordinates[0] != null ) {
+	Coordinate first = coordinates[0];
+	dimension = Coordinates.getDimension(first);
+	measures = Coordinates.getMeasures(first);
+    }
     if (type == DOUBLE) {
-      return new PackedCoordinateSequence.Double(coordinates, dimension);
+      return new PackedCoordinateSequence.Double(coordinates, dimension, measures);
     } else {
-      return new PackedCoordinateSequence.Float(coordinates, dimension);
+      return new PackedCoordinateSequence.Float(coordinates,  dimension, measures);
     }
   }
 
@@ -110,34 +88,40 @@ public class PackedCoordinateSequenceFactory implements
    * @see org.locationtech.jts.geom.CoordinateSequenceFactory#create(org.locationtech.jts.geom.CoordinateSequence)
    */
   public CoordinateSequence create(CoordinateSequence coordSeq) {
+    int dimension = coordSeq.getDimension();
+    int measures = coordSeq.getMeasures();
     if (type == DOUBLE) {
-      return new PackedCoordinateSequence.Double(coordSeq.toCoordinateArray(), dimension);
+      return new PackedCoordinateSequence.Double(coordSeq.toCoordinateArray(), dimension, measures);
     } else {
-      return new PackedCoordinateSequence.Float(coordSeq.toCoordinateArray(), dimension);
+      return new PackedCoordinateSequence.Float(coordSeq.toCoordinateArray(), dimension, measures);
     }
   }
 
   /**
-   * @see org.locationtech.jts.geom.CoordinateSequenceFactory#create(double[],
-   *      int)
+   * Create a packed coordinate sequence from the provided array. 
+   * 
+   * @param packedCoordinates 
+   * @param dimension
+   * @return Packaged coordiante seqeunce of the requested type
    */
-  public CoordinateSequence create(double[] packedCoordinates, int dimension) {
+  public CoordinateSequence create(double[] packedCoordinates, int dimension, int measures) {
     if (type == DOUBLE) {
-      return new PackedCoordinateSequence.Double(packedCoordinates, dimension);
+      return new PackedCoordinateSequence.Double(packedCoordinates, dimension, measures);
     } else {
-      return new PackedCoordinateSequence.Float(packedCoordinates, dimension);
+      return new PackedCoordinateSequence.Float(packedCoordinates, dimension, measures);
     }
   }
-
   /**
-   * @see org.locationtech.jts.geom.CoordinateSequenceFactory#create(float[],
-   *      int)
+   * @param packedCoordinates
+   * @param dimension
+   * @param measures
+   * @return Packaged coordiante seqeunce of the requested type
    */
-  public CoordinateSequence create(float[] packedCoordinates, int dimension) {
+  public CoordinateSequence create(float[] packedCoordinates, int dimension, int measures) {
     if (type == DOUBLE) {
-      return new PackedCoordinateSequence.Double(packedCoordinates, dimension);
+      return new PackedCoordinateSequence.Double(packedCoordinates, dimension, measures);
     } else {
-      return new PackedCoordinateSequence.Float(packedCoordinates, dimension);
+      return new PackedCoordinateSequence.Float(packedCoordinates, dimension, measures);
     }
   }
 
@@ -146,9 +130,20 @@ public class PackedCoordinateSequenceFactory implements
    */
   public CoordinateSequence create(int size, int dimension) {
     if (type == DOUBLE) {
-      return new PackedCoordinateSequence.Double(size, dimension);
+      return new PackedCoordinateSequence.Double(size, dimension, 0);
     } else {
-      return new PackedCoordinateSequence.Float(size, dimension);
+      return new PackedCoordinateSequence.Float(size, dimension, 0 );
+    }
+  }
+  
+  /**
+   * @see org.locationtech.jts.geom.CoordinateSequenceFactory#create(int, int, int)
+   */
+  public CoordinateSequence create(int size, int dimension, int measures) {
+    if (type == DOUBLE) {
+      return new PackedCoordinateSequence.Double(size, dimension, measures);
+    } else {
+      return new PackedCoordinateSequence.Float(size, dimension, measures);
     }
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
@@ -259,7 +259,7 @@ public class WKTReader
     coord.x = getNextNumber();
     coord.y = getNextNumber();
     if (isNumberNext()) {
-        coord.z = getNextNumber();
+        coord.setZ(getNextNumber());
     }
     if (isNumberNext()) {
       getNextNumber(); // ignore M value

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTWriter.java
@@ -527,9 +527,9 @@ public class WKTWriter
     throws IOException
   {
     writer.write(writeNumber(coordinate.x) + " " + writeNumber(coordinate.y));
-    if (outputDimension >= 3 && ! Double.isNaN(coordinate.z)) {
+    if (outputDimension >= 3 && ! Double.isNaN(coordinate.getZ())) {
       writer.write(" ");
-      writer.write(writeNumber(coordinate.z));
+      writer.write(writeNumber(coordinate.getZ()));
     }
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/io/gml2/GMLWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/gml2/GMLWriter.java
@@ -380,7 +380,7 @@ public class GMLWriter {
 		int dim = 2;
 
 		if (coords.length > 0) {
-			if (!(Double.isNaN(coords[0].z)))
+			if (!(Double.isNaN(coords[0].getZ())))
 				dim = 3;
 		}
 
@@ -399,7 +399,7 @@ public class GMLWriter {
 				writer.write(coordinateSeparator);
 				writer.write("" + coords[i].y);
 				writer.write(coordinateSeparator);
-				writer.write("" + coords[i].z);
+				writer.write("" + coords[i].getZ());
 			}
 			writer.write(tupleSeparator);
 

--- a/modules/core/src/main/java/org/locationtech/jts/io/gml2/GeometryStrategies.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/gml2/GeometryStrategies.java
@@ -431,7 +431,7 @@ public class GeometryStrategies{
 				if(axis.length>1)
 					c.y = axis[1].doubleValue();
 				if(axis.length>2)
-					c.z = axis[2].doubleValue();
+					c.setZ(axis[2].doubleValue());
 				
 				return c;
 			}

--- a/modules/core/src/main/java/org/locationtech/jts/io/kml/KMLWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/kml/KMLWriter.java
@@ -356,7 +356,7 @@ public class KMLWriter
     buf.append(COORDINATE_SEPARATOR);
     write(p.y, buf);
 
-    double z = p.z;
+    double z = p.getZ();
     // if altitude was specified directly, use it
     if (!Double.isNaN(zVal))
       z = zVal;

--- a/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
@@ -64,7 +64,7 @@ public class LinearLocation
     double x = (p1.x - p0.x) * frac + p0.x;
     double y = (p1.y - p0.y) * frac + p0.y;
     // interpolate Z value. If either input Z is NaN, result z will be NaN as well.
-    double z = (p1.z - p0.z) * frac + p0.z;
+    double z = (p1.getZ() - p0.getZ()) * frac + p0.getZ();
     return new Coordinate(x, y, z);
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/math/Vector3D.java
+++ b/modules/core/src/main/java/org/locationtech/jts/math/Vector3D.java
@@ -35,10 +35,10 @@ public class Vector3D {
 	{
 		double ABx = B.x - A.x;
 		double ABy = B.y - A.y;
-		double ABz = B.z - A.z;
+		double ABz = B.getZ() - A.getZ();
 		double CDx = D.x - C.x;
 		double CDy = D.y - C.y;
-		double CDz = D.z - C.z;
+		double CDz = D.getZ() - C.getZ();
 		return ABx*CDx + ABy*CDy + ABz*CDz;
 	}
 
@@ -71,7 +71,7 @@ public class Vector3D {
 	public Vector3D(Coordinate v) {
 		x = v.x;
 		y = v.y;
-		z = v.z;
+		z = v.getZ();
 	}
 
 	/**
@@ -82,7 +82,7 @@ public class Vector3D {
 	 * @return the dot product of the vectors
 	 */
 	public static double dot(Coordinate v1, Coordinate v2) {
-		return v1.x * v2.x + v1.y * v2.y + v1.z * v2.z;
+		return v1.x * v2.x + v1.y * v2.y + v1.getZ() * v2.getZ();
 	}
 
 	private double x;
@@ -92,7 +92,7 @@ public class Vector3D {
 	public Vector3D(Coordinate from, Coordinate to) {
 		x = to.x - from.x;
 		y = to.y - from.y;
-		z = to.z - from.z;
+		z = to.getZ() - from.getZ();
 	}
 
 	public Vector3D(double x, double y, double z) {
@@ -130,7 +130,7 @@ public class Vector3D {
 	}
 
 	public static double length(Coordinate v) {
-		return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+		return Math.sqrt(v.x * v.x + v.y * v.y + v.getZ() * v.getZ());
 	}
 
 	public Vector3D normalize() {
@@ -146,7 +146,7 @@ public class Vector3D {
 
 	public static Coordinate normalize(Coordinate v) {
 		double len = length(v);
-		return new Coordinate(v.x / len, v.y / len, v.z / len);
+		return new Coordinate(v.x / len, v.y / len, v.getZ() / len);
 	}
 	  /**
 	   * Gets a string representation of this vector

--- a/modules/core/src/main/java/org/locationtech/jts/noding/ScaledNoder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/ScaledNoder.java
@@ -88,7 +88,7 @@ public class ScaledNoder
       roundPts[i] = new Coordinate(
           Math.round((pts[i].x - offsetX) * scaleFactor),
           Math.round((pts[i].y - offsetY) * scaleFactor),
-          pts[i].z
+          pts[i].getZ()
         );
     }
     Coordinate[] roundPtsNoDup = CoordinateArrays.removeRepeatedPoints(roundPts);

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/AxisPlaneCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/AxisPlaneCoordinateSequence.java
@@ -93,7 +93,7 @@ public class AxisPlaneCoordinateSequence implements CoordinateSequence {
 	public void getCoordinate(int index, Coordinate coord) {
 		coord.x = getOrdinate(index, X);
 		coord.y = getOrdinate(index, Y);
-		coord.z = getOrdinate(index, Z);
+		coord.setZ(getOrdinate(index, Z));
 	}
 
 	public double getX(int index) {

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/Distance3DOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/Distance3DOp.java
@@ -556,7 +556,7 @@ public class Distance3DOp {
 		double f = Math.abs(d0) / (Math.abs(d0) + Math.abs(d1));
 		double intx = p0.x + f * (p1.x - p0.x);
 		double inty = p0.y + f * (p1.y - p0.y);
-		double intz = p0.z + f * (p1.z - p0.z);
+		double intz = p0.getZ() + f * (p1.getZ() - p0.getZ());
 		return new Coordinate(intx, inty, intz);
 	}
 

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/PlanarPolygon3D.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/PlanarPolygon3D.java
@@ -84,13 +84,13 @@ public class PlanarPolygon3D {
 		for (int i = 0; i < n - 1; i++) {
 			seq.getCoordinate(i, p1);
 			seq.getCoordinate(i+1, p2);
-			sum.x += (p1.y - p2.y)*(p1.z + p2.z);
-			sum.y += (p1.z - p2.z)*(p1.x + p2.x);
-			sum.z += (p1.x - p2.x)*(p1.y + p2.y);
+			sum.x += (p1.y - p2.y)*(p1.getZ() + p2.getZ());
+			sum.y += (p1.getZ() - p2.getZ())*(p1.x + p2.x);
+			sum.setZ(sum.getZ() + (p1.x - p2.x)*(p1.y + p2.y));
 		}
 		sum.x /= n;
 		sum.y /= n;
-		sum.z /= n;
+		sum.setZ(sum.getZ() / n);
 		Vector3D norm = Vector3D.create(sum).normalize();
 		return norm;
 	}
@@ -110,11 +110,11 @@ public class PlanarPolygon3D {
 		for (int i = 0; i < n; i++) {
 			a.x += seq.getOrdinate(i, CoordinateSequence.X);
 			a.y += seq.getOrdinate(i, CoordinateSequence.Y);
-			a.z += seq.getOrdinate(i, CoordinateSequence.Z);
+			a.setZ(a.getZ() + seq.getOrdinate(i, CoordinateSequence.Z));
 		}
 		a.x /= n;
 		a.y /= n;
-		a.z /= n;
+		a.setZ(a.getZ() / n);
 		return a;
 	}
 
@@ -164,9 +164,9 @@ public class PlanarPolygon3D {
 	{
 		switch (facingPlane) {
 		case Plane3D.XY_PLANE: return new Coordinate(p.x, p.y);
-		case Plane3D.XZ_PLANE: return new Coordinate(p.x, p.z);
+		case Plane3D.XZ_PLANE: return new Coordinate(p.x, p.getZ());
 		// Plane3D.YZ
-		default: return new Coordinate(p.y, p.z);
+		default: return new Coordinate(p.y, p.getZ());
 		}
 	}
 	

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/Segment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/Segment.java
@@ -109,7 +109,7 @@ public class Segment
      */
     public double getStartZ() {
         Coordinate p = ls.getCoordinate(0);
-        return p.z;
+        return p.getZ();
     }
 
     /**
@@ -139,7 +139,7 @@ public class Segment
      */
     public double getEndZ() {
         Coordinate p = ls.getCoordinate(1);
-        return p.z;
+        return p.getZ();
     }
 
     /**

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/Vertex.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/Vertex.java
@@ -68,11 +68,11 @@ public class Vertex
     }
 
     public double getZ() {
-        return p.z;
+        return p.getZ();
     }
 
     public void setZ(double _z) {
-        p.z = _z;
+        p.setZ(_z);
     }
 
     public Coordinate getCoordinate() {
@@ -277,7 +277,7 @@ public class Vertex
     public Vertex midPoint(Vertex a) {
         double xm = (p.x + a.getX()) / 2.0;
         double ym = (p.y + a.getY()) / 2.0;
-        double zm = (p.z + a.getZ()) / 2.0;
+        double zm = (p.getZ() + a.getZ()) / 2.0;
         return new Vertex(xm, ym, zm);
     }
 
@@ -351,7 +351,7 @@ public class Vertex
         double dy = p.y - y0;
         double t = (d * dx - b * dy) / det;
         double u = (-c * dx + a * dy) / det;
-        double z = v0.z + t * (v1.z - v0.z) + u * (v2.z - v0.z);
+        double z = v0.getZ() + t * (v1.getZ() - v0.getZ()) + u * (v2.getZ() - v0.getZ());
         return z;
     }
 
@@ -366,8 +366,8 @@ public class Vertex
     public static double interpolateZ(Coordinate p, Coordinate p0, Coordinate p1) {
         double segLen = p0.distance(p1);
         double ptLen = p.distance(p0);
-        double dz = p1.z - p0.z;
-        double pz = p0.z + dz * (ptLen / segLen);
+        double dz = p1.getZ() - p0.getZ();
+        double pz = p0.getZ() + dz * (ptLen / segLen);
         return pz;
     }
 

--- a/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateTest.java
@@ -163,6 +163,82 @@ public class CoordinateTest extends TestCase
     double distance = coord1.distance3D(coord2);
     assertEquals(distance, 229.128784747792, 0.000001);
   }
-
+  public void testCoordinateXY() {
+    Coordinate xy = new CoordinateXY();    
+    checkZUnsupported(xy);
+    checkMUnsupported(xy);
+    
+    xy = new CoordinateXY(1.0,1.0);        // 2D
+    Coordinate coord = new Coordinate(xy); // copy
+    assertEquals( xy, coord );
+    assertTrue( !xy.equalInZ(coord,0.000001) );    
+    
+    coord = new Coordinate(1.0,1.0,1.0); // 2.5d
+    xy = new CoordinateXY( coord ); // copy
+    assertEquals( xy, coord );
+    assertTrue( !xy.equalInZ(coord,0.000001) );        
+  }
+  public void testCoordinateXYM() {
+      Coordinate xym = new CoordinateXYM();
+      checkZUnsupported(xym);
+      
+      xym.setM(1.0);
+      assertEquals( 1.0, xym.getM());
+      
+      Coordinate coord = new Coordinate(xym); // copy
+      assertEquals( xym, coord );
+      assertTrue( !xym.equalInZ(coord,0.000001) );
+      
+      coord = new Coordinate(1.0,1.0,1.0); // 2.5d
+      xym = new CoordinateXYM( coord ); // copy
+      assertEquals( xym, coord );
+      assertTrue( !xym.equalInZ(coord,0.000001) ); 
+  }
+  public void testCoordinateXYMZ() {
+      Coordinate xyzm = new CoordinateXYZM();
+      xyzm.setZ(1.0);
+      assertEquals( 1.0, xyzm.getZ());
+      xyzm.setM(1.0);
+      assertEquals( 1.0, xyzm.getM());
+      
+      Coordinate coord = new Coordinate(xyzm); // copy
+      assertEquals( xyzm, coord );
+      assertTrue( xyzm.equalInZ(coord,0.000001) );
+      assertTrue( Double.isNaN(coord.getM()));
+      
+      coord = new Coordinate(1.0,1.0,1.0); // 2.5d
+      xyzm = new CoordinateXYZM( coord ); // copy
+      assertEquals( xyzm, coord );
+      assertTrue( xyzm.equalInZ(coord,0.000001) ); 
+  }
+  
+  /**
+   * Confirm the z field is not supported by getZ and setZ.
+   */
+  private void checkZUnsupported(Coordinate coord )
+  {
+      try {
+          coord.setZ(0.0);
+          fail(coord.getClass().getSimpleName() + " does not support Z");        
+      }
+      catch(IllegalArgumentException expected) {        
+      }       
+      assertTrue( Double.isNaN(coord.z));
+      coord.z = 0.0;                      // field still public
+      assertTrue( "z field not used", Double.isNaN(coord.getZ())); // but not used
+  }
+  /**
+   * Confirm the z field is not supported by getZ and setZ.
+   */
+  private void checkMUnsupported(Coordinate coord )
+  {
+      try {
+          coord.setM(0.0);
+          fail(coord.getClass().getSimpleName() + " does not support M");        
+      }
+      catch(IllegalArgumentException expected) {        
+      }
+      assertTrue( Double.isNaN(coord.getM()));      
+  }
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateTest.java
@@ -194,7 +194,7 @@ public class CoordinateTest extends TestCase
       assertEquals( xym, coord );
       assertTrue( !xym.equalInZ(coord,0.000001) ); 
   }
-  public void testCoordinateXYMZ() {
+  public void testCoordinateXYZM() {
       Coordinate xyzm = new CoordinateXYZM();
       xyzm.setZ(1.0);
       assertEquals( 1.0, xyzm.getZ());

--- a/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateTest.java
@@ -31,7 +31,7 @@ public class CoordinateTest extends TestCase
     Coordinate c = new Coordinate(350.2, 4566.8, 5266.3);
     assertEquals(c.x, 350.2);
     assertEquals(c.y, 4566.8);
-    assertEquals(c.z, 5266.3);
+    assertEquals(c.getZ(), 5266.3);
   }
   
   public void testConstructor2D() 
@@ -39,14 +39,14 @@ public class CoordinateTest extends TestCase
     Coordinate c = new Coordinate(350.2, 4566.8);
     assertEquals(c.x, 350.2);
     assertEquals(c.y, 4566.8);
-    assertEquals(c.z, Coordinate.NULL_ORDINATE);
+    assertEquals(c.getZ(), Coordinate.NULL_ORDINATE);
   }
   public void testDefaultConstructor() 
   {
     Coordinate c = new Coordinate();
     assertEquals(c.x, 0.0);
     assertEquals(c.y, 0.0);
-    assertEquals(c.z, Coordinate.NULL_ORDINATE);
+    assertEquals(c.getZ(), Coordinate.NULL_ORDINATE);
   }
   public void testCopyConstructor3D() 
   {
@@ -54,7 +54,7 @@ public class CoordinateTest extends TestCase
     Coordinate c = new Coordinate(orig);
     assertEquals(c.x, 350.2);
     assertEquals(c.y, 4566.8);
-    assertEquals(c.z, 5266.3);
+    assertEquals(c.getZ(), 5266.3);
   }
   public void testSetCoordinate() 
   {
@@ -63,7 +63,7 @@ public class CoordinateTest extends TestCase
     c.setCoordinate(orig);
     assertEquals(c.x, 350.2);
     assertEquals(c.y, 4566.8);
-    assertEquals(c.z, 5266.3);
+    assertEquals(c.getZ(), 5266.3);
   }
   public void testGetOrdinate() 
   {

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceTest.java
@@ -12,7 +12,12 @@
 
 package org.locationtech.jts.geom.impl;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.CoordinateXYM;
+import org.locationtech.jts.geom.CoordinateXYZM;
 
 import junit.textui.TestRunner;
 
@@ -36,5 +41,101 @@ public class CoordinateArraySequenceTest
   @Override
   CoordinateSequenceFactory getCSFactory() {
     return CoordinateArraySequenceFactory.instance();
+  }
+  
+  public void testDimensionAndMeasure()
+  {
+    CoordinateSequenceFactory factory = getCSFactory();
+    CoordinateSequence seq = factory.create(5, 2);
+    CoordinateSequence copy;
+    Coordinate coord;
+    Coordinate[] array;
+    
+    initProgression(seq);
+    assertEquals("xz", 2, seq.getDimension());
+    assertTrue("Z", !seq.hasZ());
+    assertTrue("M", !seq.hasM());
+    coord = seq.getCoordinate(4);
+    assertTrue( coord instanceof CoordinateXY);
+    assertEquals( 4.0, coord.getX());
+    assertEquals( 4.0, coord.getY());
+    array = seq.toCoordinateArray();
+    assertEquals(coord, array[4]);
+    assertTrue(isEqual(seq,array));
+    copy = factory.create(array);
+    assertTrue(isEqual(copy,array));
+    copy = factory.create(seq);
+    assertTrue(isEqual(copy,array));
+    
+    seq = factory.create(5, 3);
+    initProgression(seq);
+    assertEquals("xyz", 3, seq.getDimension());
+    assertTrue("Z", seq.hasZ());
+    assertTrue("M", !seq.hasM());
+    coord = seq.getCoordinate(4);
+    assertTrue( coord.getClass() == Coordinate.class);
+    assertEquals( 4.0, coord.getX());
+    assertEquals( 4.0, coord.getY());
+    assertEquals( 4.0, coord.getZ());
+    array = seq.toCoordinateArray();
+    assertEquals(coord, array[4]);
+    assertTrue(isEqual(seq,array));
+    copy = factory.create(array);
+    assertTrue(isEqual(copy,array));
+    copy = factory.create(seq);
+    assertTrue(isEqual(copy,array));
+    
+    seq = factory.create(5, 3, 1);
+    initProgression(seq);
+    assertEquals("xym", 3, seq.getDimension());
+    assertTrue("Z", !seq.hasZ());
+    assertTrue("M", seq.hasM());
+    coord = seq.getCoordinate(4);
+    assertTrue( coord instanceof CoordinateXYM);
+    assertEquals( 4.0, coord.getX());
+    assertEquals( 4.0, coord.getY());
+    assertEquals( 4.0, coord.getM());
+    array = seq.toCoordinateArray();
+    assertEquals(coord, array[4]);
+    assertTrue(isEqual(seq,array));
+    copy = factory.create(array);
+    assertTrue(isEqual(copy,array));
+    copy = factory.create(seq);
+    assertTrue(isEqual(copy,array));
+    
+    seq = factory.create(5, 4, 1);
+    initProgression(seq);
+    assertEquals("xyzm", 4, seq.getDimension());
+    assertTrue("Z", seq.hasZ());
+    assertTrue("M", seq.hasM());
+    coord = seq.getCoordinate(4);
+    assertTrue( coord instanceof CoordinateXYZM);
+    assertEquals( 4.0, coord.getX());
+    assertEquals( 4.0, coord.getY());
+    assertEquals( 4.0, coord.getZ());
+    assertEquals( 4.0, coord.getM());
+    array = seq.toCoordinateArray();
+    assertEquals(coord, array[4]);
+    assertTrue(isEqual(seq,array));
+    copy = factory.create(array);
+    assertTrue(isEqual(copy,array));
+    copy = factory.create(seq);
+    assertTrue(isEqual(copy,array));
+    
+    try {
+      seq = factory.create(5, 2, 1);
+      assertEquals(3,seq.getDimension());
+      assertEquals(1,seq.getMeasures());
+      fail("xm not supported");
+    } catch (IllegalArgumentException expected) {
+    }    
+  }
+  
+  private void initProgression(CoordinateSequence seq) {
+    for (int index = 0; index < seq.size(); index++) {
+       for( int ordinateIndex = 0; ordinateIndex < seq.getDimension(); ordinateIndex++) {
+         seq.setOrdinate(index, ordinateIndex, (double) index);
+       }
+    }
   }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
@@ -137,11 +137,22 @@ public abstract class CoordinateSequenceTestBase
   boolean isAllCoordsEqual(CoordinateSequence seq, Coordinate coord)
   {
     for (int i = 0; i < seq.size(); i++) {
-      if (! coord.equals(seq.getCoordinate(i)))  return false;
+      if (!coord.equals(seq.getCoordinate(i))) return false;
 
-      if (coord.x != seq.getOrdinate(i, CoordinateSequence.X))  return false;
-      if (coord.y != seq.getOrdinate(i, CoordinateSequence.Y))  return false;
-      if (coord.getZ() != seq.getOrdinate(i, CoordinateSequence.Z))  return false;
+      if (coord.x != seq.getOrdinate(i, CoordinateSequence.X)) return false;
+      if (coord.y != seq.getOrdinate(i, CoordinateSequence.Y)) return false;
+      if (seq.hasZ()) {
+        if (coord.getZ() != seq.getZ(i)) return false;
+      }
+      if (seq.hasM()) {
+        if (coord.getM() != seq.getM(i)) return false;
+      }
+      if (seq.getDimension() > 2) {
+        if (coord.getOrdinate(2) != seq.getOrdinate(i, 2)) return false;
+      }
+      if (seq.getDimension() > 3) {
+        if (coord.getOrdinate(3) != seq.getOrdinate(i, 3)) return false;
+      }
     }
     return true;
   }
@@ -157,27 +168,51 @@ public abstract class CoordinateSequenceTestBase
   boolean isEqual(CoordinateSequence seq, Coordinate[] coords)
   {
     if (seq.size() != coords.length) return false;
-
-    Coordinate p = new Coordinate();
     
+    // carefully get coordiante of the same type as the sequence
+    Coordinate p = seq.size() == 0 ? new Coordinate() : (Coordinate) seq.getCoordinate(0).clone();
+    p.setX(0);
+    p.setY(0);
+    if (seq.hasZ()) {
+      p.setZ(0.0);
+    }
+    if (seq.hasM()) {
+      p.setM(0.0);
+    }
+
     for (int i = 0; i < seq.size(); i++) {
-      if (! coords[i].equals(seq.getCoordinate(i)))  return false;
+      if (!coords[i].equals(seq.getCoordinate(i))) return false;
 
       // Ordinate named getters
-      if (coords[i].x != seq.getX(i))  return false;
-      if (coords[i].y != seq.getY(i))  return false;
+      if (coords[i].x != seq.getX(i)) return false;
+      if (coords[i].y != seq.getY(i)) return false;
+      if (seq.hasZ()) {
+        if (coords[i].getZ() != seq.getZ(i)) return false;
+      }
+      if (seq.hasM()) {
+        if (coords[i].getM() != seq.getM(i)) return false;
+      }
 
       // Ordinate indexed getters
-      if (coords[i].x != seq.getOrdinate(i, CoordinateSequence.X))  return false;
-      if (coords[i].y != seq.getOrdinate(i, CoordinateSequence.Y))  return false;
-      if (coords[i].getZ() != seq.getOrdinate(i, CoordinateSequence.Z))  return false;
-      
+      if (coords[i].x != seq.getOrdinate(i, CoordinateSequence.X)) return false;
+      if (coords[i].y != seq.getOrdinate(i, CoordinateSequence.Y)) return false;
+      if (seq.getDimension() > 2) {
+        if (coords[i].getOrdinate(2) != seq.getOrdinate(i, 2)) return false;
+      }
+      if (seq.getDimension() > 3) {
+        if (coords[i].getOrdinate(3) != seq.getOrdinate(i, 3)) return false;
+      }
+
       // Coordinate getter
       seq.getCoordinate(i, p);
       if (coords[i].x != p.x) return false;
-      if (coords[i].y != p.y)  return false;
-      if (coords[i].getZ() != p.getZ())  return false;
-      
+      if (coords[i].y != p.y) return false;
+      if (seq.hasZ()) {
+        if (coords[i].getZ() != p.getZ()) return false;
+      }
+      if (seq.hasM()) {
+        if (coords[i].getM() != p.getM()) return false;
+      }
     }
     return true;
   }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
@@ -62,7 +62,7 @@ public abstract class CoordinateSequenceTestBase
     for (int i = 0; i < seq.size(); i++) {
       seq.setOrdinate(i, 0, coords[i].x);
       seq.setOrdinate(i, 1, coords[i].y);
-      seq.setOrdinate(i, 2, coords[i].z);
+      seq.setOrdinate(i, 2, coords[i].getZ());
     }
 
     assertTrue(isEqual(seq, coords));
@@ -80,7 +80,7 @@ public abstract class CoordinateSequenceTestBase
 
     for (int i = 0; i < seq.size(); i++) {
       Coordinate p = seq.getCoordinate(i);
-      assertTrue(Double.isNaN(p.z));
+      assertTrue(Double.isNaN(p.getZ()));
     }
   }
 
@@ -141,7 +141,7 @@ public abstract class CoordinateSequenceTestBase
 
       if (coord.x != seq.getOrdinate(i, CoordinateSequence.X))  return false;
       if (coord.y != seq.getOrdinate(i, CoordinateSequence.Y))  return false;
-      if (coord.z != seq.getOrdinate(i, CoordinateSequence.Z))  return false;
+      if (coord.getZ() != seq.getOrdinate(i, CoordinateSequence.Z))  return false;
     }
     return true;
   }
@@ -170,13 +170,13 @@ public abstract class CoordinateSequenceTestBase
       // Ordinate indexed getters
       if (coords[i].x != seq.getOrdinate(i, CoordinateSequence.X))  return false;
       if (coords[i].y != seq.getOrdinate(i, CoordinateSequence.Y))  return false;
-      if (coords[i].z != seq.getOrdinate(i, CoordinateSequence.Z))  return false;
+      if (coords[i].getZ() != seq.getOrdinate(i, CoordinateSequence.Z))  return false;
       
       // Coordinate getter
       seq.getCoordinate(i, p);
       if (coords[i].x != p.x) return false;
       if (coords[i].y != p.y)  return false;
-      if (coords[i].z != p.z)  return false;
+      if (coords[i].getZ() != p.getZ())  return false;
       
     }
     return true;

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
@@ -169,7 +169,7 @@ public abstract class CoordinateSequenceTestBase
   {
     if (seq.size() != coords.length) return false;
     
-    // carefully get coordiante of the same type as the sequence
+    // carefully get coordinate of the same type as the sequence
     Coordinate p = seq.size() == 0 ? new Coordinate() : (Coordinate) seq.getCoordinate(0).clone();
     p.setX(0);
     p.setY(0);

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceTest.java
@@ -44,7 +44,7 @@ public class PackedCoordinateSequenceTest
   
   public void testDimensionAndMeasure()
   {
-    CoordinateSequenceFactory factory = new PackedCoordinateSequenceFactory();
+    CoordinateSequenceFactory factory = getCSFactory();
     CoordinateSequence seq = factory.create(5, 2);
     CoordinateSequence copy;
     Coordinate coord;

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceTest.java
@@ -46,6 +46,7 @@ public class PackedCoordinateSequenceTest
   {
     CoordinateSequenceFactory factory = new PackedCoordinateSequenceFactory();
     CoordinateSequence seq = factory.create(5, 2);
+    CoordinateSequence copy;
     Coordinate coord;
     Coordinate[] array;
     
@@ -61,7 +62,10 @@ public class PackedCoordinateSequenceTest
     assertEquals(coord, array[4]);
     assertTrue(coord != array[4]);
     assertTrue(isEqual(seq,array));
-    
+    copy = factory.create(array);
+    assertTrue(isEqual(copy,array));
+    copy = factory.create(seq);
+    assertTrue(isEqual(copy,array));
     
     seq = factory.create(5, 3);
     initProgression(seq);
@@ -77,7 +81,11 @@ public class PackedCoordinateSequenceTest
     assertEquals(coord, array[4]);
     assertTrue(coord != array[4]);
     assertTrue(isEqual(seq,array));
-
+    copy = factory.create(array);
+    assertTrue(isEqual(copy,array));
+    copy = factory.create(seq);
+    assertTrue(isEqual(copy,array));
+    
     seq = factory.create(5, 3, 1);
     initProgression(seq);
     assertEquals("xym", 3, seq.getDimension());
@@ -92,6 +100,10 @@ public class PackedCoordinateSequenceTest
     assertEquals(coord, array[4]);
     assertTrue(coord != array[4]);
     assertTrue(isEqual(seq,array));
+    copy = factory.create(array);
+    assertTrue(isEqual(copy,array));
+    copy = factory.create(seq);
+    assertTrue(isEqual(copy,array));
     
     seq = factory.create(5, 4, 1);
     initProgression(seq);
@@ -108,12 +120,16 @@ public class PackedCoordinateSequenceTest
     assertEquals(coord, array[4]);
     assertTrue(coord != array[4]);
     assertTrue(isEqual(seq,array));
+    copy = factory.create(array);
+    assertTrue(isEqual(copy,array));
+    copy = factory.create(seq);
+    assertTrue(isEqual(copy,array));
     
     try {
       seq = factory.create(5, 2, 1);
       fail("xm not supported");
     } catch (IllegalArgumentException expected) {
-    }
+    }    
   }
   
   private void initProgression(CoordinateSequence seq) {

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceTest.java
@@ -12,7 +12,12 @@
 
 package org.locationtech.jts.geom.impl;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.CoordinateXYM;
+import org.locationtech.jts.geom.CoordinateXYZM;
 
 import junit.textui.TestRunner;
 
@@ -35,6 +40,88 @@ public class PackedCoordinateSequenceTest
   @Override
   CoordinateSequenceFactory getCSFactory() {
     return new PackedCoordinateSequenceFactory();
+  }
+  
+  public void testDimensionAndMeasure()
+  {
+    CoordinateSequenceFactory factory = new PackedCoordinateSequenceFactory();
+    CoordinateSequence seq = factory.create(5, 2);
+    Coordinate coord;
+    Coordinate[] array;
+    
+    initProgression(seq);
+    assertEquals("xz", 2, seq.getDimension());
+    assertTrue("Z", !seq.hasZ());
+    assertTrue("M", !seq.hasM());
+    coord = seq.getCoordinate(4);
+    assertTrue( coord instanceof CoordinateXY);
+    assertEquals( 4.0, coord.getX());
+    assertEquals( 4.0, coord.getY());
+    array = seq.toCoordinateArray();
+    assertEquals(coord, array[4]);
+    assertTrue(coord != array[4]);
+    assertTrue(isEqual(seq,array));
+    
+    
+    seq = factory.create(5, 3);
+    initProgression(seq);
+    assertEquals("xyz", 3, seq.getDimension());
+    assertTrue("Z", seq.hasZ());
+    assertTrue("M", !seq.hasM());
+    coord = seq.getCoordinate(4);
+    assertTrue( coord.getClass() == Coordinate.class);
+    assertEquals( 4.0, coord.getX());
+    assertEquals( 4.0, coord.getY());
+    assertEquals( 4.0, coord.getZ());
+    array = seq.toCoordinateArray();
+    assertEquals(coord, array[4]);
+    assertTrue(coord != array[4]);
+    assertTrue(isEqual(seq,array));
+
+    seq = factory.create(5, 3, 1);
+    initProgression(seq);
+    assertEquals("xym", 3, seq.getDimension());
+    assertTrue("Z", !seq.hasZ());
+    assertTrue("M", seq.hasM());
+    coord = seq.getCoordinate(4);
+    assertTrue( coord instanceof CoordinateXYM);
+    assertEquals( 4.0, coord.getX());
+    assertEquals( 4.0, coord.getY());
+    assertEquals( 4.0, coord.getM());
+    array = seq.toCoordinateArray();
+    assertEquals(coord, array[4]);
+    assertTrue(coord != array[4]);
+    assertTrue(isEqual(seq,array));
+    
+    seq = factory.create(5, 4, 1);
+    initProgression(seq);
+    assertEquals("xyzm", 4, seq.getDimension());
+    assertTrue("Z", seq.hasZ());
+    assertTrue("M", seq.hasM());
+    coord = seq.getCoordinate(4);
+    assertTrue( coord instanceof CoordinateXYZM);
+    assertEquals( 4.0, coord.getX());
+    assertEquals( 4.0, coord.getY());
+    assertEquals( 4.0, coord.getZ());
+    assertEquals( 4.0, coord.getM());
+    array = seq.toCoordinateArray();
+    assertEquals(coord, array[4]);
+    assertTrue(coord != array[4]);
+    assertTrue(isEqual(seq,array));
+    
+    try {
+      seq = factory.create(5, 2, 1);
+      fail("xm not supported");
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+  
+  private void initProgression(CoordinateSequence seq) {
+    for (int index = 0; index < seq.size(); index++) {
+       for( int ordinateIndex = 0; ordinateIndex < seq.getDimension(); ordinateIndex++) {
+         seq.setOrdinate(index, ordinateIndex, (double) index);
+       }
+    }
   }
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKBTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKBTest.java
@@ -239,7 +239,7 @@ class AverageZFilter implements CoordinateFilter
 {
   public void filter(Coordinate coord)
   {
-    coord.z = (coord.x + coord.y) / 2;
+    coord.setZ((coord.x + coord.y) / 2);
   }
 }
 

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKBTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKBTest.java
@@ -151,7 +151,7 @@ public class WKBTest
 
 	private void runWKBTestPackedCoordinate(String wkt) throws IOException, ParseException {
 		GeometryFactory geomFactory = new GeometryFactory(
-				new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.DOUBLE, 2));
+				new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.DOUBLE));
 	  WKTReader rdr = new WKTReader(geomFactory);
 		Geometry g = rdr.read(wkt);
 		

--- a/modules/core/src/test/java/org/locationtech/jts/linearref/LengthIndexedLineTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/linearref/LengthIndexedLineTest.java
@@ -164,7 +164,7 @@ public class LengthIndexedLineTest
     LengthIndexedLine indexedLine = new LengthIndexedLine(linearGeom);
     double projIndex = indexedLine.project(new Coordinate(5, 5));
     Coordinate projPt = indexedLine.extractPoint(projIndex);
-    assertTrue(Double.isNaN(projPt.z ));  
+    assertTrue(Double.isNaN(projPt.getZ() ));  
   }
   
   private void checkExtractLine(String wkt, double start, double end, String expected)

--- a/modules/core/src/test/java/test/jts/junit/MiscellaneousTest.java
+++ b/modules/core/src/test/java/test/jts/junit/MiscellaneousTest.java
@@ -445,12 +445,12 @@ public class MiscellaneousTest extends TestCase {
     Coordinate c1 = new Coordinate();
     assertTrue(! Double.isNaN(c1.x));
     assertTrue(! Double.isNaN(c1.y));
-    assertTrue(Double.isNaN(c1.z));
+    assertTrue(Double.isNaN(c1.getZ()));
 
     Coordinate c2 = new Coordinate(3,4);
     assertEquals(3,c2.x,1E-10);
     assertEquals(4,c2.y,1E-10);
-    assertTrue(Double.isNaN(c2.z));
+    assertTrue(Double.isNaN(c2.getZ()));
 
     assertEquals(c1,c1);
     assertEquals(c2,c2);

--- a/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinate.java
+++ b/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinate.java
@@ -70,7 +70,7 @@ public class ExtendedCoordinate
 
   public String toString()
   {
-    String stringRep = x + " " + y + " m=" + m;
+    String stringRep = "(" + x + "," + y + "," + getZ() + " m=" + m + ")";
     return stringRep;
   }
 }

--- a/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequence.java
+++ b/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequence.java
@@ -92,7 +92,13 @@ public class ExtendedCoordinateSequence
   {
     return 1;
   }
-
+  
+  @Override
+  public Coordinate createCoordinate()
+  {
+    return new ExtendedCoordinate();
+  }
+  
   public Coordinate getCoordinate(int i) {
     return coordinates[i];
   }
@@ -109,6 +115,8 @@ public class ExtendedCoordinateSequence
   public void getCoordinate(int index, Coordinate coord) {
     coord.x = coordinates[index].x;
     coord.y = coordinates[index].y;
+    coord.setZ( coordinates[index].getZ());
+    coord.setM( coordinates[index].getM());
   }
 
 

--- a/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequence.java
+++ b/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequence.java
@@ -128,7 +128,7 @@ public class ExtendedCoordinateSequence
     switch (ordinateIndex) {
       case CoordinateSequence.X:  return coordinates[index].x;
       case CoordinateSequence.Y:  return coordinates[index].y;
-      case CoordinateSequence.Z:  return coordinates[index].z;
+      case CoordinateSequence.Z:  return coordinates[index].getZ();
       case CoordinateSequence.M:  return coordinates[index].getM();
     }
     return Double.NaN;
@@ -147,7 +147,7 @@ public class ExtendedCoordinateSequence
         coordinates[index].y = value;
         break;
       case CoordinateSequence.Z:  
-        coordinates[index].z = value;
+        coordinates[index].setZ(value);
         break;
       case CoordinateSequence.M:  
         coordinates[index].setM(value);

--- a/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequence.java
+++ b/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequence.java
@@ -86,6 +86,12 @@ public class ExtendedCoordinateSequence
    * @see org.locationtech.jts.geom.CoordinateSequence#getDimension()
    */
   public int getDimension() { return 4; }
+  
+  @Override
+  public int getMeasures()
+  {
+    return 1;
+  }
 
   public Coordinate getCoordinate(int i) {
     return coordinates[i];

--- a/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequenceFactory.java
+++ b/modules/example/src/main/java/org/locationtech/jtsexample/geom/ExtendedCoordinateSequenceFactory.java
@@ -59,4 +59,9 @@ public class ExtendedCoordinateSequenceFactory
       return new ExtendedCoordinateSequence(size);
     }
 
+    @Override
+    public CoordinateSequence create(int size, int dimension, int measures)
+    {
+      return new ExtendedCoordinateSequence(size);
+    }
 }

--- a/modules/io/ora/src/main/java/org/locationtech/jts/io/oracle/OraWriter.java
+++ b/modules/io/ora/src/main/java/org/locationtech/jts/io/oracle/OraWriter.java
@@ -373,7 +373,7 @@ public class OraWriter
   {
     Point point = (Point) geom;
     Coordinate coord = point.getCoordinate();
-    return new double[] { coord.x, coord.y, coord.z };
+    return new double[] { coord.x, coord.y, coord.getZ() };
   }
 
   /**
@@ -670,7 +670,7 @@ public class OraWriter
 		  return outputDimension;
 	  
 	  //TODO: check dimension of a geometry CoordinateSequence to determine dimension
-  	int d = Double.isNaN(geom.getCoordinate().z) ? 2 : 3;
+  	int d = Double.isNaN(geom.getCoordinate().getZ()) ? 2 : 3;
   	return d;
   }
 

--- a/modules/tests/pom.xml
+++ b/modules/tests/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.5</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
                 <version>2.15</version>
                 <configuration>
                     <includes>
-                        <include>**/*Test.`java`</include>
+                        <include>**/*Test.java</include>
                     </includes>
                     <excludes>
                         <exclude>**/*PerfTest.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <sde-version>9.1</sde-version>
 
         <!-- maven compiler target versions -->
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <!-- PROJECT INFORMATION -->
@@ -193,7 +193,7 @@
                 <version>2.15</version>
                 <configuration>
                     <includes>
-                        <include>**/*Test.java</include>
+                        <include>**/*Test.`java`</include>
                     </includes>
                     <excludes>
                         <exclude>**/*PerfTest.java</exclude>


### PR DESCRIPTION
Checklist:

* [x] CoordinateSequence.getMeasures() default method
* [x] Update to PackedCoordinateSequence
* [x] discussion and feedback
* [x] Introduce Coordinate accessors for getX(), getY(), getZ(), getM()
* [x] Introduce explicit CoordinateXY, CoordinateXYM, CoordinateXYZM
* [x] Updated CoordinateTest to cover subclasses
* [x] Added CoordinateSequence hasZ and hasM default methods to perform common dimension and measures checks
* [x] Updated PackedCoordinateSequenceTest to try out XY, XYM, XYZ, XYZM functionality
* [x] Updated CoordinateArraySequence as well
* [x] Added CoordinateSequence.createCoordinate() default method, to assist with client use
* [x] Reworked ExtendedCoordinateSequence example

Ideally:

* [ ] proof of fitness with feedback from https://github.com/locationtech/jts/pull/291 WKT Reader/Writer enhancement