### PR TITLE
Improve PackedCoordinateSequence and -Factory class

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
@@ -32,18 +32,20 @@ public class CoordinateXYM extends Coordinate {
   /** CoordinateXYM does not support Z values. */
   public static final int Z = -1;
 
+  /** Default value for {@link #m} / #getM() when this class is created by the default constructor */
+  static final double DEFAULT_MEASURE_VALUE = 0d;
   /**
    * Standard ordinate index value for M in XYM sequences.
    *
    * <p>This constant assumes XYM coordinate sequence definition.  Check this assumption using
-   * {@link #getDimension()} and {@link #getMeasures()} before use.
+   * {@link CoordinateSequence#getDimension()} and {@link CoordinateSequence#getMeasures()} before use.
    */
   public static final int M = 2;
 
   /** Default constructor */
   public CoordinateXYM() {
     super();
-    this.m = 0.0;
+    this.m = DEFAULT_MEASURE_VALUE;
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
@@ -24,7 +24,7 @@ public class CoordinateXYZM extends Coordinate {
   /** Default constructor */
   public CoordinateXYZM() {
     super();
-    this.m = 0.0;
+    this.m = CoordinateXYM.DEFAULT_MEASURE_VALUE;
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequence.java
@@ -390,6 +390,11 @@ public abstract class PackedCoordinateSequence
       boolean hasZM = this.hasZ() & this.hasM();
 
       int skipJ = Math.max(0, dimension - coordDimension);
+      if (skipJ > 0) {
+        if (removeZ) skipJ +=1;
+        else if (addZ && coordMeasures>0) skipJ-=1;
+      }
+
       coords = new double[coordinates.length * this.dimension];
       for (int i = 0, j = 0; i < coordinates.length; i++, j += skipJ) {
         coords[j++] = coordinates[i].x;
@@ -397,14 +402,15 @@ public abstract class PackedCoordinateSequence
         if (coordDimension == 2 || dimension == 2) continue;
         if (addZ) { // increment counter
           j++;
-        } else if (!removeZ) { // don't skip if z is to be preserved
+        }
+        if (!removeZ) { // don't skip if z is to be preserved
           coords[j++] = coordinates[i].getOrdinate(2); // Z or M
         }
         if (coordDimension == 3 || j%dimension == 0) continue;
         coords[j++] = coordinates[i].getOrdinate(3); // M
       }
 
-      if (!hasZ)
+      if (addZ)
         initializeZValues();
     }
     /**
@@ -457,7 +463,7 @@ public abstract class PackedCoordinateSequence
     public Coordinate getCoordinateInternal(int i) {
       double x = coords[i * dimension];
       double y = coords[i * dimension + 1];
-      if (dimension == 2/* && measures == 0*/) {
+      if (dimension == 2) {
         return new CoordinateXY(x, y);
       } else if (dimension == 3 && measures == 0) {
         double z = coords[i * dimension + 2];
@@ -631,6 +637,11 @@ public abstract class PackedCoordinateSequence
       boolean removeZ = hasZ & !this.hasZ();
 
       int skipJ = Math.max(0, dimension - coordDimension);
+      if (skipJ > 0) {
+        if (removeZ) skipJ +=1;
+        else if (addZ && coordMeasures>0) skipJ-=1;
+      }
+
       coords = new float[coordinates.length * this.dimension];
       for (int i = 0, j = 0; i < coordinates.length; i++, j += skipJ) {
         coords[j++] = (float)coordinates[i].x;
@@ -638,14 +649,15 @@ public abstract class PackedCoordinateSequence
         if (coordDimension == 2 || dimension == 2) continue;
         if (addZ) { // increment counter
           j++;
-        } else if (!removeZ) { // don't skip if z is to be preserved
+        }
+        if (!removeZ) { // don't skip if z is to be preserved
           coords[j++] = (float)coordinates[i].getOrdinate(2); // Z or M
         }
         if (coordDimension == 3 || j%dimension == 0) continue;
         coords[j++] = (float)coordinates[i].getOrdinate(3); // M
       }
 
-      if (!hasZ)
+      if (addZ)
         initializeZValues();
     }
 
@@ -690,7 +702,7 @@ public abstract class PackedCoordinateSequence
     public Coordinate getCoordinateInternal(int i) {
       double x = coords[i * dimension];
       double y = coords[i * dimension + 1];
-      if (dimension == 2 && measures == 0) {
+      if (dimension == 2) {
         return new CoordinateXY(x, y);
       } else if (dimension == 3 && measures == 0) {
         double z = coords[i * dimension + 2];

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFactory.java
@@ -51,11 +51,17 @@ public class PackedCoordinateSequenceFactory implements
   public static final PackedCoordinateSequenceFactory FLOAT_FACTORY =
       new PackedCoordinateSequenceFactory(FLOAT);
 
-  private static final int DEFAULT_MEASURES = 0;
+  /**
+   *@Deprecated Use {@link PackedCoordinateSequence#DEFAULT_MEASURES}!
+   */
+  private static final int DEFAULT_MEASURES = PackedCoordinateSequence.DEFAULT_MEASURES;
 
-  private static final int DEFAULT_DIMENSION = 3;
+  /**
+   *@Deprecated Use {@link PackedCoordinateSequence#DEFAULT_DIMENSION}!
+   */
+  private static final int DEFAULT_DIMENSION = PackedCoordinateSequence.DEFAULT_DIMENSION;
 
-  private int type = DOUBLE;
+  private final int type;
 
   /**
    * Creates a new PackedCoordinateSequenceFactory
@@ -72,7 +78,11 @@ public class PackedCoordinateSequenceFactory implements
    * {@linkplain PackedCoordinateSequenceFactory#FLOAT}or
    * {@linkplain PackedCoordinateSequenceFactory#DOUBLE}
    */
-  public PackedCoordinateSequenceFactory(int type){
+  public PackedCoordinateSequenceFactory(int type)
+  {
+    if (!(type == DOUBLE || type == FLOAT))
+      throw new IllegalArgumentException("Unknown subtype of PackedCoordinateSequenceFactory: " + type);
+
     this.type = type;
   }
 
@@ -91,8 +101,8 @@ public class PackedCoordinateSequenceFactory implements
    * @see CoordinateSequenceFactory#create(Coordinate[])
    */
   public CoordinateSequence create(Coordinate[] coordinates) {
-    int dimension = DEFAULT_DIMENSION;
-    int measures = DEFAULT_MEASURES;
+    int dimension = PackedCoordinateSequence.DEFAULT_DIMENSION;
+    int measures = PackedCoordinateSequence.DEFAULT_MEASURES;
     if (coordinates != null && coordinates.length > 0 && coordinates[0] != null) {
       Coordinate first = coordinates[0];
       dimension = Coordinates.dimension(first);
@@ -109,12 +119,10 @@ public class PackedCoordinateSequenceFactory implements
    * @see CoordinateSequenceFactory#create(CoordinateSequence)
    */
   public CoordinateSequence create(CoordinateSequence coordSeq) {
-    int dimension = coordSeq.getDimension();
-    int measures = coordSeq.getMeasures();
     if (type == DOUBLE) {
-      return new PackedCoordinateSequence.Double(coordSeq.toCoordinateArray(), dimension, measures);
+      return new PackedCoordinateSequence.Double(coordSeq);
     } else {
-      return new PackedCoordinateSequence.Float(coordSeq.toCoordinateArray(), dimension, measures);
+      return new PackedCoordinateSequence.Float(coordSeq);
     }
   }
 

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateArraySequenceTest.java
@@ -20,6 +20,7 @@ import org.locationtech.jts.geom.CoordinateXYM;
 import org.locationtech.jts.geom.CoordinateXYZM;
 
 import junit.textui.TestRunner;
+import org.locationtech.jts.io.Ordinate;
 
 /**
  * Test {@link CoordinateArraySequence}
@@ -42,7 +43,55 @@ public class CoordinateArraySequenceTest
   CoordinateArraySequenceFactory getCSFactory() {
     return CoordinateArraySequenceFactory.instance();
   }
-  
+
+  @Override
+  int getDefaultDimension() { return 3; }
+
+  @Override
+  int getFactoryMaxDimension() { return 4; }
+
+  @Override
+  protected void doTestIllegalArgumentsOnSpecific() {
+    try {
+      getCSFactory().create(0, 2, 1);
+      // ToDo:
+      //   Evaluate: javadoc on CoordinateSequenceFactory.create
+      //   functions state that the they "should not fail" and
+      //   instead should return some sort of sequence.
+      // fail();
+    } catch (IllegalArgumentException e) { }
+  }
+
+  @Override
+  public void testConstructorDirect() {
+
+    CoordinateSequence seq = new CoordinateArraySequence(5);
+    assertNotNull(seq);
+    assertEquals(5, seq.size());
+    assertEquals(getDefaultDimension(), seq.getDimension());
+
+  }
+
+  public void testSetMeasureThrows() {
+    CoordinateSequence seq = new CoordinateArraySequence(1);
+    try {
+      seq.setOrdinate(0, CoordinateSequence.M, 0d);
+      fail();
+    }
+    catch (IllegalArgumentException e) {
+    }
+  }
+
+  @Override
+  public void testFactoryCreateWithSize0AndMaxDimension() {
+    // ToDo:
+    //  Fails because CoordinateArraySequence.create(size, dimension)
+    //  only allows a dimension value of 4 when at least a measure value
+    //  is specified.
+    //super.testFactoryCreateWithSize0AndMaxDimension();
+  }
+
+  @Override
   public void testFactoryLimits() {
     // Expected to clip dimension and measure value within factory limits
     
@@ -84,8 +133,6 @@ public class CoordinateArraySequenceTest
     assertTrue(!sequence.hasZ());
     assertTrue(sequence.hasM());
   }
-  
-  
   
   public void testDimensionAndMeasure()
   {
@@ -195,5 +242,23 @@ public class CoordinateArraySequenceTest
          seq.setOrdinate(index, ordinateIndex, (double) index);
        }
     }
+  }
+
+  @Override
+  boolean isSame(CoordinateSequence seq1, CoordinateSequence seq2) {
+
+    if (seq1 == seq2)
+      return true;
+    if (seq1.toCoordinateArray() == seq2.toCoordinateArray())
+      return true;
+
+    if (seq1.size() == seq2.size()) {
+      for (int i = 0; i < seq1.size(); i++) {
+        if (seq1.getCoordinate(i) != seq2.getCoordinate(i))
+          return false;
+      }
+      return true;
+    }
+    return false;
   }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/CoordinateSequenceTestBase.java
@@ -17,13 +17,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.EnumSet;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.CoordinateSequence;
-import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.*;
 
 import junit.framework.TestCase;
 import junit.textui.TestRunner;
+import org.locationtech.jts.io.Ordinate;
+import org.locationtech.jts.util.Assert;
 
 
 /**
@@ -43,15 +44,227 @@ public abstract class CoordinateSequenceTestBase
 
   public CoordinateSequenceTestBase(String name) { super(name); }
 
+  /**
+   * Gets the {@link CoordinateSequenceFactory} to use for the tests
+   *
+   * @return A factory to create {@link CoordinateSequence}s.
+   */
   abstract CoordinateSequenceFactory getCSFactory();
-  
+
+  /**
+   * Gets the default dimension for {@link CoordinateSequence}s created with {@link #getCSFactory()}.
+   *
+   * @return A number of dimensions
+   */
+  abstract int getDefaultDimension();
+
+  /**
+   * Gets the maximum possible dimension for {@link CoordinateSequence}s created with {@link #getCSFactory()}.
+   *
+   * @return A number of dimensions
+   */
+  abstract int getFactoryMaxDimension();
+
+
+
+  public void testConstructorDirect() {
+    assertTrue(true);
+  }
+
+  public void testFactoryCreateWithNullCoordinateArray() {
+
+    CoordinateSequenceFactory factory = getCSFactory();
+    CoordinateSequence seq = factory.create((Coordinate[]) null);
+    assertNotNull(seq);
+    assertEquals(0, seq.size());
+    assertEquals(getDefaultDimension(), seq.getDimension());
+    assertEquals("()", seq.toString());
+  }
+
+  public void testFactoryCreateWithNullCoordinateSequence() {
+
+    CoordinateSequenceFactory factory = getCSFactory();
+    CoordinateSequence seq = factory.create((CoordinateSequence) null);
+    assertNotNull(seq);
+    assertEquals(0, seq.size());
+    assertEquals(getDefaultDimension(), seq.getDimension());
+    assertEquals("()", seq.toString());
+  }
+
+  public void testFactoryCreateWithSize0AndMaxDimension() {
+
+    CoordinateSequenceFactory factory = getCSFactory();
+    CoordinateSequence seq = factory.create(0, getFactoryMaxDimension());
+    assertNotNull(seq);
+    assertEquals(0, seq.size());
+    assertEquals(getFactoryMaxDimension(), seq.getDimension());
+    assertEquals("()", seq.toString());
+  }
+
+  public void testFactoryCreateWithSizeAndDimension() {
+
+    CoordinateSequenceFactory factory = getCSFactory();
+    CoordinateSequence seq = factory.create(5, 2);
+    assertNotNull(seq);
+    assertTrue(seq.getCoordinate(0) instanceof CoordinateXY);
+    assertEquals(5, seq.size());
+    assertEquals(2, seq.getDimension());
+    assertEquals(0, seq.getMeasures());
+    assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.X));
+    assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.Y));
+    if (seq instanceof CoordinateArraySequence) {
+      assertTrue(Double.isNaN(seq.getZ(0)));
+      assertTrue(Double.isNaN(seq.getM(0)));
+    }
+
+    seq = factory.create(5, 3);
+    assertNotNull(seq);
+    //assertTrue(seq.getCoordinate(0) instanceof Coordinate);
+    assertNotNull(seq.getCoordinate(0));
+    assertTrue(!(seq.getCoordinate(0) instanceof CoordinateXY));
+    assertTrue(!(seq.getCoordinate(0) instanceof CoordinateXYM));
+    assertTrue(!(seq.getCoordinate(0) instanceof CoordinateXYZM));
+    assertEquals(5, seq.size());
+    assertEquals(3, seq.getDimension());
+    assertEquals(0, seq.getMeasures());
+    assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.X));
+    assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.Y));
+    assertTrue(Double.isNaN(seq.getOrdinate(0, CoordinateSequence.Z)));
+    if (seq instanceof CoordinateArraySequence) {
+      assertTrue(Double.isNaN(seq.getM(0)));
+    }
+
+    seq = factory.create(5, 4);
+    if (seq.getDimension() == 4) {
+      assertNotNull(seq);
+      assertEquals(5, seq.size());
+      assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.X));
+      assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.Y));
+      assertTrue(Double.isNaN(seq.getZ(0)));
+      assertTrue(Double.isNaN(seq.getOrdinate(0, CoordinateSequence.Z)));
+      if (seq.hasM())
+        assertEquals(0d, seq.getM(0));
+      assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.M));
+    }
+
+    seq = factory.create(5, 4, 1);
+    if (seq.getDimension() == 4) {
+      assertNotNull(seq);
+      assertEquals(5, seq.size());
+      assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.X));
+      assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.Y));
+      assertTrue(Double.isNaN(seq.getZ(0)));
+      assertTrue(Double.isNaN(seq.getOrdinate(0, CoordinateSequence.Z)));
+      if (seq.hasM())
+        assertEquals(0d, seq.getM(0));
+      assertEquals(0d, seq.getOrdinate(0, CoordinateSequence.M));
+    }
+  }
+
+  public void testFactoryCreateWithSequence() {
+
+    CoordinateSequenceFactory factory = getCSFactory();
+    CoordinateSequence seqTest = createSequence(factory, 5);
+    CoordinateSequence seq = factory.create(seqTest);
+
+    assertNotNull(seq);
+    assertEquals(5, seq.size());
+    assertTrue(isEqual(seqTest, seq));
+  }
+
+  public void testFactoryCreateWithCoordinateArray()
+  {
+    Coordinate[] coords;
+    CoordinateSequence seq;
+
+    coords = createArray(SIZE, Ordinate.createXY());
+    seq = getCSFactory().create(coords);
+    assertTrue(isEqual(seq, coords));
+
+    coords = createArray(SIZE);
+    seq = getCSFactory().create(coords);
+    assertTrue(isEqual(seq, coords));
+
+    coords = createArray(SIZE, Ordinate.createXYM());
+    seq = getCSFactory().create(coords);
+    assertTrue(isEqual(seq, coords));
+
+    coords = createArray(SIZE, Ordinate.createXYZM());
+    seq = getCSFactory().create(coords);
+    assertTrue(isEqual(seq, coords));
+
+  }
+
+  public void testFactoryCreateWithCoordinateArrayAddingDimension()
+  {
+    Assert.isTrue(true);
+  }
+
+  public void testFactoryCreateWithCoordinateSequence()
+  {
+    doTestCreateByInitSequence(createSequence(getCSFactory(), 100, Ordinate.createXY()));
+    doTestCreateByInitSequence(createSequence(getCSFactory(), 100));
+    doTestCreateByInitSequence(createSequence(getCSFactory(), 100, Ordinate.createXYM()));
+    doTestCreateByInitSequence(createSequence(getCSFactory(), 100, Ordinate.createXYZM()));
+  }
+
+  public void testFactoryCreateExtensions() {
+    assertTrue(true);
+  }
+
   public void testZeroLength()
   {
-    CoordinateSequence seq = getCSFactory().create(0, 3);
-    assertTrue(seq.size() == 0);
+    CoordinateSequenceFactory factory = getCSFactory();
+    CoordinateSequence seq;
 
-    CoordinateSequence seq2 = getCSFactory().create((Coordinate[]) null);
-    assertTrue(seq2.size() == 0);
+    seq = factory.create(0, 3);
+    assertNotNull(seq);
+    assertEquals(0, seq.size());
+    assertEquals(3, seq.getDimension());
+    assertEquals(0, seq.getMeasures());
+
+    seq = factory.create(0, 3, 1);
+    assertNotNull(seq);
+    assertEquals(0, seq.size());
+    assertEquals(3, seq.getDimension());
+    assertEquals(1, seq.getMeasures());
+
+    seq = factory.create((Coordinate[]) null);
+    assertNotNull(seq);
+    assertEquals(0, seq.size());
+    assertEquals(3, seq.getDimension());
+    assertEquals(0, seq.getMeasures());
+
+    seq = factory.create((CoordinateSequence) null);
+    assertNotNull(seq);
+    assertEquals(0, seq.size());
+    assertEquals(3, seq.getDimension());
+    assertEquals(0, seq.getMeasures());
+  }
+
+  public void testIllegalArguments()
+  {
+    try {
+      getCSFactory().create(-3, 3);
+      fail("negative sequence size does not throw IllegalArgumentException");
+    }
+    catch (IllegalArgumentException ignored) { }
+    catch (NegativeArraySizeException e) {
+      // sub-optimal?
+      System.out.println("NegativeArraySizeException thrown (instead of IllegalArgumentException)");
+    }
+
+    // continue with specific tests
+    doTestIllegalArgumentsOnSpecific();
+  }
+
+  protected void doTestIllegalArgumentsOnSpecific() {
+    assertTrue(true);
+  }
+
+  public void testFactoryLimits()
+  {
+    assertTrue(true);
   }
 
   public void testCreateBySizeAndModify()
