### PR TITLE
Ensure valid input to DepthSegment constructor inunit test

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/DepthSegmentTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/DepthSegmentTest.java
@@ -56,7 +56,11 @@ public class DepthSegmentTest extends TestCase {
   }
 
   private SubgraphDepthLocater.DepthSegment depthSeg(double x0, double y0, double x1, double y1) {
-    return new SubgraphDepthLocater.DepthSegment(new LineSegment(x0,y0,x1,y1), 0);
+    LineSegment seg = new LineSegment(x0,y0,x1,y1);
+    // DepthSegment compareTo method assumes upward segments
+    if (seg.p0.y > seg.p1.y)
+      seg.reverse();
+    return new SubgraphDepthLocater.DepthSegment(seg, 0);  
   }
 
 }


### PR DESCRIPTION
Whilst struggling with an NTS issue related to [BufferOp](https://github.com/NetTopologySuite/NetTopologySuite/issues/260) I noticed that the input for the `DepthSegmentTest` is not valid according to the assumptions made in the DepthSegment constructor:
https://github.com/locationtech/jts/blob/8e2f394b3b55bfba64ab605ad26652482c1ceb51/modules/core/src/main/java/org/locationtech/jts/operation/buffer/SubgraphDepthLocater.java#L164-L170
