### PR TITLE
Fix inconsistency with CoordinateArraySequence using M measures

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
@@ -220,14 +220,7 @@ public class CoordinateArraySequence
    * @see org.locationtech.jts.geom.CoordinateSequence#getX(int)
    */
   public void getCoordinate(int index, Coordinate coord) {
-    coord.x = coordinates[index].x;
-    coord.y = coordinates[index].y;
-    if( hasZ()) {
-      coord.setZ(coordinates[index].getZ());
-    }
-    if( hasM() && (coord instanceof CoordinateXYM || coord instanceof CoordinateXYZM)) {
-      coord.setM(coordinates[index].getM());
-    }    
+    coord.setCoordinate(coordinates[index]);
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
@@ -13,12 +13,7 @@ package org.locationtech.jts.geom.impl;
 
 import java.io.Serializable;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.CoordinateArrays;
-import org.locationtech.jts.geom.CoordinateSequence;
-import org.locationtech.jts.geom.Coordinates;
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.*;
 
 /**
  * A {@link CoordinateSequence} backed by an array of {@link Coordinate}s.
@@ -230,7 +225,7 @@ public class CoordinateArraySequence
     if( hasZ()) {
       coord.setZ(coordinates[index].getZ());
     }
-    if( hasM()) {
+    if( hasM() && (coord instanceof CoordinateXYM || coord instanceof CoordinateXYZM)) {
       coord.setM(coordinates[index].getM());
     }    
   }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/PointLocationOn4DLineTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/PointLocationOn4DLineTest.java
@@ -1,0 +1,36 @@
+package org.locationtech.jts.algorithm;
+
+import junit.textui.TestRunner;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+import test.jts.GeometryTestCase;
+
+public class PointLocationOn4DLineTest extends GeometryTestCase {
+  public static void main(String args[]) {
+    TestRunner.run(PointLocationOn4DLineTest.class);
+  }
+
+  public PointLocationOn4DLineTest(String name) {
+    super(name);
+  }
+
+  public void testOnVertex() throws Exception {
+    checkOnLine(20, 20, "LINESTRINGZM (0 0 0 0, 20 20 20 20, 30 30 30 30)", true);
+  }
+
+  public void testOnSegment() throws Exception {
+    checkOnLine(10, 10, "LINESTRINGZM (0 0 0 0, 20 20 20 20, 0 40 40 40)", true);
+    checkOnLine(10, 30, "LINESTRINGZM (0 0 0 0, 20 20 20 20, 0 40 40 40)", true);
+  }
+
+  public void testNotOnLine() throws Exception {
+    checkOnLine(0, 100, "LINESTRINGZM (10 10 10 10, 20 10 10 10, 30 10 10 10)", false);
+  }
+
+  void checkOnLine(double x, double y, String wktLine, boolean expected) {
+    LineString line = (LineString) read(wktLine);
+    assertTrue(expected == PointLocation.isOnLine(new Coordinate(x,y), line.getCoordinates()));
+    assertTrue(expected == PointLocation.isOnLine(new Coordinate(x,y), line.getCoordinateSequence()));
+  }
+
+}


### PR DESCRIPTION
Throws exception if CoordinateArraySequence has M values and coord is just an instance of Coordinate in
CoordinateArraySequence#getCoordinate(index,coord)
This happens, for example, in PointLocation code, but this may not be the only place.
The solution in this PR is not nice (instanceof tests), but I miss a hasM() method in Coordinate class to do it more properly. Any reason why such a method has not been added with all the "measure" stuff ? 