@@ -91,6 +304,15 @@ public abstract class CoordinateSequenceTestBase
     assertTrue(isEqual(seq, coords));
   }
 
+  private void doTestCreateByInitSequence(CoordinateSequence sequence)
+  {
+    if (sequence == null)
+      return;
+
+    CoordinateSequence seq = getCSFactory().create(sequence);
+    assertTrue(isEqual(sequence, seq));
+  }
+
   public void testCreateByInitAndCopy()
   {
     Coordinate[] coords = createArray(SIZE);
@@ -98,6 +320,31 @@ public abstract class CoordinateSequenceTestBase
     CoordinateSequence seq2 = getCSFactory().create(seq);
     assertTrue(isEqual(seq2, coords));
   }
+
+  public void testCreateByInitAndCopySequence()
+  {
+    doTestCreateByInitAndCopySequence(createSequence(getCSFactory(), 100, Ordinate.createXY()));
+    doTestCreateByInitAndCopySequence(createSequence(getCSFactory(), 100));
+    doTestCreateByInitAndCopySequence(createSequence(getCSFactory(), 100, Ordinate.createXYM()));
+    doTestCreateByInitAndCopySequence(createSequence(getCSFactory(), 100, Ordinate.createXYZM()));
+  }
+
+  private void doTestCreateByInitAndCopySequence(CoordinateSequence sequence) {
+    if (sequence == null)
+      return;
+
+    CoordinateSequenceFactory factory = getCSFactory();
+    CoordinateSequence seq1 = factory.create(sequence);
+    CoordinateSequence seq2 = factory.create(seq1);
+    assertTrue(isNotSameButEqual(seq2, sequence));
+  }
+
+  public void testToCoordinateArray() {
+    CoordinateSequence seq = createSequence(getCSFactory(), 5, Ordinate.createXY());
+    Coordinate[] coords = seq.toCoordinateArray();
+    assertTrue(isEqual(seq, coords));
+  }
+
 
   public void testSerializable() throws IOException, ClassNotFoundException {
     Coordinate[] coords = createArray(SIZE);
@@ -108,7 +355,37 @@ public abstract class CoordinateSequenceTestBase
     CoordinateSequence seq2 = deserialize(data);
     assertTrue(isEqual(seq2, coords));
   }
