### PR TITLE
Improve performance of UniqueCoordinateFilter

### DIFF
--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -30,6 +30,7 @@ Distributions for older JTS versions can be obtained at the
 
 * Added `IndexedFacetDistance.isWithinDistance`
 * Added `OrdinateFormat` to ensure that ordinate text output is accurate and consistent
+* Improve performance of `UniqueCoordinateFilter`
 
 ### Bug Fixes
 

--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -30,7 +30,7 @@ Distributions for older JTS versions can be obtained at the
 
 * Added `IndexedFacetDistance.isWithinDistance`
 * Added `OrdinateFormat` to ensure that ordinate text output is accurate and consistent
-* Improve performance of `UniqueCoordinateFilter`
+* Improve performance of `UniqueCoordinateFilter` (#422)
 
 ### Bug Fixes
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateFilter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateFilter.java
@@ -23,8 +23,8 @@ package org.locationtech.jts.geom;
  * an example of the Gang-of-Four Visitor pattern. 
  * <p>
  * <b>Note</b>: it is not recommended to use these filters to mutate the coordinates.
- * There is no guarantee that the coordinate is the actual object stored in the geometry.
- * In particular, modified values may not be preserved if the target Geometry uses a non-default {@link CoordinateSequence}.
+ * There is no guarantee that the coordinate is the actual object stored in the source geometry.
+ * In particular, modified values may not be preserved if the source Geometry uses a non-default {@link CoordinateSequence}.
  * If in-place mutation is required, use {@link CoordinateSequenceFilter}.
  *  
  * @see Geometry#apply(CoordinateFilter)
@@ -35,8 +35,10 @@ package org.locationtech.jts.geom;
 public interface CoordinateFilter {
 
   /**
-   * Performs an operation with the <code>coord</code>.
-   * There is no guarantee that the coordinate is the actual object stored in the target geometry.
+   * Performs an operation with the provided <code>coord</code>.
+   * Note that there is no guarantee that the input coordinate 
+   * is the actual object stored in the source geometry,
+   * so changes to the coordinate object may not be persistent.
    *
    *@param  coord  a <code>Coordinate</code> to which the filter is applied.
    */

--- a/modules/core/src/main/java/org/locationtech/jts/util/UniqueCoordinateArrayFilter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/util/UniqueCoordinateArrayFilter.java
@@ -14,15 +14,17 @@
 package org.locationtech.jts.util;
 
 import java.util.ArrayList;
-import java.util.TreeSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateFilter;
 
 
 /**
- *  A {@link CoordinateFilter} that builds a set of <code>Coordinate</code>s.
- *  The set of coordinates contains no duplicate points.
+ *  A {@link CoordinateFilter} that extracts a unique array of <code>Coordinate</code>s.
+ *  The array of coordinates contains no duplicate points.
  *  It preserves the order of the input points.
  *
  *@version 1.7
@@ -44,8 +46,9 @@ public class UniqueCoordinateArrayFilter implements CoordinateFilter
     return filter.getCoordinates();
   }
   
-  TreeSet treeSet = new TreeSet();
-  ArrayList list = new ArrayList();
+  private Set<Coordinate> coordSet = new HashSet<Coordinate>();
+  // Use an auxiliary list as well in order to preserve coordinate order
+  private List<Coordinate> list = new ArrayList<Coordinate>();
 
   public UniqueCoordinateArrayFilter() { }
 
@@ -59,10 +62,12 @@ public class UniqueCoordinateArrayFilter implements CoordinateFilter
     return (Coordinate[]) list.toArray(coordinates);
   }
 
+  /**
+   * @see CoordinateFilter#filter(Coordinate)
+   */
   public void filter(Coordinate coord) {
-    if (!treeSet.contains(coord)) {
+    if (coordSet.add(coord)) {
       list.add(coord);
-      treeSet.add(coord);
     }
   }
 }


### PR DESCRIPTION
Use HashSet, and boolean return value from Set.add().
Javadoc improvements

Based on suggestions in #420.