### PR TITLE
Functionality change for ArrayCoordinateSequence with inconsistent coordinate types

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceTest.java
@@ -178,13 +178,15 @@ public class CoordinateArraySequenceTest
     Coordinate coord1 = new Coordinate(1.0,1.0,1.0);
     CoordinateXY coord2 = new CoordinateXY(2.0,2.0);
     CoordinateXYM coord3 = new CoordinateXYM(3.0,3.0,3.0);
-    Coordinate[] array = new Coordinate[] {coord1, coord2, coord3};
+    
+    Coordinate[] array = new Coordinate[] {coord1, coord2, coord3, null};
     CoordinateSequence seq = factory.create(array);
     assertEquals( 3, seq.getDimension());
     assertEquals( 1, seq.getMeasures());
     assertTrue( coord1.equals( seq.getCoordinate(0)));
     assertTrue( coord2.equals( seq.getCoordinate(1)));
     assertTrue( coord3.equals( seq.getCoordinate(2)));   
+    assertNull( seq.getCoordinate(3));   
   }
   
   private void initProgression(CoordinateSequence seq) {


### PR DESCRIPTION
Two changes made after discussion of #374 

* [x] ArrayCoordinateSequence will leave null values in place
* [x] ArrayCoordinateSequence will create a copy of the array if modification is required