-  
+
+  public void testZOrdinateIsNaN() {
+    CoordinateSequence cs = getCSFactory().create(1, 3);
+    assertTrue(Double.isNaN(cs.getOrdinate(0, CoordinateSequence.Z)));
+  }
+
+  public void testCopy()
+  {
+    CoordinateSequence csOrig = getCSFactory().create(9, 3);
+    CoordinateSequence csCopy = csOrig.copy();
+    assertTrue(isNotSameButEqual(csOrig, csCopy));
+  }
+
+  /** @deprecated */
+  public void testClone() {
+    CoordinateSequence csOrig = getCSFactory().create(9, 3);
+    CoordinateSequence csClone = (CoordinateSequence) csOrig.clone();
+    assertTrue(isNotSameButEqual(csOrig, csClone));
+  }
+
+  public void testExpandEnvelope() {
+    CoordinateSequence cs = createSequence(getCSFactory(), 0);
+    Envelope e = new Envelope();
+    cs.expandEnvelope(e);
+    assertTrue(e.isNull());
+
+    cs = createSequence(getCSFactory(), 5);
+    cs.expandEnvelope(e = new Envelope());
+    assertEquals(new Envelope(11, 51, 12, 52), e);
+  }
+
   private static byte[] serialize(CoordinateSequence seq) throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     ObjectOutputStream oos = new ObjectOutputStream(bos);
