### PR TITLE
Fixes for Segment Noding to avoid 1-point edges and collapsed edges

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNode.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNode.java
@@ -70,6 +70,11 @@ public class SegmentNode
 
     if (coord.equals2D(other.coord)) return 0;
 
+    // an exterior node is the segment start point, so always sorts first
+    // this guards against a robustness problem where the octants are not reliable
+    //if (! isInterior) return -1;
+    //if (! other.isInterior) return 1;
+    
     return SegmentPointComparator.compare(segmentOctant, coord, other.coord);
     //return segment.compareNodePosition(this, other);
   }

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNode.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNode.java
@@ -72,8 +72,8 @@ public class SegmentNode
 
     // an exterior node is the segment start point, so always sorts first
     // this guards against a robustness problem where the octants are not reliable
-    //if (! isInterior) return -1;
-    //if (! other.isInterior) return 1;
+    if (! isInterior) return -1;
+    if (! other.isInterior) return 1;
     
     return SegmentPointComparator.compare(segmentOctant, coord, other.coord);
     //return segment.compareNodePosition(this, other);

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
@@ -235,6 +235,9 @@ public class SegmentNodeList
 //Debug.println("\ncreateSplitEdge"); Debug.print(ei0); Debug.print(ei1);
     int npts = ei1.segmentIndex - ei0.segmentIndex + 2;
 
+    // if only two points in split edge they must be the node points
+    if (npts == 2) return new Coordinate[] { new Coordinate(ei0.coord), new Coordinate(ei1.coord) };
+    
     Coordinate lastSegStartPt = edge.getCoordinate(ei1.segmentIndex);
     /**
      * If the last intersection point is not equal to the its segment start pt,
@@ -245,7 +248,7 @@ public class SegmentNodeList
      * 
      * The check for point equality is 2D only - Z values are ignored
      */
-    boolean useIntPt1 = npts == 2 || ei1.isInterior() || ! ei1.coord.equals2D(lastSegStartPt);
+    boolean useIntPt1 = ei1.isInterior() || ! ei1.coord.equals2D(lastSegStartPt);
     if (! useIntPt1) {
       npts--;
     }

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
@@ -221,6 +221,16 @@ public class SegmentNodeList
     return new NodedSegmentString(pts, edge.getData());
   }
   
+  /**
+   * Extracts the points for a split edge running between two nodes.
+   * The extracted points should contain no duplicate points.
+   * There should always be at least two points extracted
+   * (which will be the given nodes).
+   * 
+   * @param ei0 the start node of the split edge
+   * @param ei1 the end node of the split edge
+   * @return the points for the split edge
+   */
   private Coordinate[] createSplitEdgePts(SegmentNode ei0, SegmentNode ei1) {
 //Debug.println("\ncreateSplitEdge"); Debug.print(ei0); Debug.print(ei1);
     int npts = ei1.segmentIndex - ei0.segmentIndex + 2;

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
@@ -208,7 +208,6 @@ public class SegmentNodeList
     Coordinate ptn = splitnPts[splitnPts.length - 1];
     if (! ptn.equals2D(edgePts[edgePts.length - 1]))
       throw new RuntimeException("bad split edge end point at " + ptn);
-
   }
 
   /**
@@ -216,17 +215,27 @@ public class SegmentNodeList
    * (and including) the two intersections.
    * The label for the new edge is the same as the label for the parent edge.
    */
