### PR TITLE
degrade javadoc comment of commented out method

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -175,7 +175,7 @@ public class Polygon
     return shell.isEmpty();
   }
 
-  /**
+  /*
    * Tests if a valid polygon is simple.
    * This method always returns true, since a valid polygon is always simple
    *
@@ -185,7 +185,7 @@ public class Polygon
   public boolean isSimple() {
     return true;
   }
-*/
+  */
   
   public boolean isRectangle()
   {


### PR DESCRIPTION
So that the javadoc builder don't mistake it for the documentation of the `isRectangle` method: 

[![selection_208](https://user-images.githubusercontent.com/1927298/53328067-6f753b00-38e9-11e9-9653-a27e134b1040.png)](http://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/Polygon.html#isRectangle())
