### PR TITLE
fix read error when sdo_geometry is empty.

### DIFF
--- a/modules/io/ora/src/main/java/org/locationtech/jts/io/oracle/OraReader.java
+++ b/modules/io/ora/src/main/java/org/locationtech/jts/io/oracle/OraReader.java
@@ -191,6 +191,9 @@ public class OraReader
   Geometry read(OraGeom oraGeom) {
     int ordDim = oraGeom.ordDim();
     if (ordDim < 2) {
+        if(ordDim == 0) {
+            return null;
+        }
     	throw new IllegalArgumentException("Dimension D = " + ordDim + " is not supported by JTS. " +
     			"Either specify a valid dimension or use Oracle Locator Version 9i or later");
     }


### PR DESCRIPTION
When geometry parameter is null, OraWriter.write() will create an empty geometry(ordDim=0) to store, then OraReader.read() will throw an error, I think it should return null when it is empty.