-  SegmentString createSplitEdge(SegmentNode ei0, SegmentNode ei1)
+  private SegmentString createSplitEdge(SegmentNode ei0, SegmentNode ei1)
   {
+    Coordinate[] pts = createSplitEdgePts(ei0, ei1);
+    return new NodedSegmentString(pts, edge.getData());
+  }
+  
+  private Coordinate[] createSplitEdgePts(SegmentNode ei0, SegmentNode ei1) {
 //Debug.println("\ncreateSplitEdge"); Debug.print(ei0); Debug.print(ei1);
     int npts = ei1.segmentIndex - ei0.segmentIndex + 2;
 
     Coordinate lastSegStartPt = edge.getCoordinate(ei1.segmentIndex);
-    // if the last intersection point is not equal to the its segment start pt,
-    // add it to the points list as well.
-    // (This check is needed because the distance metric is not totally reliable!)
-    // The check for point equality is 2D only - Z values are ignored
-    boolean useIntPt1 = ei1.isInterior() || ! ei1.coord.equals2D(lastSegStartPt);
+    /**
+     * If the last intersection point is not equal to the its segment start pt,
+     * add it to the points list as well.
+     * This check is needed because the distance metric is not totally reliable!
+     * 
+     * Also ensure that the created edge always has at least 2 points.
+     * 
+     * The check for point equality is 2D only - Z values are ignored
+     */
+    boolean useIntPt1 = npts == 2 || ei1.isInterior() || ! ei1.coord.equals2D(lastSegStartPt);
     if (! useIntPt1) {
       npts--;
     }
@@ -238,8 +247,7 @@ public class SegmentNodeList
       pts[ipt++] = edge.getCoordinate(i);
     }
     if (useIntPt1) pts[ipt] = new Coordinate(ei1.coord);
-
-    return new NodedSegmentString(pts, edge.getData());
+    return pts;
   }
 
   /**
@@ -270,26 +278,8 @@ public class SegmentNodeList
 
   private void addEdgeCoordinates(SegmentNode ei0, SegmentNode ei1,
       CoordinateList coordList) {
-    int npts = ei1.segmentIndex - ei0.segmentIndex + 2;
-
-    Coordinate lastSegStartPt = edge.getCoordinate(ei1.segmentIndex);
-    // if the last intersection point is not equal to the its segment start pt,
-    // add it to the points list as well.
-    // (This check is needed because the distance metric is not totally reliable!)
-    // The check for point equality is 2D only - Z values are ignored
-    boolean useIntPt1 = ei1.isInterior() || ! ei1.coord.equals2D(lastSegStartPt);
-    if (! useIntPt1) {
-      npts--;
-    }
-
-    int ipt = 0;
-    coordList.add(new Coordinate(ei0.coord), false);
-    for (int i = ei0.segmentIndex + 1; i <= ei1.segmentIndex; i++) {
-      coordList.add(edge.getCoordinate(i));
-    }
-    if (useIntPt1) {
-      coordList.add(new Coordinate(ei1.coord));
-    }
+    Coordinate[] pts = createSplitEdgePts(ei0, ei1);
+    coordList.add(pts, false);
   }
 
   public void print(PrintStream out)
@@ -367,3 +357,4 @@ class NodeVertexIterator
   }
 
 }
+

--- a/modules/core/src/test/java/org/locationtech/jts/noding/snapround/SegmentStringNodingTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/noding/snapround/SegmentStringNodingTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.locationtech.jts.noding.snapround;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineSegment;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.noding.NodedSegmentString;
+import org.locationtech.jts.noding.snapround.MCIndexSnapRounder;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+
+/**
+ * Test for correctly created Noded Segment Strings
+ * under an extreme usage of SnapRounding.
+ * This test reveals a bug in SegmentNodeList.createSplitEdge()
+ * which can create 1-point Segment Strings
+ * if the input is incorrectly noded due to robustness issues.
+ * 
+ * See https://github.com/locationtech/jts/pull/395
+ *
+ * @version 1.7
+ */
+public class SegmentStringNodingTest  extends TestCase {
+
+  WKTReader rdr = new WKTReader();
+
+  public static void main(String args[]) {
+    TestRunner.run(SegmentStringNodingTest.class);
+  }
+
+  public SegmentStringNodingTest(String name) { super(name); }
+  
+  public void testThinTriangle() throws Exception {
+    String wkt = "LINESTRING ( 55121.54481117887 42694.49730855581, 55121.54481117887 42694.4973085558, 55121.458748617406 42694.419143944244, 55121.54481117887 42694.49730855581 )";
+    Geometry g = new WKTReader().read(wkt);
+    List<NodedSegmentString> strings = new ArrayList<>();
+    strings.add(new NodedSegmentString(g.getCoordinates(), null));
+    PrecisionModel pm = new PrecisionModel(1.1131949079327356E11);
+    new MCIndexSnapRounder(pm).computeNodes(strings);
+    strings.get(0).getNodeList().addSplitEdges(strings);
+    for (NodedSegmentString s : strings) {
+      assertTrue(s.size() >= 2);
+  }
+}
+  
+  public void testSegmentLength1Failure() throws Exception {
+    PrecisionModel pm = new PrecisionModel(1.11E10);
+    String wkt = "LINESTRING ( -1677607.6366504875 -588231.47100446, -1674050.1010869485 -587435.2186255794, -1670493.6527468169 -586636.7948791061, -1424286.3681743187 -525586.1397894835, -1670493.6527468169 -586636.7948791061, -1674050.1010869485 -587435.2186255795, -1677607.6366504875 -588231.47100446)";
+    Geometry g = new WKTReader().read(wkt);
+    List<NodedSegmentString> strings = new ArrayList<>();
+    strings.add(new NodedSegmentString(g.getCoordinates(), null));
+    new MCIndexSnapRounder(pm).computeNodes(strings);
+    strings.get(0).getNodeList().addSplitEdges(strings);
+    for (NodedSegmentString s : strings) {
+      assertTrue(s.size() >= 2);
+    }
+  }
+  
+}

