### PR TITLE
Fix LinearLocation::isEndpoint for not-normalized locations [jts-core] [bug]

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
@@ -444,7 +444,7 @@ public class LinearLocation
     int nseg = lineComp.getNumPoints() - 1;
     // if not an endpoint can be returned directly
     if (segmentIndex < nseg) return this;
-    return new LinearLocation(componentIndex, nseg, 1.0, false);
+    return new LinearLocation(componentIndex, nseg - 1, 1.0, false);
   }
   
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
@@ -420,7 +420,7 @@ public class LinearLocation
     // check for endpoint
     int nseg = lineComp.getNumPoints() - 1;
     return segmentIndex >= nseg
-        || (segmentIndex == nseg && segmentFraction >= 1.0);
+        || (segmentIndex == nseg - 1 && segmentFraction >= 1.0);
   }
   
   /**


### PR DESCRIPTION
The second condition was never actually evaluated:
https://github.com/locationtech/jts/blob/67fcc3d6f9b20cb3eecd29560f6fe9e5061804e8/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java#L422-L423

Now if the location refers to the second to last `segmentIndex` but with `segmentFraction >= 1.0` it's also considered endpoint.