@@ -124,16 +401,30 @@ public abstract class CoordinateSequenceTestBase
     return (CoordinateSequence) o;
   }
 
-  Coordinate[] createArray(int size)
+  static Coordinate[] createArray(int size)
+  {
+    return createArray(size, Ordinate.createXYZ());
+  }
+  static Coordinate[] createArray(int size, EnumSet<Ordinate> ordinates)
   {
     Coordinate[] coords = new Coordinate[size];
+    // Note: EnumSet sucks!
     for (int i = 0; i < size; i++) {
-      double base = 2 * 1;
-      coords[i] = new Coordinate(base, base + 1, base + 2);
+      double base = i * 10;
+      if (ordinates.contains(Ordinate.Z) && ordinates.contains(Ordinate.M))
+        coords[i] = new CoordinateXYZM(base, base + 1, base + 2, base + 3);
+      else if (ordinates.contains(Ordinate.Z))
+        coords[i] = new Coordinate(base, base + 1, base + 2);
+      else if (ordinates.contains(Ordinate.M))
+        coords[i] = new CoordinateXYM(base, base + 1, base + 3);
+      else
+        coords[i] = new CoordinateXY(base, base + 1);
     }
     return coords;
   }
 
+  // not used
+  /*
   boolean isAllCoordsEqual(CoordinateSequence seq, Coordinate coord)
   {
     for (int i = 0; i < seq.size(); i++) {
@@ -156,14 +447,16 @@ public abstract class CoordinateSequenceTestBase
     }
     return true;
   }
+   */
 
   /**
    * Tests for equality using all supported accessors,
    * to provides test coverage for them.
-   * 
-   * @param seq
-   * @param coords
-   * @return
+   *
+   * @param seq    a sequence
+   * @param coords an array of coordinates
+   * @return <code>true</code> if the ordinate values in the sequence match those in the
+   * coordinate array.
    */
   boolean isEqual(CoordinateSequence seq, Coordinate[] coords)
   {
@@ -207,8 +500,149 @@ public abstract class CoordinateSequenceTestBase
     }
     return true;
   }
-  boolean isEqual( double expected, double actual) {
-    return expected == actual || (Double.isNaN(expected)&&Double.isNaN(actual));
+
+  /**
+   * Tests for equality using all supported accessors,
+   * to provides test coverage for them. The type of
+   * the {@link CoordinateSequence}s may differ.
+   *
+   * @param seq1  the first sequence
+   * @param seq2  the second sequence
+   * @return {@code true} if both sequences are equal in size, dimension and contents.
+   */
+  protected boolean isEqual(CoordinateSequence seq1, CoordinateSequence seq2) {
+    return isEqual(seq1, seq2, 0d);
   }
+
+  protected boolean isEqual(CoordinateSequence seq1, CoordinateSequence seq2, double tolerance)
+  {
+    if (seq1.size() != seq2.size()) return false;
+    if (seq1.getDimension() != seq2.getDimension()) return false;
+
+    for (int i = 0; i < seq1.size(); i++) {
+      // Ordinate indexed getters
+      for (int j = 0; j < seq1.getDimension(); j++) {
+        double o1 = seq1.getOrdinate(i, j);
+        double o2 = seq2.getOrdinate(i, j);
+        if (Double.isNaN(o1)) {
+          if (!Double.isNaN(o2)) return false;
+        } else if (Math.abs(o1 - o2) > tolerance)
+          return false;
+      }
+
+      if (tolerance > 0d) continue;
+
+      // Ordinate named getters
+      if (seq1.getX(i) != seq2.getX(i))  return false;
+      if (seq1.getY(i) != seq2.getY(i))  return false;
+
+      // Get Coordinate
+      if (!seq1.getCoordinate(i).equals3D(seq2.getCoordinate(i)))
+        return false;
+
+      // Get Coordinate copy
+      Coordinate cc1 = seq1.getCoordinateCopy(i);
+      Coordinate cc2 = seq2.getCoordinateCopy(i);
+      if (areCoordinatesDifferent(cc1, cc2, tolerance)) return false;
+
+      // Get Coordinate as out argument
+      cc1 = seq1.createCoordinate(); seq1.getCoordinate(i, cc1);
+      cc2 = seq1.createCoordinate(); seq2.getCoordinate(i, cc2);
+      if (areCoordinatesDifferent(cc1, cc2, tolerance)) return false;
+    }
+
+    return true;
+  }
+
+  private static boolean areCoordinatesDifferent(Coordinate cc1, Coordinate cc2, double tolerance) {
+
+    if (cc1 == null && cc2 == null) return false;
+    if (cc1 == null) return true;
+    if (cc2 == null) return true;
+    if (cc1.getClass() != cc2.getClass()) return true;
+
+    if (cc1 instanceof CoordinateXYM && cc2 instanceof  CoordinateXYM) {
+      if (areOrdinateValuesDifferent(cc1.getM(), cc2.getM(), tolerance))
+        return true;
+    }
+
+    if (cc1 instanceof CoordinateXYZM && !(cc2 instanceof  CoordinateXY)) {
+      if (areOrdinateValuesDifferent(cc1.getZ(), cc2.getZ(), tolerance))
+        return true;
+    }
+
+    if (areOrdinateValuesDifferent(cc1.x, cc2.x, tolerance))
+      return true;
+
+    return areOrdinateValuesDifferent(cc1.y, cc2.y, tolerance);
+
+  }
+
+  private static boolean areOrdinateValuesDifferent(double o1, double o2, double tolerance) {
+    if (java.lang.Double.isNaN(o1) ^ java.lang.Double.isNaN(o2))
+      return true;
+
+    if (java.lang.Double.isNaN(o1))
+      return false;
+
+    return !(Math.abs(o1 - o2) <= tolerance);
+  }
+
+  boolean isNotSameButEqual(CoordinateSequence seq1, CoordinateSequence seq2) {
+    if (isSame(seq1, seq2))
+      return false;
+    return isEqual(seq1,seq2);
+  }
+
+  abstract boolean isSame(CoordinateSequence seq1, CoordinateSequence seq2);
+
+  static boolean isEqual(double expected, double actual) {
+    return expected == actual || (Double.isNaN(expected) && Double.isNaN(actual));
+  }
+
+  private static CoordinateSequence createSequence(CoordinateSequenceFactory factory, int size) {
+    return createSequence(factory,size, EnumSet.of(Ordinate.X, Ordinate.Y, Ordinate.Z));
+  }
+
+  static CoordinateSequence createSequence(CoordinateSequenceFactory factory, int size,
+                                           EnumSet<Ordinate> ordinates)
+  {
+    if (size > 100)
+      throw new IllegalArgumentException("size *must not* be greater than 100");
+
+    // We always have x- and y-ordinates
+    int dimension = 2;
+    int measures = 0;
+    if (ordinates.contains(Ordinate.Z)) dimension++;
+    if (ordinates.contains(Ordinate.M)) { dimension++; measures++; }
+
+    CoordinateSequence seq = null;
+    try {
+      seq = factory.create(size, dimension, measures);
+      for (int i = 0; i < size; i++)
+      {
+        for (int j = 0; j < dimension; j++) {
+          seq.setOrdinate(i, j, (i + 1) * 10 + j + 1);
+        }
+      }
+    }
+    catch (Throwable ex)
+    {
+      System.out.println("Failed to create sequence " +
+              "of size " + size + " and ordinate flag " + ordinateFlagString(ordinates) + " " +
+              "using '" + factory.getClass().getSimpleName() + "'!");
+    }
+    return seq;
+  }
+
+  private static String ordinateFlagString(EnumSet<Ordinate> ordinateFlag) {
+
+    StringBuilder sb = new StringBuilder("XY");
+    if (ordinateFlag.contains(Ordinate.Z)) sb.append('Z');
+    if (ordinateFlag.contains(Ordinate.M)) sb.append('M');
+
+    return sb.toString();
+  }
+
 }
 

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceDoubleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceDoubleTest.java
@@ -83,7 +83,7 @@ public class PackedCoordinateSequenceDoubleTest
 
     // Add additional dimensions
     Coordinate[] coords = createArray(5, Ordinate.createXY());