--- a/modules/core/src/test/java/org/locationtech/jts/noding/snapround/SegmentStringNodingTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/noding/snapround/SegmentStringNodingTest.java
@@ -15,14 +15,11 @@ package org.locationtech.jts.noding.snapround;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.LineSegment;
-import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.noding.NodedSegmentString;
-import org.locationtech.jts.noding.snapround.MCIndexSnapRounder;
 
 import junit.framework.TestCase;
 import junit.textui.TestRunner;
@@ -51,28 +48,28 @@ public class SegmentStringNodingTest  extends TestCase {
   
   public void testThinTriangle() throws Exception {
     String wkt = "LINESTRING ( 55121.54481117887 42694.49730855581, 55121.54481117887 42694.4973085558, 55121.458748617406 42694.419143944244, 55121.54481117887 42694.49730855581 )";
-    Geometry g = new WKTReader().read(wkt);
-    List<NodedSegmentString> strings = new ArrayList<>();
-    strings.add(new NodedSegmentString(g.getCoordinates(), null));
     PrecisionModel pm = new PrecisionModel(1.1131949079327356E11);
-    new MCIndexSnapRounder(pm).computeNodes(strings);
-    strings.get(0).getNodeList().addSplitEdges(strings);
-    for (NodedSegmentString s : strings) {
-      assertTrue(s.size() >= 2);
-  }
+    checkNodedStrings(wkt, pm);
 }
-  
+
   public void testSegmentLength1Failure() throws Exception {
-    PrecisionModel pm = new PrecisionModel(1.11E10);
     String wkt = "LINESTRING ( -1677607.6366504875 -588231.47100446, -1674050.1010869485 -587435.2186255794, -1670493.6527468169 -586636.7948791061, -1424286.3681743187 -525586.1397894835, -1670493.6527468169 -586636.7948791061, -1674050.1010869485 -587435.2186255795, -1677607.6366504875 -588231.47100446)";
+    PrecisionModel pm = new PrecisionModel(1.11E10);
+    checkNodedStrings(wkt, pm);
+  }
+  
+  private void checkNodedStrings(String wkt, PrecisionModel pm) throws ParseException {
     Geometry g = new WKTReader().read(wkt);
     List<NodedSegmentString> strings = new ArrayList<>();
     strings.add(new NodedSegmentString(g.getCoordinates(), null));
     new MCIndexSnapRounder(pm).computeNodes(strings);
-    strings.get(0).getNodeList().addSplitEdges(strings);
-    for (NodedSegmentString s : strings) {
+    
+    @SuppressWarnings("unchecked")
+    List<NodedSegmentString> noded = NodedSegmentString.getNodedSubstrings(strings);
+    for (NodedSegmentString s : noded) {
       assertTrue(s.size() >= 2);
     }
   }
   
+
 }


### PR DESCRIPTION
This is a reworking of the fix committed a long time ago in https://github.com/libgeos/geos/commit/c7094065ad1285a88071654f8b8626cc60022ff2

It replaces PR #395 with the following improvements:

* Refactoring to simplify and centralize the complex logic containing the original bug
* Adding a unit test for on this behaviour

It also adds a further fix to improve sorting of SegmentNodes along segments.  This was resulting in output of collapsed edges in some extreme cases.