### PR TITLE
Add AnchorPoint noding to jtslab

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/LineIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/LineIntersector.java
@@ -16,6 +16,8 @@ package org.locationtech.jts.algorithm;
  */
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geomgraph.index.EdgeSetIntersector;
+import org.locationtech.jts.geomgraph.index.SimpleMCSweepLineIntersector;
 import org.locationtech.jts.io.WKTWriter;
 import org.locationtech.jts.util.Assert;
 
@@ -165,6 +167,15 @@ public abstract class LineIntersector
     pa = intPt[0];
     pb = intPt[1];
     result = 0;
+  }
+
+  /**
+   * Create an EdgeSetIntersector
+   *
+   * @return an EdgeSetIntersector
+   */
+  public EdgeSetIntersector create() {
+    return new SimpleMCSweepLineIntersector();
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
@@ -194,7 +194,7 @@ public class RobustLineIntersector
    * removing common significant digits from the calculation to
    * maintain more bits of precision.
    */
-  private Coordinate intersection(
+  protected Coordinate intersection(
     Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2)
   {
     Coordinate intPt = intersectionWithNormalization(p1, p2, q1, q2);
@@ -250,7 +250,7 @@ public class RobustLineIntersector
     }
   }
 
-  private Coordinate intersectionWithNormalization(
+  protected Coordinate intersectionWithNormalization(
     Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2)
     {
       Coordinate n1 = new Coordinate(p1);

--- a/modules/core/src/main/java/org/locationtech/jts/noding/BasicSegmentString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/BasicSegmentString.java
@@ -69,6 +69,13 @@ public class BasicSegmentString
     return pts[0].equals(pts[pts.length - 1]);
   }
 
+  public boolean hasExtent() {
+    if (pts.length == 0) return false;
+    for (int i = 1; i < pts.length; i++) {
+      if (!pts[0].equals2D(pts[i])) return true;
+    }
+    return false;
+  }
   /**
    * Gets the octant of the segment starting at vertex <code>index</code>.
    *

--- a/modules/core/src/main/java/org/locationtech/jts/noding/NodedSegmentString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/NodedSegmentString.java
@@ -103,6 +103,13 @@ public class NodedSegmentString
   {
     return pts[0].equals(pts[pts.length - 1]);
   }
+  public boolean hasExtent() {
+    if (pts.length == 0) return false;
+    for (int i = 1; i < pts.length; i++) {
+      if (!pts[0].equals2D(pts[i])) return true;
+    }
+    return false;
+  }
 
   /**
    * Gets the octant of the segment starting at vertex <code>index</code>.

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
@@ -182,7 +182,9 @@ public class SegmentNodeList
       if (newEdge.size() < 2)
         throw new RuntimeException("created single point edge: " + newEdge.toString());
       */
-      edgeList.add(newEdge);
+      if (newEdge.hasExtent())
+        edgeList.add(newEdge);
+
       eiPrev = ei;
     }
     //checkSplitEdgesCorrectness(testingSplitEdges);

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentString.java
@@ -28,17 +28,48 @@ public interface SegmentString
    *
    * @return the user-defined data
    */
-  public Object getData();
+  Object getData();
 
   /**
    * Sets the user-defined data for this segment string.
    *
    * @param data an Object containing user-defined data
    */
-  public void setData(Object data);
+  void setData(Object data);
 
-  public int size();
-  public Coordinate getCoordinate(int i);
-  public Coordinate[] getCoordinates();
-  public boolean isClosed();
+  /**
+   * Gets the number of coordinates that make up the segment string
+   *
+   * @return the number of coordinates
+   */
+  int size();
+
+  /**
+   * Get the i'th coordinate of this segment string.
+   *
+   * @param i the index of the coordinate to get. Must be in the range [0, {@linkplain #size()} - 1]
+   * @return a coordinate.
+   */
+  Coordinate getCoordinate(int i);
+
+  /**
+   * Gets the array of coordinates that make up this segment string.
+   *
+   * @return an array of coordinates
+   */
+  Coordinate[] getCoordinates();
+
+  /**
+   * Tests if the segment string is closed, start- and endpoint are the same.
+   *
+   * @return <c>true</c> if the segment string is closed
+   */
+  boolean isClosed();
+
+  /**
+   * Test if this segment has at least two different coordinates.
+   *
+   * @return <c>true</c> if there are at least 2 different points in the sequence
+   */
+  boolean hasExtent();
 }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/GeometryGraphOperation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/GeometryGraphOperation.java