-    CoordinateSequence seq = new PackedCoordinateSequence.Double(coords, 5, 2);
+    CoordinateSequence seq = new PackedCoordinateSequence.Float(coords, 5, 2);
 
     assertNotNull(seq);
     assertTrue(seq.size() == 5);
@@ -97,7 +97,7 @@ public class PackedCoordinateSequenceDoubleTest
 
     // remove m-dimension
     coords = createArray(5, Ordinate.createXYZM());
-    seq = new PackedCoordinateSequence.Double(coords, 3, 0);
+    seq = new PackedCoordinateSequence.Float(coords, 3, 0);
 
     assertNotNull(seq);
     assertTrue(seq.size() == 5);
@@ -108,7 +108,7 @@ public class PackedCoordinateSequenceDoubleTest
 
     // remove z-dimension
     coords = createArray(5, Ordinate.createXYZM());
-    seq = new PackedCoordinateSequence.Double(coords, 3, 1);
+    seq = new PackedCoordinateSequence.Float(coords, 3, 1);
 
     assertNotNull(seq);
     assertTrue(seq.size() == 5);
@@ -116,6 +116,33 @@ public class PackedCoordinateSequenceDoubleTest
     assertTrue(seq.getMeasures() == 1);
 
     assertEquals(coords[2].getM(), seq.getM(2));
+
+    // remove z-dimension, add measures
+    coords = createArray(5, Ordinate.createXYZM());
+    seq = new PackedCoordinateSequence.Float(coords, 5, 3);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 5);
+    assertTrue(seq.getMeasures() == 3);
+
+    assertEquals(coords[2].getM(), seq.getM(2));
+
+    // add z-dimension, and additional measures
+    double initZ = PackedCoordinateSequence.getInitialZValue();
+    PackedCoordinateSequence.setInitialZValue(Coordinate.NULL_ORDINATE);
+
+    coords = createArray(5, Ordinate.createXYM());
+    seq = new PackedCoordinateSequence.Float(coords, 6, 3);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 6);
+    assertTrue(seq.getMeasures() == 3);
+
+    assertEquals(coords[2].getZ(), seq.getZ(2));
+    assertEquals(coords[2].getM(), seq.getM(2));
+    PackedCoordinateSequence.setInitialZValue(initZ);
   }
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceDoubleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceDoubleTest.java
@@ -12,9 +12,12 @@
 
 package org.locationtech.jts.geom.impl;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
 
 import junit.textui.TestRunner;
