### PR TITLE
Fix CoordinateSequencesTest.checkCoordinateAt() test for y

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateSequencesTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateSequencesTest.java
@@ -333,7 +333,7 @@ public class CoordinateSequencesTest extends TestCase {
     assertEquals("unexpected x-ordinate at pos " + pos2,
             seq1.getOrdinate(pos1, 0), seq2.getOrdinate(pos2, 0));
     assertEquals("unexpected y-ordinate at pos " + pos2,
-            seq1.getOrdinate(pos1, 0), seq2.getOrdinate(pos2, 0));
+            seq1.getOrdinate(pos1, 1), seq2.getOrdinate(pos2, 1));
 
     // check additional ordinates
     for (int j = 2; j < dim; j++) {


### PR DESCRIPTION
Looks like this was never actually testing y values... this **probably** won't reveal any existing problems, since NTS's clone has been testing Y this whole time and I've never seen issues here.