### PR TITLE
Revert use of string.format in WKTWriter

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTWriter.java
@@ -18,9 +18,21 @@ import java.io.Writer;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.EnumSet;
-import java.util.Locale;
 
-import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFilter;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.GeometryCollection;
+
 import org.locationtech.jts.util.Assert;
 
 /**
@@ -78,13 +90,13 @@ public class WKTWriter
       for (int i = 0; i < seq.size(); i++) {
         if (i > 0)
           buf.append(", ");
-        buf.append(String.format(Locale.US, "%1$G %2$G", seq.getX(i), seq.getY(i)));
+        buf.append(seq.getX(i) + " " + seq.getY(i));
       }
       buf.append(")");
     }
     return buf.toString();
   }
-  
+
   /**
    * Generates the WKT for a <tt>LINESTRING</tt>
    * specified by a {@link CoordinateSequence}.
@@ -104,7 +116,7 @@ public class WKTWriter
       for (int i = 0; i < coord.length; i++) {
         if (i > 0)
           buf.append(", ");
-        buf.append(String.format(Locale.US, "%1$G %2$G", coord[i].x, coord[i].y));
+        buf.append(coord[i].x + " " + coord[i].y);
       }
       buf.append(")");
     }

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTWriterStaticFnTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTWriterStaticFnTest.java
@@ -1,0 +1,88 @@
+package org.locationtech.jts.io;
+
+import junit.framework.TestSuite;
+import junit.textui.TestRunner;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.LineString;
+import test.jts.GeometryTestCase;
+
+import java.util.Random;
+
+public class WKTWriterStaticFnTest extends GeometryTestCase {
+
+  private Random _rnd;
+  private WKTReader _reader;
+
+  public static void main(String[] args) {
+    TestRunner.run(new TestSuite(WKTWriterStaticFnTest.class));
+  }
+
+  public WKTWriterStaticFnTest(String name) {
+    super(name);
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    _rnd = new Random(13);
+    _reader = new WKTReader();
+    _reader.setIsOldJtsCoordinateSyntaxAllowed(false);
+  }
+
+  public void testStaticToPoint() throws ParseException {
+    for (int i = 0; i < 1000; i++) {
+      Coordinate cs = new Coordinate(100 * _rnd.nextDouble(), 100 * _rnd.nextDouble());
+      String toPointText = WKTWriter.toPoint(cs);
+      Coordinate cd = _reader.read(toPointText).getCoordinate();
+      assertEquals(cs, cd);
+    }
+  }
+
+  public void testStaticToLineStringFromSequence() throws ParseException {
+    for (int i = 0; i < 1000; i++) {
+      int size = 2 + _rnd.nextInt(10);
+      CoordinateSequence cs = getCSFactory(Ordinate.createXY()).create(size, 2, 0);
+      for (int j = 0; j < cs.size(); j++) {
+        cs.setOrdinate(j, CoordinateSequence.X, 100 * _rnd.nextDouble());
+        cs.setOrdinate(j, CoordinateSequence.Y, 100 * _rnd.nextDouble());
+      }
+      String toLineStringText = WKTWriter.toLineString(cs);
+      CoordinateSequence cd = ((LineString)_reader.read(toLineStringText)).getCoordinateSequence();
+      assertEquals(cs.size(), cd.size());
+      for (int j = 0; j < cs.size(); j++) {
+        assertEquals(cs.getCoordinate(j), cd.getCoordinate(j));
+      }
+      //assertEquals(cs, cd);
+    }
+  }
+
+  public void testStaticToLineStringFromCoordinateArray() throws ParseException {
+    for (int i = 0; i < 1000; i++) {
+      int size = 2 + _rnd.nextInt(10);
+      Coordinate[] cs = new Coordinate[size];
+      for (int j = 0; j < cs.length; j++) {
+        cs[j] = new CoordinateXY(100 * _rnd.nextDouble(), 100 * _rnd.nextDouble());
+      }
+      String toLineStringText = WKTWriter.toLineString(cs);
+      Coordinate[] cd = _reader.read(toLineStringText).getCoordinates();
+
+      for (int j = 0; j < cs.length; j++) {
+        assertEquals(cs[j], cd[j]);
+      }
+    }
+  }
+
+  public void testStaticToLineStringFromTwoCoords() throws ParseException {
+    for (int i = 0; i < 1000; i++) {
+      Coordinate[] cs = new Coordinate[] {new CoordinateXY(100 * _rnd.nextDouble(), 100 * _rnd.nextDouble()),
+              new CoordinateXY(100 * _rnd.nextDouble(), 100 * _rnd.nextDouble())};
+      String toLineStringText = WKTWriter.toLineString(cs[0], cs[1]);
+      Coordinate[] cd = _reader.read(toLineStringText).getCoordinates();
+      assertEquals(2, cd.length);
+      assertEquals(cs[0], cd[0]);
+      assertEquals(cs[1], cd[1]);
+    }
+  }
+}


### PR DESCRIPTION
* Add unit test of static WKTWriter.toPoint and WKTWriter.toLineString
  functions.
* fixes #308

Signed-off-by: Felix Obermaier <felix.obermaier@netcologne.de>