+import org.locationtech.jts.io.Ordinate;
 
 /**
  * Test {@link PackedCoordinateSequence.Double}
@@ -36,6 +39,83 @@ public class PackedCoordinateSequenceDoubleTest
   @Override
   CoordinateSequenceFactory getCSFactory() {
     return PackedCoordinateSequenceFactory.DOUBLE_FACTORY;
+  }
+
+  @Override
+  int getDefaultDimension() { return PackedCoordinateSequence.DEFAULT_DIMENSION; }
+
+  @Override
+  int getFactoryMaxDimension() { return Integer.MAX_VALUE; }
+
+  @Override
+  boolean isSame(CoordinateSequence seq1, CoordinateSequence seq2) {
+
+    if (seq1 == seq2)
+      return true;
+
+
+    if (((PackedCoordinateSequence.Double)seq1).getRawCoordinates() ==
+            ((PackedCoordinateSequence.Double)seq2).getRawCoordinates())
+      return true;
+
+    return false;
+  }
+
+  @Override
+  public void testZOrdinateIsNaN() {
+    double initalZ = PackedCoordinateSequence.getInitialZValue();
+    PackedCoordinateSequence.setInitialZValue(Coordinate.NULL_ORDINATE);
+    super.testZOrdinateIsNaN();
+    PackedCoordinateSequence.setInitialZValue(initalZ);
+  }
+
+  @Override
+  public void testFactoryCreateWithSizeAndDimension() {
+    double initialZ = PackedCoordinateSequence.getInitialZValue();
+    PackedCoordinateSequence.setInitialZValue(Coordinate.NULL_ORDINATE);
+    super.testFactoryCreateWithSizeAndDimension();
+    PackedCoordinateSequence.setInitialZValue(initialZ);
+  }
+
+  @Override
+  public void testConstructorDirect() {
+
+
+    // Add additional dimensions
+    Coordinate[] coords = createArray(5, Ordinate.createXY());
+    CoordinateSequence seq = new PackedCoordinateSequence.Double(coords, 5, 2);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 5);
+    assertTrue(seq.getMeasures() == 2);
+
+    if (Double.isNaN(PackedCoordinateSequence.getInitialZValue()))
+      assertTrue(Double.isNaN(seq.getZ(2)));
+    else
+      assertEquals(0d, seq.getZ(2));
+
+    // remove m-dimension
+    coords = createArray(5, Ordinate.createXYZM());
+    seq = new PackedCoordinateSequence.Double(coords, 3, 0);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 3);
+    assertTrue(seq.getMeasures() == 0);
+
+    assertEquals(coords[2].getZ(), seq.getZ(2));
+
+    // remove z-dimension
+    coords = createArray(5, Ordinate.createXYZM());
+    seq = new PackedCoordinateSequence.Double(coords, 3, 1);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 3);
+    assertTrue(seq.getMeasures() == 1);
+
+    assertEquals(coords[2].getM(), seq.getM(2));
   }
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFloatTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFloatTest.java
@@ -12,9 +12,12 @@
 
 package org.locationtech.jts.geom.impl;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
 
 import junit.textui.TestRunner;
+import org.locationtech.jts.io.Ordinate;
 
 /**
  * Test {@link PackedCoordinateSequence.Float}
@@ -37,6 +40,83 @@ public class PackedCoordinateSequenceFloatTest
   @Override
   CoordinateSequenceFactory getCSFactory() {
     return PackedCoordinateSequenceFactory.FLOAT_FACTORY;
+  }
+
+  @Override
+  int getDefaultDimension() { return PackedCoordinateSequence.DEFAULT_DIMENSION; }
+
+  @Override
+  int getFactoryMaxDimension() { return Integer.MAX_VALUE; }
+
+  @Override
+  boolean isSame(CoordinateSequence seq1, CoordinateSequence seq2) {
+
+    if (seq1 == seq2)
+      return true;
+
+
+    if (((PackedCoordinateSequence.Float)seq1).getRawCoordinates() ==
+            ((PackedCoordinateSequence.Float)seq2).getRawCoordinates())
+      return true;
+
+    return false;
+  }
+
+  @Override
+  public void testZOrdinateIsNaN() {
+    double initalZ = PackedCoordinateSequence.getInitialZValue();
+    PackedCoordinateSequence.setInitialZValue(Coordinate.NULL_ORDINATE);
+    super.testZOrdinateIsNaN();
+    PackedCoordinateSequence.setInitialZValue(initalZ);
+  }
+
+  @Override
+  public void testFactoryCreateWithSizeAndDimension() {
+    double initialZ = PackedCoordinateSequence.getInitialZValue();
+    PackedCoordinateSequence.setInitialZValue(Coordinate.NULL_ORDINATE);
+    super.testFactoryCreateWithSizeAndDimension();
+    PackedCoordinateSequence.setInitialZValue(initialZ);
+  }
+
+  @Override
+  public void testConstructorDirect() {
+
+
+    // Add additional dimensions
+    Coordinate[] coords = createArray(5, Ordinate.createXY());
+    CoordinateSequence seq = new PackedCoordinateSequence.Float(coords, 5, 2);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 5);
+    assertTrue(seq.getMeasures() == 2);
+
+    if (Double.isNaN(PackedCoordinateSequence.getInitialZValue()))
+      assertTrue(Double.isNaN(seq.getZ(2)));
+    else
+      assertEquals(0d, seq.getZ(2));
+
+    // remove m-dimension
+    coords = createArray(5, Ordinate.createXYZM());
+    seq = new PackedCoordinateSequence.Float(coords, 3, 0);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 3);
+    assertTrue(seq.getMeasures() == 0);
+
+    assertEquals(coords[2].getZ(), seq.getZ(2));
+
+    // remove z-dimension
+    coords = createArray(5, Ordinate.createXYZM());
+    seq = new PackedCoordinateSequence.Float(coords, 3, 1);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 3);
+    assertTrue(seq.getMeasures() == 1);
+
+    assertEquals(coords[2].getM(), seq.getM(2));
   }
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFloatTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceFloatTest.java
@@ -117,6 +117,33 @@ public class PackedCoordinateSequenceFloatTest
     assertTrue(seq.getMeasures() == 1);
 
     assertEquals(coords[2].getM(), seq.getM(2));
+
+    // remove z-dimension, add measures
+    coords = createArray(5, Ordinate.createXYZM());
+    seq = new PackedCoordinateSequence.Float(coords, 5, 3);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 5);
+    assertTrue(seq.getMeasures() == 3);
+
+    assertEquals(coords[2].getM(), seq.getM(2));
+
+    // add z-dimension, and additional measures
+    double initZ = PackedCoordinateSequence.getInitialZValue();
+    PackedCoordinateSequence.setInitialZValue(Coordinate.NULL_ORDINATE);
+
+    coords = createArray(5, Ordinate.createXYM());
+    seq = new PackedCoordinateSequence.Float(coords, 6, 3);
+
+    assertNotNull(seq);
+    assertTrue(seq.size() == 5);
+    assertTrue(seq.getDimension() == 6);
+    assertTrue(seq.getMeasures() == 3);
+
+    assertEquals(coords[2].getZ(), seq.getZ(2));
+    assertEquals(coords[2].getM(), seq.getM(2));
+    PackedCoordinateSequence.setInitialZValue(initZ);
   }
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/impl/PackedCoordinateSequenceTest.java
@@ -20,6 +20,8 @@ import org.locationtech.jts.geom.CoordinateXYM;
 import org.locationtech.jts.geom.CoordinateXYZM;
 
 import junit.textui.TestRunner;
+import org.locationtech.jts.io.Ordinate;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /**
  * Test {@link PackedCoordinateSequence}
@@ -37,11 +39,157 @@ public class PackedCoordinateSequenceTest
     super(name);
   }
 
+  /* OVERRIDES OF CoordinateSequenceBase */
+
   @Override
   CoordinateSequenceFactory getCSFactory() {
     return new PackedCoordinateSequenceFactory();
   }
