### PR TITLE
Force StringUtil.toString(double) method to use Locale.ENGLISH

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/util/StringUtil.java
+++ b/modules/core/src/main/java/org/locationtech/jts/util/StringUtil.java
@@ -17,9 +17,12 @@ import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.PrintStream;
 import java.io.StringReader;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.Locale;
 
 /**
  * Utility methods for working with {@link String}s.
@@ -29,6 +32,41 @@ import java.util.ArrayList;
  */
 public class StringUtil
 {
+
+  private static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS;
+  private static String DECIMAL_FORMAT_PATTERN;
+  private static NumberFormat SIMPLE_ORDINATE_FORMAT;
+
+  /**
+   * Static initialization of {@linkplain #SIMPLE_ORDINATE_FORMAT}
+   */
+  static {
+    DECIMAL_FORMAT_SYMBOLS = new DecimalFormatSymbols(Locale.ENGLISH);
+    setDecimalFormatPattern("0.#");
+  }
+
+  /**
+   * Gets the pattern used to print numbers using {@linkplain #toString(double)} function
+   *
+   * @return the pattern
+   */
+  public static String getDecimalFormatPattern() {
+    return DECIMAL_FORMAT_PATTERN;
+  }
+
+  /**
+   * Sets the pattern used to print numbers using {@linkplain #toString(double)} function
+   *
+   * @param pattern a pattern
+   */
+  public static void setDecimalFormatPattern(String pattern) {
+    DecimalFormat df = new DecimalFormat(pattern, DECIMAL_FORMAT_SYMBOLS);
+    // TODO: is this desired?
+    df.setRoundingMode(RoundingMode.HALF_UP);
+    DECIMAL_FORMAT_PATTERN = pattern;
+    SIMPLE_ORDINATE_FORMAT = df;
+  }
+
   /**
    * Mimics the the Java SE {@link String#split(String)} method.
    *
@@ -83,8 +121,6 @@ public class StringUtil
      return stackTrace;
  }
 
-  private static NumberFormat SIMPLE_ORDINATE_FORMAT = new DecimalFormat("0.#");
-  
   public static String toString(double d)
   {
     return SIMPLE_ORDINATE_FORMAT.format(d);

--- a/modules/core/src/main/java/org/locationtech/jts/util/StringUtil.java
+++ b/modules/core/src/main/java/org/locationtech/jts/util/StringUtil.java
@@ -41,7 +41,7 @@ public class StringUtil
    * Static initialization of {@linkplain #SIMPLE_ORDINATE_FORMAT}
    */
   static {
-    DECIMAL_FORMAT_SYMBOLS = new DecimalFormatSymbols(Locale.ENGLISH);
+    DECIMAL_FORMAT_SYMBOLS = new DecimalFormatSymbols(Locale.ROOT);
     setDecimalFormatPattern("0.#");
   }
 
@@ -61,10 +61,23 @@ public class StringUtil
    */
   public static void setDecimalFormatPattern(String pattern) {
     DecimalFormat df = new DecimalFormat(pattern, DECIMAL_FORMAT_SYMBOLS);
-    // TODO: is this desired?
-    df.setRoundingMode(RoundingMode.HALF_UP);
     DECIMAL_FORMAT_PATTERN = pattern;
     SIMPLE_ORDINATE_FORMAT = df;
+  }
+
+  /**
+   * Gets the {@linkplain RoundingMode} applied when using {@link #toString(double)}
+   * @return A rounding mode
+   */
+  public static RoundingMode getRoundingMode() {
+    return SIMPLE_ORDINATE_FORMAT.getRoundingMode();
+  }
+
+  /**
+   * Sets the {@linkplain RoundingMode} to apply when using {@link #toString(double)}
+   */
+  public static void setRoundingMode(RoundingMode roundingMode) {
+    SIMPLE_ORDINATE_FORMAT.setRoundingMode(roundingMode);
   }
 
   /**
@@ -121,6 +134,16 @@ public class StringUtil
      return stackTrace;
  }
 
+  /**
+   * Creates a string of the  provided {@link double} value using
+   * the globally set {@linkplain #SIMPLE_ORDINATE_FORMAT}.
+   *
+   * @param d    a double value.
+   * @return     A numerical string.
+   *
+   * @see #setDecimalFormatPattern(String)
+   * @see #setRoundingMode(RoundingMode)
+   */
   public static String toString(double d)
   {
     return SIMPLE_ORDINATE_FORMAT.format(d);

--- a/modules/core/src/test/java/org/locationtech/jts/util/StringUtilTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/util/StringUtilTest.java
@@ -2,6 +2,7 @@ package org.locationtech.jts.util;
 
 import junit.framework.TestCase;
 
+import java.math.RoundingMode;
 import java.util.Locale;
 
 public class StringUtilTest extends TestCase {
@@ -20,6 +21,21 @@ public class StringUtilTest extends TestCase {
     assertEquals("0.#", pattern);
 
     StringUtil.setDecimalFormatPattern("0.00");
+    assertEquals("0.00", StringUtil.getDecimalFormatPattern());
+
+    RoundingMode r = StringUtil.getRoundingMode();
+    if (r != RoundingMode.UNNECESSARY) {
+      StringUtil.setRoundingMode(RoundingMode.UNNECESSARY);
+      assertEquals(RoundingMode.UNNECESSARY, StringUtil.getRoundingMode());
+    }
+    else {
+      StringUtil.setRoundingMode(RoundingMode.UP);
+      assertEquals(RoundingMode.UP, StringUtil.getRoundingMode());
+    }
+
+    StringUtil.setRoundingMode(r);
+    assertEquals(r, StringUtil.getRoundingMode());
+
     assertEquals("0.00", StringUtil.getDecimalFormatPattern());
 
     StringUtil.setDecimalFormatPattern("0.#");

--- a/modules/core/src/test/java/org/locationtech/jts/util/StringUtilTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/util/StringUtilTest.java
@@ -1,0 +1,39 @@
+package org.locationtech.jts.util;
+
+import junit.framework.TestCase;
+
+import java.util.Locale;
+
+public class StringUtilTest extends TestCase {
+
+  public StringUtilTest(String name) {
+    super(name);
+  }
+
+  public static void main(String[] args) {
+    junit.textui.TestRunner.run(StringUtilTest.class);
+  }
+
+  public void testDecimalPattern()
+  {
+    String pattern = StringUtil.getDecimalFormatPattern();
+    assertEquals("0.#", pattern);
+
+    StringUtil.setDecimalFormatPattern("0.00");
+    assertEquals("0.00", StringUtil.getDecimalFormatPattern());
+
+    StringUtil.setDecimalFormatPattern("0.#");
+  }
+
+  public void testDecimalSeperatorIsPoint() {
+
+    Locale current = Locale.getDefault();
+    Locale.setDefault(Locale.GERMAN);
+    String s1 = StringUtil.toString(1.5);
+    assertEquals("1.5", s1);
+    String s2 = StringUtil.toString(1001.551);
+    assertEquals("1001.6", s2);
+
+    Locale.setDefault(current);
+  }
+}


### PR DESCRIPTION
Currently `StringUtil.toString(double)` function uses `Locale.getDefault()` to write a `double` to a `String`.
This function is being used from within `CoordinateSequences.toString(CoordinateSequence)` making the output un[read|use]able in environments that have a comma as a decimal seperator (like e.g. german).

This PR contains
* Fix for `StringUtil.toString(double)` method to use `Locale.ENGLISH`
* Add methods to change decimal format pattern
* Add unit test

Signed-off-by: Felix Obermaier <felix.obermaier@netcologne.de>