@@ -27,7 +27,7 @@ import org.locationtech.jts.geomgraph.GeometryGraph;
  */
 public class GeometryGraphOperation
 {
-  protected final LineIntersector li = new RobustLineIntersector();
+  protected final LineIntersector li;
   protected PrecisionModel resultPrecisionModel;
 
   /**
@@ -35,16 +35,28 @@ public class GeometryGraphOperation
    */
   protected GeometryGraph[] arg;  // the arg(s) of the operation
 
-  public GeometryGraphOperation(Geometry g0, Geometry g1)
+  /** @deprecated Specify {@linkplain LineIntersector} to use */
+  public GeometryGraphOperation(Geometry g0, Geometry g1) {
+    this(new RobustLineIntersector(), g0, g1);
+  }
+
+  public GeometryGraphOperation(LineIntersector li, Geometry g0, Geometry g1)
   {
-    this(g0, g1,
+    this(li, g0, g1,
          BoundaryNodeRule.OGC_SFS_BOUNDARY_RULE
 //         BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE
          );
   }
+  /** @deprecated Specify {@linkplain LineIntersector} to use */
+  public GeometryGraphOperation(Geometry g0, Geometry g1, BoundaryNodeRule boundaryNodeRule) {
+    this(new RobustLineIntersector(), g0, g1, boundaryNodeRule);
+  }
 
-  public GeometryGraphOperation(Geometry g0, Geometry g1, BoundaryNodeRule boundaryNodeRule)
+  public GeometryGraphOperation(LineIntersector li,  Geometry g0, Geometry g1, BoundaryNodeRule boundaryNodeRule)
   {
+    // assign the line intersector
+    this.li = li;
+
     // use the most precise model for the result
     if (g0.getPrecisionModel().compareTo(g1.getPrecisionModel()) >= 0)
       setComputationPrecision(g0.getPrecisionModel());
@@ -57,10 +69,15 @@ public class GeometryGraphOperation
   }
 
   public GeometryGraphOperation(Geometry g0) {
+    this(new RobustLineIntersector(), g0);
+  }
+
+  public GeometryGraphOperation(LineIntersector li, Geometry g0) {
+    this.li = li;
     setComputationPrecision(g0.getPrecisionModel());
 
     arg = new GeometryGraph[1];
-    arg[0] = new GeometryGraph(0, g0);;
+    arg[0] = new GeometryGraph(0, g0);
   }
 
   public Geometry getArgGeometry(int i) { return arg[i].getGeometry(); }
@@ -68,6 +85,7 @@ public class GeometryGraphOperation
   protected void setComputationPrecision(PrecisionModel pm)
   {
     resultPrecisionModel = pm;
+    if (li == null) throw new IllegalStateException("LineIntersector not set");
     li.setPrecisionModel(resultPrecisionModel);
   }
 }

--- a/modules/lab/src/main/java/org/locationtech/jtslab/algorithm/AnchorPoint.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/algorithm/AnchorPoint.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019 Felix Obermaier
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jtslab.algorithm;
+
+import org.locationtech.jts.geom.Coordinate;
+
+/**
+ * A wrapper around a {@linkplain Coordinate} in order to possibly reuse it
+ * during intersection computations.
+ */
+public class AnchorPoint {
+  /** The wrapped coordinate */
+  final Coordinate anchorPoint;
+
+  /** a flag indicating it represents an input vertex */
+  final boolean fromVertex;
+
+  /**
+   * Creates an instance of this class
+   *
+   * @param anchorPoint a point
+   * @param fromVertex a flag indicating that {@param anchorPoint} is a vertex.
+   */
+  public AnchorPoint(Coordinate anchorPoint, boolean fromVertex) {
+    this.anchorPoint = anchorPoint;
+    this.fromVertex = fromVertex;
+  }
+
+  /**
+   * Access to the wrapped {@linkplain Coordinate}.
+   * @return the wrapped coordinate.
+   */
+  public Coordinate getCoordinate() { return this.anchorPoint; }
+
+  /**
+   * Indicates  to the wrapped {@linkplain Coordinate}.
+   * @return <c>true</c> if {@linkplain #getCoordinate()} is a vertex from the input.
+   */
+  public boolean getFromVertex() { return this.fromVertex; }
+
+  public String toString() {
+    return "[AP" + this.anchorPoint + ", v=" + (this.fromVertex ? "T":"F") + "]";
+  }
+}

--- a/modules/lab/src/main/java/org/locationtech/jtslab/algorithm/AnchorPointRobustLineIntersector.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/algorithm/AnchorPointRobustLineIntersector.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2019 Felix Obermaier
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jtslab.algorithm;
+
+import org.locationtech.jts.algorithm.RobustLineIntersector;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geomgraph.index.EdgeSetIntersector;
+import org.locationtech.jts.geomgraph.index.SegmentIntersector;
+import org.locationtech.jts.index.kdtree.KdNode;
+import org.locationtech.jts.index.kdtree.KdNodeVisitor;
+import org.locationtech.jts.index.kdtree.KdTree;
+import org.locationtech.jtslab.geomgraph.index.AnchorPointMCSweepLineIntersector;
+
+import java.util.List;
+
+/**
+ * An extended version of the {@linkplain RobustLineIntersector}.
+ * It is supported by an index of {@linkplain AnchorPoint}s which
+ * is used to query for and reuse already existant points.
+ */
+public class AnchorPointRobustLineIntersector
+  extends RobustLineIntersector
+{
+
+  /**
+   * The default distance that points need to have from anchor points in order
+   * to qualify for <i>real</i> points
+   */
+  private static final double DEFAULT_MIN_DISTANCE_FROM_ANCHOR_POINT = 1E-10;
+
+  /** Index of {@linkplain AnchorPoint}s */
+  private final KdTree anchorPoints = new KdTree();
+
+  /** Minimum distance new points must have to already existant {@linkplain AnchorPoint}s. */
+  private double minDistanceToAnchorPoint;
+
+  /**
+   * Creates an instance of this class using the provided precision model
+   *
+   * @param precisionModel a precision model
+   */
+  public AnchorPointRobustLineIntersector(PrecisionModel precisionModel) {
+    this(precisionModel, determineMinDistanceFromAnchorPoint(precisionModel));
+  }
+
+  /**
+   * Creates an instance of this class using the provided distance measure.
+   *
+   * @param minDistanceToAnchorPoint a distance measure
+   */
+  public AnchorPointRobustLineIntersector(double minDistanceToAnchorPoint) {
+    this(null, minDistanceToAnchorPoint);
+  }
+
+  /**
+   * Creates an instance of this class using the provided precision model and
+   * distance measure.
+   *
+   * @param precisionModel a precision model
+   * @param minDistanceToAnchorPoint a distance measure
+   */
+  public AnchorPointRobustLineIntersector(PrecisionModel precisionModel, double minDistanceToAnchorPoint) {
+    super.setPrecisionModel(precisionModel);
+    this.minDistanceToAnchorPoint = minDistanceToAnchorPoint;
+  }
+
+  /**
+   * Determines the distance points need to have from anchor points in order to qualify
+   * as *real* points.
+   *
+   * @param precisionModel a precision model
+   * @return a distance
+   */
+  private static double determineMinDistanceFromAnchorPoint(PrecisionModel precisionModel) {
+    if (precisionModel != null && !precisionModel.isFloating())
+      return 1d / (2d * precisionModel.getScale());
+    else
+      return  DEFAULT_MIN_DISTANCE_FROM_ANCHOR_POINT;
+  }
+
+  @Override
+  public EdgeSetIntersector create() {
+    return new AnchorPointMCSweepLineIntersector(this.anchorPoints);
+  }
+
+  @Override
+  public void setPrecisionModel(PrecisionModel precisionModel) {
+    double minDistanceToAnchorPoint = determineMinDistanceFromAnchorPoint(precisionModel);
+    if (minDistanceToAnchorPoint > this.minDistanceToAnchorPoint)
+      this.minDistanceToAnchorPoint = minDistanceToAnchorPoint;
+
+    super.setPrecisionModel(precisionModel);
+  }
+
+  /**
+   * Computes the actual intersection point between the segments {@param p0} to {@param p1} and
+   * {@param q0} to {@param q1}.
+   *
+   * If {@linkplain #minDistanceToAnchorPoint} has a positive value, an attempt is made to query
+   * and substitute an {@linkplain AnchorPoint} from {@linkplain #getAnchorPoints()}.
+   *
+   * @param p1 the starting point of the 1st segment
+   * @param p2 the end-point of the 1st segment
+   * @param q1 the starting point of the 2nd segment
+   * @param q2 the end-point of the 2nd segment
+   *
+   * @return the intersection point
+   *
+   */
+  @Override
+  protected Coordinate intersection(Coordinate p1, Coordinate p2, Coordinate q1, Coordinate q2) {
+
+    if (this.minDistanceToAnchorPoint <= 0)
+      return super.intersection(p1, p2, q1, q2);
+
+    Coordinate intPt = intersectionWithNormalization(p1, p2, q1, q2);
+
+    // create search envelope for anchor points
+    Envelope e = new Envelope(p1, p2);
+    e.expandToInclude(new Envelope(q1, q2));
+
+    // create visitor and query anchor points
+    AnchorPointVisitor apv = new AnchorPointVisitor(intPt);
+    this.anchorPoints.query(e, apv);
+
+    // get the possible anchor point
+    AnchorPoint ap = apv.getAnchorPoint();
+    if (ap != null) {
+      // if anchor point is a input vertex, the intersection is not proper!
+      if (ap.fromVertex) this.isProper = false;
+      return ap.getCoordinate();
+    }
+
+    // apply precision model to intersection point
+    if (this.precisionModel != null)
+      this.precisionModel.makePrecise(intPt);
+
+    // add intersection point to index!
+    this.anchorPoints.insert(intPt, new AnchorPoint(intPt, false));
+
+    return intPt;
+
+  }
+
+  /**
+   * Access to the index of {@linkplain AnchorPoint}s.
+   * @return an index of {@linkplain AnchorPoint}s.
+   */
+  public KdTree getAnchorPoints() {
+    return this.anchorPoints;
+  }
+
+  /**
+   * Visitor class that searches for the closest {@linkplain AnchorPoint} to
+   * a {@linkplain #testPoint}.
+   */
+  private class AnchorPointVisitor implements KdNodeVisitor {
+
+    /** the test point*/
+    final Coordinate testPoint;
+
+    /** the distance of the closest anchor point to {@linkplain #testPoint} */
+    double anchorPointDistance;
+
+    /** the closest anchor point to {@linkplain #testPoint} */
+    AnchorPoint anchorPoint;
+
+    /**
+     * Creates an instance of this class
+     * @param testPoint a test point
+     */
+    AnchorPointVisitor(Coordinate testPoint) {
+      this.testPoint = testPoint;
+      this.anchorPointDistance = Double.MAX_VALUE;
+    }
+
+    @Override
+    public void visit(KdNode node) {
+      double distance = node.getCoordinate().distance(testPoint);
+      if (distance < anchorPointDistance && distance <= minDistanceToAnchorPoint) {
+        this.anchorPointDistance = distance;
+        this.anchorPoint = (AnchorPoint) node.getData();
+      }
+    }
+
+    /**
+     * Access to the closest {@linkplain AnchorPoint}.
+     * @return an anchor point if found or <c>null</c>.
+     */
+    public AnchorPoint getAnchorPoint() {
+      if (anchorPointDistance == Double.MAX_VALUE)
+        return null;
+
+      return this.anchorPoint;
+    }
+  }
+}

--- a/modules/lab/src/main/java/org/locationtech/jtslab/geomgraph/index/AnchorPointMCSweepLineIntersector.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/geomgraph/index/AnchorPointMCSweepLineIntersector.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ * Copyright (c) 2019 Felix Obermaier
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jtslab.geomgraph.index;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.locationtech.jts.geomgraph.index.*;
+import org.locationtech.jtslab.algorithm.AnchorPoint;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geomgraph.Edge;
+import org.locationtech.jts.index.kdtree.KdTree;
+
+/**
+ * Finds all intersections in one or two sets of edges,
+ * using an x-axis sweepline algorithm in conjunction with Monotone Chains.
+ * While still O(n^2) in the worst case, this algorithm
+ * drastically improves the average-case time.
+ * The use of MonotoneChains as the items in the index
+ * seems to offer an improvement in performance over a sweep-line alone.
+ *
+ * @version 1.17
+ */
+public class AnchorPointMCSweepLineIntersector
+  extends EdgeSetIntersector
+{
+
+  /** The index of {@linkplain AnchorPoint}s. */
+  private final KdTree anchorPoints;
+
+  List events = new ArrayList();
+
+  // statistics information
+  int nOverlaps;
+
+  /**
+   * Creates an instance of this class
+   *
+   * @param anchorPoints an index of {@linkplain AnchorPoint}s.
+   */
+  public AnchorPointMCSweepLineIntersector(KdTree anchorPoints) {
+    if (anchorPoints == null)
+      throw new IllegalArgumentException("anchorPoints");
+
+    this.anchorPoints = anchorPoints;
+  }
+
+  public void computeIntersections(List edges, SegmentIntersector si, boolean testAllSegments)
+  {
+    if (testAllSegments)
+      addEdges(edges, null);
+    else
+      addEdges(edges);
+    computeIntersections(si);
+  }
+
+  public void computeIntersections(List edges0, List edges1, SegmentIntersector si)
+  {
+    addEdges(edges0, edges0);
+    addEdges(edges1, edges1);
+    computeIntersections(si);
+  }
+
+  private void addEdges(List edges)
+  {
+    for (Iterator i = edges.iterator(); i.hasNext(); ) {
+      Edge edge = (Edge) i.next();
+      // edge is its own group
+      addEdge(edge, edge);
+    }
+  }
+  private void addEdges(List edges, Object edgeSet)
+  {
+    for (Iterator it = edges.iterator(); it.hasNext(); ) {
+      Edge edge = (Edge) it.next();
+      // add the edge's vertices to the anchor points index
+      for (int i = 0; i < edge.getNumPoints(); i++) {
+        Coordinate c = edge.getCoordinate(i);
+        this.anchorPoints.insert(c, new AnchorPoint(c, true));
+      }
+      addEdge(edge, edgeSet);
+    }
+  }
+
+  private void addEdge(Edge edge, Object edgeSet)
+  {
+    MonotoneChainEdge mce = edge.getMonotoneChainEdge();
+    int[] startIndex = mce.getStartIndexes();
+    for (int i = 0; i < startIndex.length - 1; i++) {
+      MonotoneChain mc = new MonotoneChain(mce, i);
+      SweepLineEvent insertEvent = new SweepLineEvent(edgeSet, mce.getMinX(i), mc);
+      events.add(insertEvent);
+      events.add(new SweepLineEvent(mce.getMaxX(i), insertEvent));
+    }
+  }
+
+  /**
+   * Because Delete Events have a link to their corresponding Insert event,
+   * it is possible to compute exactly the range of events which must be
+   * compared to a given Insert event object.
+   */
+  private void prepareEvents()
+  {
+    Collections.sort(events);
+    // set DELETE event indexes
+    for (int i = 0; i < events.size(); i++ )
+    {
+      SweepLineEvent ev = (SweepLineEvent) events.get(i);
+      if (ev.isDelete()) {
+        ev.getInsertEvent().setDeleteEventIndex(i);
+      }
+    }
+  }
+
+  private void computeIntersections(SegmentIntersector si)
+  {
+    nOverlaps = 0;
+    prepareEvents();
+
+    for (int i = 0; i < events.size(); i++ )
+    {
+      SweepLineEvent ev = (SweepLineEvent) events.get(i);
+      if (ev.isInsert()) {
+        processOverlaps(i, ev.getDeleteEventIndex(), ev, si);
+      }
+      if (si.isDone()) {
+        break;
+      }
+    }
+  }
+
+  private void processOverlaps(int start, int end, SweepLineEvent ev0, SegmentIntersector si)
+  {
+    MonotoneChain mc0 = (MonotoneChain) ev0.getObject();
+    /**
+     * Since we might need to test for self-intersections,
+     * include current INSERT event object in list of event objects to test.
+     * Last index can be skipped, because it must be a Delete event.
+     */
+    for (int i = start; i < end; i++ ) {
+      SweepLineEvent ev1 = (SweepLineEvent) events.get(i);
+      if (ev1.isInsert()) {
+        MonotoneChain mc1 = (MonotoneChain) ev1.getObject();
+        // don't compare edges in same group, if labels are present
+        if (! ev0.isSameLabel(ev1)) {
+          mc0.computeIntersections(mc1, si);
+          nOverlaps++;
+        }
+      }
+    }
+  }
+}

--- a/modules/lab/src/main/java/org/locationtech/jtslab/noding/anchorpoint/AnchorPoint.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/noding/anchorpoint/AnchorPoint.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2019 Felix Obermaier
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jtslab.noding.anchorpoint;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.LineSegment;
+import org.locationtech.jts.noding.NodedSegmentString;
+
+/**
+ * An anchor point
+ */
+class AnchorPoint {
+
+  /** The actual anchor point */
+  private final Coordinate anchorPoint;
+  /** the maximum distance for coordinates to test to {@linkplain #anchorPoint}. */
+  private final double maxAnchorDistance;
+  /** An envelope around {@linkplain #anchorPoint} */
+  private final Envelope anchorEnvelope;
+  /** A utility value to pre-exclude points from more expensive tests. */
+  private final double maxAnchorDistanceDiag;
+  private final boolean fromVertex;
+
+  private int usedCounter;
+  /**
+   * Creates an instance of this class
+   *
+   * @param anchorPoint       the anchor point coordinate
+   * @param maxAnchorDistance the maximum distance for coordinates to be anchored to {@linkplain #anchorPoint}.
+   */
+  public AnchorPoint(Coordinate anchorPoint, double maxAnchorDistance) {
+    this(anchorPoint, maxAnchorDistance, false);
+  }
+
+  public AnchorPoint(Coordinate anchorPoint, double maxAnchorDistance, boolean notUsed) {
+    this.anchorPoint = anchorPoint;
+    this.maxAnchorDistance = maxAnchorDistance;
+    this.maxAnchorDistanceDiag = maxAnchorDistance * Math.sqrt(2);
+
+    this.anchorEnvelope = new Envelope(anchorPoint);
+    this.anchorEnvelope.expandBy(maxAnchorDistance);
+    this.fromVertex = notUsed;
+
+    usedCounter = notUsed ? 0 : 1;
+  }
+
+  /**
+   * Adds a new node (equal to the {@linkplain #anchorPoint} to the specified segment
+   * if the segment is close enough to {@linkplain #anchorPoint}
+   *
+   * @param nodedSegmentString  a string of segments
+   * @param index   the index of the segment to test
+   * @return true if a node was added to the segment
+   */
+  public boolean addAnchoredNode(NodedSegmentString nodedSegmentString, int index) {
+
+    Coordinate p0 = nodedSegmentString.getCoordinate(index);
+    Coordinate p1 = nodedSegmentString.getCoordinate(index + 1);
+
+    final LineSegment ls =  new LineSegment(p0, p1);
+    double distance = ls.distancePerpendicular(this.anchorPoint);
+    if (distance > this.maxAnchorDistanceDiag)
+      return false;
+
+    double projectFactor = ls.projectionFactor(this.anchorPoint);
+    if (0d <= projectFactor && projectFactor <= 1d) {
+      Coordinate p = ls.project(anchorPoint);
+      if (this.anchorEnvelope.intersects(p)) {
+        if (p.x == this.anchorEnvelope.getMaxX() ||
+            p.y == this.anchorEnvelope.getMaxY()) return false;
+
+        if (projectFactor == 0d)
+          p0.setCoordinate(this.anchorPoint);
+
+        if (projectFactor == 1d)
+          p1.setCoordinate(this.anchorPoint);
+
+        nodedSegmentString.addIntersection(this.anchorPoint, index);
+        usedCounter++;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the anchor point coordinate.
+   *
+   * @return a coordinate
+   */
+  public Coordinate getCoordinate() { return this.anchorPoint; }
+
+  /**
+   * Gets a value indicating that this {@linkplain #anchorPoint} has been used for noding
+   *
+   * @return a distance threshold
+   */
+  public boolean getUsed() { return this.usedCounter > 0; }
+
+  /**
+   * Gets a value indicating that this {@linkplain #anchorPoint} was created by a vertex
+   *
+   * @return a distance threshold
+   */
+  public boolean getFromVertex() { return this.fromVertex; }
+
+  /**
+   * Gets the distance value that coordinates must have to
+   * {@linkplain #anchorPoint} <b>not</b> be anchored.
+   *
+   * @return a distance threshold
+   */
+  public double getMaxAnchorDistance() { return this.maxAnchorDistance; }
+
+}

--- a/modules/lab/src/main/java/org/locationtech/jtslab/noding/anchorpoint/AnchorPointNoder.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/noding/anchorpoint/AnchorPointNoder.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2019 Felix Obermaier
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jtslab.noding.anchorpoint;
+
+import org.locationtech.jts.algorithm.LineIntersector;
+import org.locationtech.jts.algorithm.RobustLineIntersector;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.noding.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A noder implementation based on {@linkplain AnchorPoint}.
+ */
+class AnchorPointNoder
+  implements Noder
+{
+  final PrecisionModel precisionModel;
+  final LineIntersector lineIntersector;
+  final double scaleFactor;
+
+  private MCIndexNoder lastNoder;
+  private Collection lastNodedSegStrings;
+  private AnchorPointSnapper lastAnchorPointSnapper;
+
+  /**
+   * Creates an instance of this class
+   *
+   * @param precisionModel the precision model to use for the underlying {@linkplain LineIntersector}.
+   */
+  public AnchorPointNoder(PrecisionModel precisionModel)
+  {
+    this.precisionModel = precisionModel;
+    this.lineIntersector = new RobustLineIntersector();
+    this.lineIntersector.setPrecisionModel(precisionModel);
+
+    this.scaleFactor = precisionModel.isFloating() ? 1E10 : precisionModel.getScale();
+  }
+
+  @Override
+  public void computeNodes(Collection segStrings) {
+
+    Collection current = segStrings;
+
+    MCIndexNoder currentNoder = new MCIndexNoder();
+    double maxAnchorDistance = 1d / (this.scaleFactor*2);
+
+    AnchorPointSnapper apx = new AnchorPointSnapper(segStrings, currentNoder.getIndex(), maxAnchorDistance);
+
+    // compute intersections
+    List intersections = findInteriorIntersections(current, currentNoder, this.lineIntersector);
+    anchor(apx, current, intersections);
+
+    this.lastNoder = currentNoder;
+    this.lastAnchorPointSnapper = apx;
+    this.lastNodedSegStrings = current;
+  }
+
+  @Override
+  public Collection getNodedSubstrings() {
+    return NodedSegmentString.getNodedSubstrings(this.lastNodedSegStrings);
+  }
+
+  /**
+   *
+   *
+   * @return a list of anchor points
+   * @param onlyIntersection
+   */
+  List<AnchorPoint> getAnchorPoints(boolean onlyIntersection){
+    if (this.lastAnchorPointSnapper == null)
+      return new ArrayList<>();
+    return this.lastAnchorPointSnapper.getAnchorPoints(onlyIntersection);
+  }
+
+  private void anchor(AnchorPointSnapper aps, Collection segStrings, List intersections)
+  {
+    computeIntersectionAnchors(aps, intersections);
+    computeVertexAnchors(aps, segStrings);
+  }
+
+  private void computeIntersectionAnchors(AnchorPointSnapper aps, List intersections) {
+    for (Iterator it = intersections.iterator(); it.hasNext(); ) {
+      Coordinate intersection = (Coordinate) it.next();
+      aps.snap(intersection);
+    }
+  }
+
+  /**
+   * Snaps segments to all vertices.
+   *
+   * @param edges the list of segment strings to snap together
+   */
+  private void computeVertexAnchors(AnchorPointSnapper aps, Collection edges)
+  {
+    for (Iterator i0 = edges.iterator(); i0.hasNext(); ) {
+      NodedSegmentString edge0 = (NodedSegmentString) i0.next();
+      computeVertexAnchors(aps, edge0);
+    }
+  }
+
+  /**
+   * Snaps segments to the vertices of a Segment String.
+   */
+  private void computeVertexAnchors(AnchorPointSnapper aps, NodedSegmentString e)
+  {
+    Coordinate[] pts0 = e.getCoordinates();
+    for (int i = 0; i < pts0.length ; i++) {
+      boolean isNodeAdded = aps.snap(pts0[i], e, i);
+      // if a node is created for a vertex, that vertex must be noded too
+      if (isNodeAdded) {
+        e.addIntersection(pts0[i], i);
+      }
+    }
+  }
+  /**
+   * Computes all interior intersections in the collection of {@link SegmentString}s,
+   * and returns their {@link Coordinate}s.
+   *
+   * Does NOT node the segStrings.
+   *
+   * @return a list of Coordinates for the intersections
+   */
+  private List findInteriorIntersections(Collection segStrings, MCIndexNoder noder, LineIntersector li)
+  {
+    InteriorIntersectionFinderAdder intFinderAdder = new InteriorIntersectionFinderAdder(li);
+    noder.setSegmentIntersector(intFinderAdder);
+    noder.computeNodes(segStrings);
+
+    return intFinderAdder.getInteriorIntersections();
+  }
+}

--- a/modules/lab/src/main/java/org/locationtech/jtslab/noding/anchorpoint/AnchorPointSnapper.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/noding/anchorpoint/AnchorPointSnapper.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2019 Felix Obermaier
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jtslab.noding.anchorpoint;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.index.ItemVisitor;
+import org.locationtech.jts.index.SpatialIndex;
+import org.locationtech.jts.index.chain.MonotoneChain;
+import org.locationtech.jts.index.chain.MonotoneChainSelectAction;
+import org.locationtech.jts.index.kdtree.KdNode;
+import org.locationtech.jts.index.kdtree.KdTree;
+import org.locationtech.jts.index.strtree.STRtree;
+import org.locationtech.jts.noding.NodedSegmentString;
+import org.locationtech.jts.noding.SegmentString;
+
+import java.util.*;
+
+/**
+ * Anchor point snapper attempts to snap coordinates that are the result of intersection
+ * computation to already existing {@linkplain AnchorPoint}s.
+ *
+ * If that is not possible, but required, a new {@linkplain AnchorPoint} is created.
+ *
+ * @version 1.17
+ * @author Felix Obermaier
+ */
+class AnchorPointSnapper {
+
+  /** An index of {@linkplain MonotoneChain}s. */
+  final STRtree index;
+
+  /** An index of already created {@linkplain AnchorPoint}s. */
+  final KdTree ptIndex;
+
+  /**
+   * The distance coordinates must have from an {@linkplain AnchorPoint} to <b>not</b>
+   * be anchored/snapped to it.
+   * */
+  final double maxAnchorDistance;
+
+  /**
+   * Creates an instance of this class
+   * @param segStrings        A collection of segment strings
+   * @param index             the index of {@linkplain MonotoneChain}s.
+   * @param maxAnchorDistance the distance coordinates must have from an {@linkplain AnchorPoint} to <b>not</b>
+   */
+  AnchorPointSnapper(Collection segStrings, SpatialIndex index, double maxAnchorDistance) {
+    this.index = (STRtree)index;
+    this.maxAnchorDistance = maxAnchorDistance;
+    this.ptIndex = new KdTree();
+    AddVertexAnchorNodes(segStrings);
+  }
+
+  /**
+   * Fills the search anchor point index with segment string vertices.
+   * @param segStrings the segment strings
+   */
+  private void AddVertexAnchorNodes(Collection segStrings) {
+    Iterator it = segStrings.iterator();
+    while (it.hasNext()) {
+      SegmentString ss = (SegmentString)it.next();
+      for (int i = 0; i < ss.size(); i++) {
+        Coordinate c = ss.getCoordinate(i);
+        this.ptIndex.insert(c, new AnchorPoint(c, maxAnchorDistance, true));
+      }
+    }
+  }
+
+  /**
+   * Gets all  {@linkplain AnchorPoint}s used by this anchor point snapper.
+   *
+   * @param onlyIntersections return only anchor points that were created from intersections
+   */
+  public List<AnchorPoint> getAnchorPoints(boolean onlyIntersections) {
+    ArrayList<KdNode> anchorNodes = new ArrayList<>();
+    this.ptIndex.query(
+      new Envelope(Double.MIN_VALUE, Double.MAX_VALUE, Double.MIN_VALUE, Double.MAX_VALUE),
+      anchorNodes);
+
+    List<AnchorPoint> res = new ArrayList<>();
+    for (int i = 0; i < anchorNodes.size(); i++)
+    {
+      AnchorPoint ap = (AnchorPoint) anchorNodes.get(i).getData();
+      if (ap.getUsed())
+        if (!onlyIntersections || !ap.getFromVertex())
+          res.add((AnchorPoint)anchorNodes.get(i).getData());
+    }
+    return res;
+  }
+
+  /**
+   * Attempts to snap a {@linkplain Coordinate} to an {@linkplain AnchorPoint}.
+
+   * @param c the coordinate
+   *
+   * @return <pre>true</pre> if the coordinate was snapped.
+   */
+  boolean snap(Coordinate c) {
+    return snap(c, null, -1);
+  }
+
+  /**
+   * Attempts to snap a {@linkplain Coordinate} to an {@linkplain AnchorPoint}.
+
+   * @param c          the coordinate
+   * @param parentEdge the segment string that <pre>c</pre> belongs.to.
+   * @param index      the index of the segment that <pre>c</pre> is the starting point of.
+   *
+   * @return <pre>true</pre> if the coordinate was snapped.
+   */
+  boolean snap(Coordinate c, SegmentString parentEdge, int index) {
+
+    // search for anchor points
+    Envelope e = new Envelope(c);
+    e.expandBy(maxAnchorDistance);
+    List<KdNode> anchoredPoints = new ArrayList<>();
+    this.ptIndex.query(e, anchoredPoints);
+
+    // get or create anchor point
+    boolean newAnchorPoint = anchoredPoints.size() == 0;
+    if (newAnchorPoint) {
+      anchoredPoints.add(new KdNode(c, new AnchorPoint(c, maxAnchorDistance)));
+    } else {
+      anchoredPoints.sort(new AnchorPointDistanceComparator(c));
+    }
+
+    for (int i = 0; i < anchoredPoints.size(); i++) {
+      AnchorPoint ap = (AnchorPoint) anchoredPoints.get(i).getData();
+      final AnchorSnapAction asa = new AnchorSnapAction(ap, parentEdge, index);
+      this.index.query(e, new ItemVisitor() {
+        public void visitItem(Object item) {
+          MonotoneChain testChain = (MonotoneChain) item;
+          testChain.select(e, asa);
+        }
+      });
+
+      // if the anchor point was not in the index before, add it now.
+      if (asa.isNodeAdded() && newAnchorPoint)
+        ptIndex.insert(c, ap);
+
+      if (asa.isNodeAdded())
+      {
+        c.setCoordinate(ap.getCoordinate());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static class AnchorPointDistanceComparator implements Comparator<KdNode> {
+
+    private final Coordinate c;
+
+    public AnchorPointDistanceComparator(Coordinate c) {
+      this.c = c;
+    }
+
+    public int compare(KdNode kd1, KdNode kd2) {
+      double distToKd1 = c.distance(kd1.getCoordinate());
+      double distToKd2 = c.distance(kd2.getCoordinate());
+
+      if (distToKd1 < distToKd2) return -1;
+      if (distToKd1 > distToKd2) return 1;
+      return 0;
+    }
+  }
+
+  static class AnchorSnapAction extends MonotoneChainSelectAction {
+
+    private final AnchorPoint anchorPoint;
+    private final SegmentString parentEdge;
+    private final int coordinateIndex;
+    private boolean isNodeAdded;
+
+    public AnchorSnapAction(AnchorPoint anchorPoint, SegmentString parentEdge, int coordinateIndex) {
+      this.anchorPoint = anchorPoint;
+      this.parentEdge = parentEdge;
+      this.coordinateIndex = coordinateIndex;
+    }
+
+    boolean isNodeAdded() {return this.isNodeAdded;}
+
+    public void select(MonotoneChain mc, int startIndex) {
+      NodedSegmentString ss = (NodedSegmentString) mc.getContext();
+
+      if (this.parentEdge != null){
+        if (ss == parentEdge && startIndex == this.coordinateIndex)
+          return;
+      }
+
+      this.isNodeAdded = anchorPoint.addAnchoredNode(ss, startIndex);
+    }
+  }
+}

--- a/modules/lab/src/main/java/org/locationtech/jtslab/noding/anchorpoint/GeometryNoder.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/noding/anchorpoint/GeometryNoder.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ * Portions
+ * Copyright (c) 2019 Felix Obermaier
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.locationtech.jtslab.noding.anchorpoint;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.util.LinearComponentExtracter;
+import org.locationtech.jts.noding.NodedSegmentString;
+import org.locationtech.jts.noding.NodingValidator;
+import org.locationtech.jts.noding.SegmentString;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Nodes the linework in a list of {@link Geometry}s using anchor points
+ * to a given {@link PrecisionModel}.
+ * <p>
+ * The input coordinates are expected to be rounded
+ * to the given precision model.
+ * This class does not perform that function.
+ * <code>GeometryPrecisionReducer</code> may be used to do this.
+ * <p>
+ * This class does <b>not</b> dissolve the output linework,
+ * so there may be duplicate linestrings in the output.  
+ * Subsequent processing (e.g. polygonization) may require
+ * the linework to be unique.  Using <code>UnaryUnion</code> is one way
+ * to do this (although this is an inefficient approach).
+ * 
+ * @version 1.17
+ * @author Martin Davis, Felix Obermaier
+ */
+public class GeometryNoder
+{
+  private final PrecisionModel pm;
+  private boolean checkValidity = false;
+  private AnchorPointNoder lastAnchorPointNoder;
+
+  /**
+   * Creates a new noder which snap-rounds to a grid specified
+   * by the given {@link PrecisionModel}.
+   * 
+   * @param pm the precision model for the grid to snap-round to
+   */
+  public GeometryNoder(PrecisionModel pm) {
+    this.pm = pm;
+  }
+
+  /**
+   * Sets whether noding validity is checked after noding is performed.
+   * 
+   * @param checkValidity
+   */
+  void setValidate(boolean checkValidity)
+  {
+  	this.checkValidity = checkValidity;
+  }
+  
+  /**
+   * Nodes the linework of a set of Geometrys using SnapRounding. 
+   * 
+   * @param geoms a Collection of Geometrys of any type
+   * @return a List of LineStrings representing the noded linework of the input
+   */
+  public List node(Collection geoms)
+  {
+    List segStrings = toSegmentStrings(extractLines(geoms));
+    AnchorPointNoder apn = new AnchorPointNoder(pm);
+    apn.computeNodes(segStrings);
+    Collection nodedLines = apn.getNodedSubstrings();
+
+    //TODO: improve this to check for full snap-rounded correctness
+    if (this.checkValidity) {
+      NodingValidator nv = new NodingValidator(nodedLines);
+      nv.checkValid();
+    }
+
+    this.lastAnchorPointNoder = apn;
+
+    // get geometry factory
+    Geometry geom0 = (Geometry) geoms.iterator().next();
+    return toLineStrings(nodedLines, geom0.getFactory());
+  }
+
+  private List toLineStrings(Collection segStrings, GeometryFactory factory)
+  {
+    List lines = new ArrayList();
+    for (Iterator it = segStrings.iterator(); it.hasNext(); ) {
+      SegmentString ss = (SegmentString) it.next();
+      // skip collapsed lines
+      if (ss.size() < 2)
+      	continue;
+      lines.add(factory.createLineString(ss.getCoordinates()));
+    }
+    return lines;
+  }
+
+  private static List extractLines(Collection geoms)
+  {
+    List lines = new ArrayList();
+    LinearComponentExtracter lce = new LinearComponentExtracter(lines);
+    for (Iterator it = geoms.iterator(); it.hasNext(); ) {
+      Geometry geom = (Geometry) it.next();
+      geom.apply(lce);
+    }
+    return lines;
+  }
+
+  private static List toSegmentStrings(Collection lines)
+  {
+    List segStrings = new ArrayList();
+    for (Iterator it = lines.iterator(); it.hasNext(); ) {
+      LineString line = (LineString) it.next();
+      segStrings.add(new NodedSegmentString(line.getCoordinates(), null));
+    }
+    return segStrings;
+  }
+
+  /**
+   *
+   * @return
+   */
+  public List<AnchorPoint> getLastAnchorPoints(boolean onlyIntersection) {
+    if (lastAnchorPointNoder == null)
+      return new ArrayList<>();
+    return this.lastAnchorPointNoder.getAnchorPoints(onlyIntersection);
+  }
+}

--- a/modules/lab/src/test/java/org/locationtech/jtslab/algorithm/AnchorPointRobustLineIntersectorTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jtslab/algorithm/AnchorPointRobustLineIntersectorTest.java
@@ -95,7 +95,7 @@ public class AnchorPointRobustLineIntersectorTest extends TestCase
   private static final int numRotations = 10;
 
   private static final Coordinate p0 = new Coordinate(-rnd.nextDouble() * 1E10, rnd.nextDouble());
-  private static final Coordinate p1 = new Coordinate(rnd.nextDouble()*1e10, p0.y);
+  private static final Coordinate p1 = new Coordinate(rnd.nextDouble()*1E10, p0.y);
 
 
   private static int computeIntersectionPoints(LineIntersector li) {
@@ -107,11 +107,13 @@ public class AnchorPointRobustLineIntersectorTest extends TestCase
     Coordinate p0s[] = new Coordinate[numRotations];
     Coordinate p1s[] = new Coordinate[numRotations];
 
+    Coordinate tmpP0 = p0.copy();
+    Coordinate tmpP1 = p1.copy();
     for (int i = 0; i < numRotations; i++) {
-      p0s[i] = p0.copy();
-      p1s[i] = p1.copy();
-      af.transform(p0, p0);
-      af.transform(p1, p1);
+      p0s[i] = tmpP0.copy();
+      p1s[i] = tmpP1.copy();
+      af.transform(tmpP0, tmpP0);
+      af.transform(tmpP1, tmpP1);
     }
 
     for (int i = 0; i < numRotations; i++)

--- a/modules/lab/src/test/java/org/locationtech/jtslab/algorithm/AnchorPointRobustLineIntersectorTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jtslab/algorithm/AnchorPointRobustLineIntersectorTest.java
@@ -2,11 +2,20 @@ package org.locationtech.jtslab.algorithm;
 
 import junit.framework.TestCase;
 import junit.textui.TestRunner;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.CoordinateXY;
-import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.algorithm.LineIntersector;
+import org.locationtech.jts.algorithm.RobustLineIntersector;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.util.AffineTransformation;
+import org.locationtech.jts.index.kdtree.KdNode;
 import org.locationtech.jts.index.kdtree.KdTree;
+import org.locationtech.jts.operation.overlay.OverlayOp;
+import org.locationtech.jts.util.Assert;
 import org.locationtech.jtslab.noding.anchorpoint.AnchorPointNodingTest;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 public class AnchorPointRobustLineIntersectorTest extends TestCase
 {
@@ -17,7 +26,7 @@ public class AnchorPointRobustLineIntersectorTest extends TestCase
 
   public AnchorPointRobustLineIntersectorTest(String name) { super(name); }
 
-  public void test1() {
+  public void testIntersectionAnchorToVertex() {
 
     Coordinate p0 = new Coordinate(0, 0);
     Coordinate p1 = new Coordinate(10, 0);
@@ -29,26 +38,151 @@ public class AnchorPointRobustLineIntersectorTest extends TestCase
 
     li.setPrecisionModel(new PrecisionModel(10));
     Coordinate res = li.intersection(p0, p1, q0, q1);
-    assertEquals(p1, res);
+    assertEquals("equal", p1, res);
+    assertTrue("reference equal", p1 == res);
+
+    List apNodes = li.getAnchorPoints().query(new Envelope(res));
+    assertEquals(1, apNodes.size());
+    assertTrue(((AnchorPoint)((KdNode)apNodes.get(0)).getData()).getFromVertex());
+
   }
 
-  public void test2() {
+  public void testReuseAnchorPoint() {
 
     Coordinate p0 = new Coordinate(0, 0);
     Coordinate p1 = new Coordinate(10, 0);
     Coordinate q0 = new Coordinate(8, 5);
     Coordinate q1 = new Coordinate(7, -5);
 
+    Coordinate r0 = new Coordinate(7.5, 0);
     AnchorPointRobustLineIntersector li = new AnchorPointRobustLineIntersector(1);
     AddVertexAnchorPoints(li.getAnchorPoints(),new Coordinate[] { p0, p1, q0, q1 });
 
     li.setPrecisionModel(new PrecisionModel(10));
     Coordinate res = li.intersection(p0, p1, q0, q1);
-    assertEquals(new Coordinate(7.5, 0), res);
+    assertEquals("equal", r0, res);
+
+    List apNodes = li.getAnchorPoints().query(new Envelope(res));
+    assertEquals(1, apNodes.size());
+    assertTrue(!((AnchorPoint)((KdNode)apNodes.get(0)).getData()).getFromVertex());
+
+    Coordinate q2 = new Coordinate(8, -5);
+    AddVertexAnchorPoints(li.getAnchorPoints(), new Coordinate[] {q2});
+    Coordinate res2 = li.intersection(p0, p1, q0, q2);
+    assertTrue("reference equal", res == res2);
   }
 
   private static void AddVertexAnchorPoints(KdTree res, Coordinate[] coordinates) {
     for (int i = 0; i < coordinates.length; i++)
       res.insert(coordinates[i], new AnchorPoint(coordinates[i], true));
+  }
+
+  public void testIntersectionOfLongLinesRotatedAroundCommonCenter()
+  {
+    LineIntersector rli = new RobustLineIntersector();
+    rli.setPrecisionModel(new PrecisionModel());
+    int numIntersectionsRli1  = computeIntersectionPoints(rli);
+    rli.setPrecisionModel(new PrecisionModel(1E4));
+    int numIntersectionsRli2  = computeIntersectionPoints(rli);
+    int numIntersectionsApLi = computeIntersectionPoints(new AnchorPointRobustLineIntersector(1E-5));
+    assertTrue(numIntersectionsRli1 > numIntersectionsRli2);
+    assertEquals(1, numIntersectionsApLi);
+    assertEquals(1, numIntersectionsRli2);
+
+  }
+
+  private static final Random rnd = new Random(17);
+  private static final int numRotations = 10;
+
+  private static final Coordinate p0 = new Coordinate(-rnd.nextDouble() * 1E10, rnd.nextDouble());
+  private static final Coordinate p1 = new Coordinate(rnd.nextDouble()*1e10, p0.y);
+
+
+  private static int computeIntersectionPoints(LineIntersector li) {
+
+    Set<Coordinate> coordinates = new HashSet<>();
+
+    AffineTransformation af = AffineTransformation.rotationInstance(1d / 18d * Math.PI, 0.5 * (p0.x+p1.x), p0.y);
+
+    Coordinate p0s[] = new Coordinate[numRotations];
+    Coordinate p1s[] = new Coordinate[numRotations];
+
+    for (int i = 0; i < numRotations; i++) {
+      p0s[i] = p0.copy();
+      p1s[i] = p1.copy();
+      af.transform(p0, p0);
+      af.transform(p1, p1);
+    }
+
+    for (int i = 0; i < numRotations; i++)
+      for (int j = 0; j < numRotations; j++) {
+        if (i == j) continue;
+        li.computeIntersection(p0s[i], p1s[i], p0s[j], p1s[j]);
+        assertTrue("proper intersection", li.hasIntersection() && li.isProper());
+        Coordinate c = li.getIntersection(0);
+        if (!coordinates.contains(c))
+          coordinates.add(c);
+      }
+    return coordinates.size();
+  }
+
+  public void testUnionOfLongLinesRotatedAroundCommonCenter() {
+
+    RobustLineIntersector rli = new RobustLineIntersector();
+    try { computeUnions(rli, new PrecisionModel()); }
+    catch (TopologyException tpe)
+    { System.out.println("Union with RobustLineIntersector and floating PrecisionModel failed"); }
+
+    try { computeUnions(rli, new PrecisionModel(1e2)); }
+    catch (TopologyException tpe )
+    { System.out.println("Union with RobustLineIntersector and PrecisionModel(1E2) failed"); }
+
+    Geometry g = null;
+    double minDistanceToAnchorPoint = 1E-10;
+
+    while (true)
+    {
+      g = null;
+      try { g = computeUnions(new AnchorPointRobustLineIntersector(minDistanceToAnchorPoint), new PrecisionModel()); }
+      catch (Exception e)
+      { System.out.println("Union with AnchorPointRobustLineIntersector (mapd="+ minDistanceToAnchorPoint +") failed"); }
+
+      // check if ok
+      if (g != null) {
+        System.out.println("Union with AnchorPointRobustLineIntersector (mapd="+ minDistanceToAnchorPoint +"): " + g.getNumGeometries());
+        if (g.getNumGeometries() == 20)
+          break;
+      }
+
+      // increase min. distance to anchor point.
+      minDistanceToAnchorPoint *= 10;
+
+      if (minDistanceToAnchorPoint > 1)
+        fail("Union with AnchorPointRobustLineIntersector failed");
+    }
+    assertEquals("number of geometries", 20, g.getNumGeometries());
+
+    System.out.println("Union with AnchorPointRobustLineIntersector (mapd="+ minDistanceToAnchorPoint + ") passed");
+  }
+
+  private static Geometry computeUnions(LineIntersector li, PrecisionModel pm)
+  {
+    li.setPrecisionModel(pm);
+    GeometryFactory f = new GeometryFactory(pm);
+
+    Coordinate q0 = p0.copy();
+    Coordinate q1 = p1.copy();
+    AffineTransformation af = AffineTransformation.rotationInstance(1d / 18d * Math.PI, 0.5 * (p0.x+p1.x), p0.y);
+
+    Geometry g = f.createLineString(new Coordinate[] {q0, q1});
+    for (int i = 1; i < numRotations; i++) {
+      q0 = q0.copy();
+      q1 = q1.copy();
+      af.transform(q0, q0);
+      af.transform(q1, q1);
+      Geometry gtmp = f.createLineString(new Coordinate[] {q0, q1});
+      g = OverlayOp.overlayOp(li, g, gtmp, OverlayOp.UNION);
+    }
+    return g;
   }
 }

--- a/modules/lab/src/test/java/org/locationtech/jtslab/algorithm/AnchorPointRobustLineIntersectorTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jtslab/algorithm/AnchorPointRobustLineIntersectorTest.java
@@ -1,0 +1,54 @@
+package org.locationtech.jtslab.algorithm;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.index.kdtree.KdTree;
+import org.locationtech.jtslab.noding.anchorpoint.AnchorPointNodingTest;
+
+public class AnchorPointRobustLineIntersectorTest extends TestCase
+{
+
+  public static void main(String[] args) {
+    TestRunner.run(AnchorPointNodingTest.class);
+  }
+
+  public AnchorPointRobustLineIntersectorTest(String name) { super(name); }
+
+  public void test1() {
+
+    Coordinate p0 = new Coordinate(0, 0);
+    Coordinate p1 = new Coordinate(10, 0);
+    Coordinate q0 = new Coordinate(8, 5);
+    Coordinate q1 = new Coordinate(7, -5);
+
+    AnchorPointRobustLineIntersector li = new AnchorPointRobustLineIntersector(3);
+    AddVertexAnchorPoints(li.getAnchorPoints(),new Coordinate[] { p0, p1, q0, q1 });
+
+    li.setPrecisionModel(new PrecisionModel(10));
+    Coordinate res = li.intersection(p0, p1, q0, q1);
+    assertEquals(p1, res);
+  }
+
+  public void test2() {
+
+    Coordinate p0 = new Coordinate(0, 0);
+    Coordinate p1 = new Coordinate(10, 0);
+    Coordinate q0 = new Coordinate(8, 5);
+    Coordinate q1 = new Coordinate(7, -5);
+
+    AnchorPointRobustLineIntersector li = new AnchorPointRobustLineIntersector(1);
+    AddVertexAnchorPoints(li.getAnchorPoints(),new Coordinate[] { p0, p1, q0, q1 });
+
+    li.setPrecisionModel(new PrecisionModel(10));
+    Coordinate res = li.intersection(p0, p1, q0, q1);
+    assertEquals(new Coordinate(7.5, 0), res);
+  }
+
+  private static void AddVertexAnchorPoints(KdTree res, Coordinate[] coordinates) {
+    for (int i = 0; i < coordinates.length; i++)
+      res.insert(coordinates[i], new AnchorPoint(coordinates[i], true));
+  }
+}

--- a/modules/lab/src/test/java/org/locationtech/jtslab/noding/anchorpoint/AnchorPointNodingTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jtslab/noding/anchorpoint/AnchorPointNodingTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.locationtech.jtslab.noding.anchorpoint;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.io.WKTReader;
+
+import java.util.*;
+
+
+/**
+ * Test AnchorPoint noding
+ *
+ * @version 1.17
+ */
+public class AnchorPointNodingTest extends TestCase {
+
+  private static final double SNAP_TOLERANCE = 1.0;
+  private static final boolean verbose = true;
+
+  private final WKTReader wktReader = new WKTReader();
+
+  public static void main(String[] args) {
+    TestRunner.run(AnchorPointNodingTest.class);
+  }
+
+  public AnchorPointNodingTest(String name) {
+    super(name);
+  }
+
+  public void testPolyWithCloseNode() {
+    String[] polyWithCloseNode = {
+      "POLYGON ((20 0, 20 160, 140 1, 160 160, 160 1, 20 0))"
+    };
+    runAnchorNoding(polyWithCloseNode);
+    runComparison(polyWithCloseNode);
+  }
+
+  public void testLineStringLongShort() {
+    String[] geoms = {
+      "LINESTRING (0 0, 2 0)",
+      "LINESTRING (0 0, 10 -1)"
+    };
+    runAnchorNoding(geoms);
+    runComparison(geoms);
+  }
+
+  public void testBadLines1() {
+    String[] badLines1 = {
+      "LINESTRING ( 171 157, 175 154, 170 154, 170 155, 170 156, 170 157, 171 158, 171 159, 172 160, 176 156, 171 156, 171 159, 176 159, 172 155, 170 157, 174 161, 174 156, 173 156, 172 156 )"
+    };
+    runAnchorNoding(badLines1);
+    runComparison(badLines1);
+  }
+
+  public void testBadLines2() {
+    String[] badLines2 = {
+      "LINESTRING ( 175 222, 176 222, 176 219, 174 221, 175 222, 177 220, 174 220, 174 222, 177 222, 175 220, 174 221 )"
+    };
+    runAnchorNoding(badLines2);
+    runComparison(badLines2);
+  }
+
+  public void testCollapse1() {
+    String[] collapse1 = {
+      "LINESTRING ( 362 177, 375 164, 374 164, 372 161, 373 163, 372 165, 373 164, 442 58 )"
+    };
+    runAnchorNoding(collapse1);
+    runComparison(collapse1);
+  }
+
+  public void testCollapse2() {
+    String[] collapse2 = {
+      "LINESTRING ( 393 175, 391 173, 390 175, 391 174, 391 173 )"
+    };
+    runAnchorNoding(collapse2);
+    runComparison(collapse2);
+  }
+
+  public void testBadNoding1() {
+    String[] badNoding1 = {
+      "LINESTRING ( 76 47, 81 52, 81 53, 85 57, 88 62, 89 64, 57 80, 82 55, 101 74, 76 99, 92 67, 94 68, 99 71, 103 75, 139 111 )"
+    };
+    runAnchorNoding(badNoding1);
+    runComparison(badNoding1);
+  }
+
+  public void testBadNoding1Extract() {
+    String[] badNoding1Extract = {
+      "LINESTRING ( 82 55, 101 74 )",
+      "LINESTRING ( 94 68, 99 71 )",
+      "LINESTRING ( 85 57, 88 62 )"
+    };
+    runAnchorNoding(badNoding1Extract);
+    runComparison(badNoding1Extract);
+  }
+
+  public void testBadNoding1ExtractShift() {
+    String[] badNoding1ExtractShift = {
+      "LINESTRING ( 0 0, 19 19 )",
+      "LINESTRING ( 12 13, 17 16 )",
+      "LINESTRING ( 3 2, 6 7 )"
+    };
+    runAnchorNoding(badNoding1ExtractShift);
+    runComparison(badNoding1ExtractShift);
+  }
+
+  public void testGeos1() {
+
+  String[] wkt = {"LINESTRING ("
+    + "-1677607.6366504875 -588231.47100446,"
+    + "-1674050.1010869485 -587435.2186255794,"
+    + "-1670493.6527468169 -586636.7948791061,"
+    + "-1424286.3681743187 -525586.1397894835,"
+    + "-1670493.6527468169 -586636.7948791061,"
+    + "-1674050.1010869485 -587435.2186255795,"
+    + "-1677607.6366504875 -588231.47100446)"};
+
+    runAnchorNoding(wkt, new PrecisionModel(1E5));
+    runComparison(wkt);
+    runAnchorNoding(wkt, new PrecisionModel(1.11E10));
+    runComparison(wkt);
+  }
+
+  public void testGeos2() {
+    String[] wkt = {"LINESTRING ("
+      + "55121.54481117887 42694.49730855581,"
+      + "55121.54481117887 42694.4973085558,"
+      + "55121.458748617406 42694.419143944244,"
+      + "55121.54481117887 42694.49730855581 )"};
+
+    runAnchorNoding(wkt, new PrecisionModel(1.E5));
+    runComparison(wkt, new PrecisionModel(1.E5));
+
+    runAnchorNoding(wkt, new PrecisionModel(1.1131949079327356E11));
+    runComparison(wkt, new PrecisionModel(1.1131949079327356E11));
+  }
+
+  private void runAnchorNoding(String[] wkt) {
+    runAnchorNoding(wkt, new PrecisionModel(SNAP_TOLERANCE));
+  }
+
+  private void runAnchorNoding(String[] wkt, PrecisionModel pm)
+  {
+    List geoms = fromWKT(wkt);
+    GeometryNoder noder = new GeometryNoder(pm);
+    noder.setValidate(true);
+    List nodedLines = null;
+    if (verbose) {
+      for (int i = 0; i < geoms.size(); i++)
+        System.out.println(geoms.get(i));
+    }
+
+    try {
+      nodedLines = noder.node(geoms);
+      if (verbose)
+        System.out.println(new GeometryFactory().buildGeometry(nodedLines));
+    }
+    catch (RuntimeException reV) {
+      try {
+        noder.setValidate(false);
+        nodedLines = noder.node(geoms);
+        if (verbose) {
+          System.out.println("Without noding validation:");
+          System.out.println(new GeometryFactory().buildGeometry(nodedLines));
+        }
+      }
+      catch (RuntimeException reNV) {
+      }
+      Assert.fail("noding validation failed:\n" + reV.toString());
+    }
+    if (verbose)
+      System.out.println();
+
+    assertTrue("all anchored", areAnchored(nodedLines, noder.getLastAnchorPoints(true)));
+  }
+
+  private void runComparison(String[] wkt) {
+    runComparison(wkt, new PrecisionModel(SNAP_TOLERANCE));
+  }
+
+  private void runComparison(String[] wkt, PrecisionModel pm)
+  {
+    List geoms = fromWKT(wkt);
+
+    org.locationtech.jtslab.noding.anchorpoint.GeometryNoder noder1 =
+      new org.locationtech.jtslab.noding.anchorpoint.GeometryNoder(pm);
+
+    org.locationtech.jts.noding.snapround.GeometryNoder noder2 =
+      new org.locationtech.jts.noding.snapround.GeometryNoder(pm);
+
+    List nodedLines1 = noder1.node(geoms);
+    List nodedLines2 = noder2.node(geoms);
+
+    GeometryFactory factory = ((Geometry)geoms.get(0)).getFactory();
+    Geometry geom1 = factory.buildGeometry(nodedLines1);
+    Geometry geom2 = factory.buildGeometry(nodedLines2);
+
+    Geometry diff = geom1.difference(geom2);
+    if (diff.isEmpty() || nodedLines1.size() != nodedLines2.size()) return;
+
+    System.out.println("Input:");
+    for (int i = 0; i < geoms.size(); i++)
+      System.out.println(geoms.get(i));
+
+    System.out.println("\nSnapRound:");
+    System.out.println(geom2.toText());
+    for (int i = 0; i < nodedLines2.size(); i++)
+      System.out.println(nodedLines2.get(i));
+
+    System.out.println("\nAnchorPoint:");
+    System.out.println(geom1.toText());
+    for (int i = 0; i < nodedLines1.size(); i++)
+      System.out.println(nodedLines1.get(i));
+
+  }
+
+  private List fromWKT(String[] wkts)
+  {
+    List geomList = new ArrayList();
+    if (wkts == null || wkts.length == 0)
+      return geomList;
+
+
+    for (int i = 0; i < wkts.length; i++) {
+      try {
+        geomList.add(wktReader.read(wkts[i]));
+      }
+      catch (Exception ex) {
+        ex.printStackTrace();
+      }
+    }
+    return geomList;
+  }
+
+  private static boolean areAnchored(Collection lines, List<AnchorPoint> anchorPoints)
+  {
+    Iterator it = lines.iterator();
+    while(it.hasNext()) {
+      LineString line = (LineString) it.next();
+      for (int j = 0; j < anchorPoints.size(); j++) {
+        if (!areAnchored(line, anchorPoints.get(j)))
+          return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean areAnchored(LineString line, AnchorPoint anchorPoint) {
+    CoordinateSequence seq = line.getCoordinateSequence();
+    for (int i = 0; i < seq.size(); i++)
+    {
+      Coordinate c = seq.getCoordinate(i);
+      double d = c.distance(anchorPoint.getCoordinate());
+      if (d > anchorPoint.getMaxAnchorDistance()) continue;
+      if (d != 0d) {
+        if (verbose) {
+          System.out.println("areAnchored fails:");
+          System.out.println(line.toText());
+          System.out.println("with");
+          System.out.println(anchorPoint.getCoordinate());
+          System.out.println("  at index = " + i + " => " + line.getPointN(i));
+          System.out.println("  distance = " + d);
+        }
+        return false;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
An `AnchorPoint` is a coordinate that has already has been determined and is known to the process. It is kept in a `KdTree` and retrieved and reused during further computation.

This PR adds `AnchorPoint` based
* noding and 
* intersection computation

to the jts-lab module.