-  
+
+  @Override
+  int getDefaultDimension() { return PackedCoordinateSequence.DEFAULT_DIMENSION; }
+
+  @Override
+  int getFactoryMaxDimension() { return Integer.MAX_VALUE; }
+
+  @Override
+  public void testFactoryCreateWithSizeAndDimension() {
+    double initialZ = PackedCoordinateSequence.getInitialZValue();
+    PackedCoordinateSequence.setInitialZValue(Coordinate.NULL_ORDINATE);
+    super.testFactoryCreateWithSizeAndDimension();
+    PackedCoordinateSequence.setInitialZValue(initialZ);
+  }
+
+  @Override
+  public void testFactoryCreateExtensions() {
+    super.testFactoryCreateExtensions();
+
+    PackedCoordinateSequenceFactory factory = (PackedCoordinateSequenceFactory)getCSFactory();
+    PackedCoordinateSequence seq;
+
+    try {
+      seq = (PackedCoordinateSequence)factory.create(new double[0], 0);
+      fail();
+    }
+    catch (IllegalArgumentException e) {
+
+    }
+    seq = (PackedCoordinateSequence)factory.create(new double[0], 2);
+    assertNotNull(seq);
+    assertEquals(0, seq.size());
+    assertEquals(2, seq.getDimension());
+
+    seq = (PackedCoordinateSequence)factory.create(new double[] {1d, 2d}, 2);
+    assertNotNull(seq);
+    assertEquals(1, seq.size());
+    assertEquals(2, seq.getDimension());
+    assertEquals(1d, seq.getX(0));
+    assertEquals(2d, seq.getY(0));
+
+    seq = (PackedCoordinateSequence)factory.create(new float[] {1f, 2f}, 2);
+    assertNotNull(seq);
+    assertEquals(1, seq.size());
+    assertEquals(2, seq.getDimension());
+    assertEquals(1d, seq.getX(0));
+    assertEquals(2d, seq.getY(0));
+
+    try {
+      factory.create(new double[] {1d, 2d, 3d}, 2);
+      fail();
+    }
+    catch (IllegalArgumentException e) {
+    }
+    try {
+      factory.create(new double[] {1d, 2d, 3d}, 0);
+      fail();
+    }
+    catch (IllegalArgumentException e) {
+    }    try {
+      factory.create(new float[] {1f, 2f, 3f}, 2);
+      fail();
+    }
+    catch (IllegalArgumentException e) {
+    }
+    try {
+      factory.create(new double[] {1d, 2d, 3d}, 0);
+      fail();
+    }
+    catch (IllegalArgumentException e) {
+    }
+
+    assertEquals(PackedCoordinateSequenceFactory.DOUBLE,
+            PackedCoordinateSequenceFactory.DOUBLE_FACTORY.getType());
+    assertEquals(PackedCoordinateSequenceFactory.FLOAT,
+            PackedCoordinateSequenceFactory.FLOAT_FACTORY.getType());
+
+    // Creating Double from Float or vice versa
+    PackedCoordinateSequenceFactory factory2 = factory.getType() == PackedCoordinateSequenceFactory.DOUBLE
+            ? PackedCoordinateSequenceFactory.FLOAT_FACTORY
+            : PackedCoordinateSequenceFactory.DOUBLE_FACTORY;
+
+    CoordinateSequence seq1 = createSequence(factory, 7, Ordinate.createXYZM());
+    CoordinateSequence seq2 = factory2.create(seq1);
+
+    assertTrue(isEqual(seq1, seq2, 1e-5d));
+  }
+
+  @Override
+  public void testZOrdinateIsNaN() {
+    double initalZ = PackedCoordinateSequence.getInitialZValue();
+    PackedCoordinateSequence.setInitialZValue(Coordinate.NULL_ORDINATE);
+    super.testZOrdinateIsNaN();
+    PackedCoordinateSequence.setInitialZValue(initalZ);
+  }
+
+
+  @Override
+  protected void doTestIllegalArgumentsOnSpecific() {
+
+    CoordinateSequenceFactory factory = getCSFactory();
+
+    try {
+      factory.create(0, 2, 1);
+      // ToDo:
+      //   Evaluate: javadoc on CoordinateSequenceFactory.create
+      //   functions state that the they "should not fail" and
+      //   instead should return some sort of sequence.
+      //   @see #CoordinateSequence.create(int, int)
+      //   @see #CoordinateSequence.create(int, int, int)
+      fail();
+    } catch (IllegalArgumentException e) { }
+
+  }
+
+  @Override
+  boolean isSame(CoordinateSequence seq1, CoordinateSequence seq2) {
+
+    if (seq1 == seq2)
+      return true;
+
+    if (seq1.getClass() != seq2.getClass())
+      return false;
+
+    PackedCoordinateSequence pseq1 = (PackedCoordinateSequence)seq1;
+    PackedCoordinateSequence pseq2 = (PackedCoordinateSequence)seq2;
+
+    if (pseq1 instanceof PackedCoordinateSequence.Double)
+    {
+      return  ((PackedCoordinateSequence.Double) pseq1).getRawCoordinates()
+              == ((PackedCoordinateSequence.Double) pseq2).getRawCoordinates();
+    }
+
+    if (pseq1 instanceof PackedCoordinateSequence.Float)
+    {
+      return  ((PackedCoordinateSequence.Float) pseq1).getRawCoordinates()
+              == ((PackedCoordinateSequence.Float) pseq2).getRawCoordinates();
+    }
+
+    return false;
+  }
+
+
+  /* END OVERRIDES of CoordinateSequenceBase */
+
   public void testDouble() {
     checkAll( PackedCoordinateSequenceFactory.DOUBLE_FACTORY );
   }
@@ -49,7 +197,7 @@ public class PackedCoordinateSequenceTest
   public void testFloat() {
     checkAll( PackedCoordinateSequenceFactory.FLOAT_FACTORY) ;
   }
-  
+
   public void checkAll(CoordinateSequenceFactory factory)
   {
     checkDim2(1, factory);
@@ -188,4 +336,207 @@ public class PackedCoordinateSequenceTest
     }
   }
 
+  public void testFactoryConstructor() {
+    PackedCoordinateSequenceFactory factory;
+    factory = new PackedCoordinateSequenceFactory();
+    assertEquals(PackedCoordinateSequenceFactory.DOUBLE, factory.getType());
+    factory = new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.DOUBLE);
+    assertEquals(PackedCoordinateSequenceFactory.DOUBLE, factory.getType());
+    factory = new PackedCoordinateSequenceFactory(PackedCoordinateSequenceFactory.FLOAT);
+    assertEquals(PackedCoordinateSequenceFactory.FLOAT, factory.getType());
+
+    try {
+      new PackedCoordinateSequenceFactory(2);
+      fail();
+    } catch (IllegalArgumentException e) {
+
+    }
+  }
+
+  public void testMOrdinateIs0() {
+    CoordinateSequence cs = getCSFactory().create(1, 3, 1);
+    assertTrue(!Double.isNaN(cs.getOrdinate(0, 2)));
+    assertEquals(0d, cs.getM(0));
+    assertEquals(0d, cs.getOrdinate(0, 2));
+    cs = getCSFactory().create(1, 4, 1);
+    assertTrue(!Double.isNaN(cs.getOrdinate(0, CoordinateSequence.M)));
+    assertEquals(0d, cs.getM(0));
+    assertEquals(0d, cs.getOrdinate(0, 3));
+  }
+
+  /** @deprecated */
+  public void testConstructorWithJustCoordinateArray() {
+    PackedCoordinateSequenceFactory factory = (PackedCoordinateSequenceFactory)getCSFactory();
+    if (factory.getType() == PackedCoordinateSequenceFactory.DOUBLE) {
+      Coordinate[] coords = createArray(5);
+      CoordinateSequence seq = new PackedCoordinateSequence.Double(coords);
+      assertNotNull(seq);
+      assertEquals(5, seq.size());
+      assertEquals(3, seq.getDimension());
+      assertTrue(isEqual(seq, coords));
+    }
+  }
+
+  public void testFailWithInsufficientDimension() {
+    PackedCoordinateSequenceFactory factory = (PackedCoordinateSequenceFactory) getCSFactory();
+
+    // dimension = 0
+    try {
+      factory.create(0, 0, 0);
+      fail();
+    } catch (IllegalArgumentException e) {
+
+    }
+
+    // dimension = 1
+    try {
+      factory.create(0, 1, 0);
+      fail();
+    } catch (IllegalArgumentException e) {
+
+    }
+
+    // dimension - measure >= 2
+    try {
+      factory.create(0, 3, 2);
+      fail();
+    } catch (IllegalArgumentException e) {
+
+    }
+  }
+
+  public void testFactoryCreateByCoordinateArrayAndDimension() {
+    PackedCoordinateSequenceFactory factory = (PackedCoordinateSequenceFactory)getCSFactory();
+
+    // Create with array of Coordinates
+    Coordinate[] coords = createArray(5); // Defaults to XYZFlag
+    CoordinateSequence sequence = factory.create(coords);
+    assertEquals("Size should be 5", 5, sequence.size());
+    assertEquals("Dimension should be 3", 3, sequence.getDimension());
+    assertEquals("Measures should be 0",0, sequence.getMeasures());
+    assertTrue("hasZ() should return true", sequence.hasZ());
+    assertTrue("hasM() should return false", !sequence.hasM());
+    assertTrue(checkOrdinates(coords, sequence));
+
+    // Create with array of CoordinateXYs
+    coords = createArray(5, Ordinate.createXY());
+    sequence = factory.create(coords);
+    assertEquals(5, sequence.size());
+    assertEquals("Dimension should be 2", 2, sequence.getDimension());
+    assertEquals("Measures should be 0", 0, sequence.getMeasures());
+    assertTrue("hasZ() should return false", !sequence.hasZ());
+    assertTrue("hasM() should return false", !sequence.hasM());
+    assertTrue(checkOrdinates(coords, sequence));
+
+    // Create with array of CoordinateXYMs
+    coords = createArray(5, Ordinate.createXYM());
+    sequence = factory.create(coords);
+    assertEquals("Size should be 5", 5, sequence.size());
+    assertEquals("Dimension should be 3", 3, sequence.getDimension());
+    assertEquals("Measures should be 1", 1, sequence.getMeasures());
+    assertTrue("hasZ() should return false", !sequence.hasZ());
+    assertTrue("hasM() should return true", sequence.hasM());
+    assertTrue(checkOrdinates(coords, sequence));
+
+    // Create with array of CoordinateXYMs
+    coords = createArray(5, Ordinate.createXYZM());
+    sequence = factory.create(coords);
+    assertEquals("Size should be 5", 5, sequence.size());
+    assertEquals("Dimension should be 4", 4, sequence.getDimension());
+    assertEquals("Measures should be 1", 1, sequence.getMeasures());
+    assertTrue("hasZ() should return true", sequence.hasZ());
+    assertTrue("hasM() should return true", sequence.hasM());
+    assertTrue(checkOrdinates(coords, sequence));
+  }
+
+  public void testSetOrdinateInvalidatesCachedCoordinateArray() {
+
+    PackedCoordinateSequence seq = (PackedCoordinateSequence) getCSFactory().create(1, 3);
+
+    Coordinate[] coords, compare = null;
+    compare = seq.toCoordinateArray();
+    seq.setX(0, 1d);
+    coords = seq.toCoordinateArray();
+    assertTrue(coords != compare);
+
+    compare = coords;
+    seq.setY(0, 2d);
+    coords = seq.toCoordinateArray();
+    assertTrue(coords != compare);
+
+    compare = coords;
+    seq.setOrdinate(0, 2, 3d);
+    coords = seq.toCoordinateArray();
+    assertTrue(coords != compare);
+
+    compare = coords;
+    coords = seq.toCoordinateArray();
+    assertTrue(coords == compare);
+
+    assertEquals(new Coordinate(1, 2, 3), coords[0]);
+
+    if (seq instanceof PackedCoordinateSequence.Float) {
+      float[] raw = ((PackedCoordinateSequence.Float)seq).getRawCoordinates();
+      assertNotNull(raw);
+      assertEquals(3, raw.length);
+      assertEquals(1f, raw[0]);
+      assertEquals(2f, raw[1]);
+      assertEquals(3f, raw[2]);
+    } else if (seq instanceof PackedCoordinateSequence.Double) {
+      double[] raw = ((PackedCoordinateSequence.Double)seq).getRawCoordinates();
+      assertNotNull(raw);
+      assertEquals(3, raw.length);
+      assertEquals(1d, raw[0]);
+      assertEquals(2d, raw[1]);
+      assertEquals(3d, raw[2]);
+    }
+
+    // make sure cache is created
+    coords = seq.toCoordinateArray();
+    Coordinate c1 = seq.getCoordinate(0);
+    Coordinate c2 = seq.getCoordinate(0);
+    assertTrue(c1 == c2);
+
+  }
+
+  private static boolean checkOrdinates(Coordinate[] coords, CoordinateSequence sequence) {
+
+    if (coords.length != sequence.size())
+      return false;
+
+    int dimension = sequence.getDimension();
+    for (int i = 0; i < coords.length; i++) {
+      if (coords[i].x != sequence.getX(i)) return false;
+      if (dimension == 1) continue;
+
+      if (coords[i].y != sequence.getY(i)) return false;
+      if (dimension == 2) continue;
+
+      if (coords[i] instanceof CoordinateXY) {
+        if (i == 0) assertTrue(!sequence.hasZ());
+        assertTrue(java.lang.Double.isNaN(sequence.getZ(i)));
+        if (i == 0) assertTrue(!sequence.hasM());
+        assertTrue(java.lang.Double.isNaN(sequence.getM(i)));
+      }
+      else if (coords[i] instanceof CoordinateXYM) {
+        if (i == 0) assertTrue(!sequence.hasZ());
+        assertTrue(java.lang.Double.isNaN(sequence.getZ(i)));
+        if (i == 0) assertTrue(sequence.hasM());
+        assertTrue(!java.lang.Double.isNaN(sequence.getM(i)));
+      }
+      else if (coords[i] instanceof CoordinateXYZM) {
+        if (i == 0) assertTrue(sequence.hasZ());
+        assertEquals(coords[i].getZ(), sequence.getZ(i));
+        if (i == 0) assertTrue(sequence.hasM());
+        assertEquals(coords[i].getM(), sequence.getM(i));
+      }
+      else {
+        if (i == 0) assertTrue(sequence.hasZ());
+        assertEquals(coords[i].getZ(), sequence.getZ(i));
+        if (i == 0) assertTrue(!sequence.hasM());
+        assertTrue(java.lang.Double.isNaN(sequence.getM(i)));
+      }
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
* add checkDimension method, call it during sequence construction
* add constructor with CoordinateSequence as argument to both
  PackedCoordinateSequence.Double and .Float
* use ordinate index constants instead of plain values
* add missing integrety checks to constructors
* add INITIAL_Z_VALUE along with get- and set methods. Call
  initializeZValues where required
* share DEFAULT_DIMENSION and DEFAULT_MEASURE in factory and sequence
  class
* add DEFAULT_MEASURE_VALUE to CoordinateXYM and use it in constructors
  of CoordinateXYM and CoordinateXYZM
* add unit tests

Closes #268 

Signed-off-by: Felix Obermaier <felix.obermaier@netcologne.de>