### PR TITLE
Fix MinimjmBoundingCircle maximum diameter computation

### DIFF
--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -36,6 +36,7 @@ Distributions for older JTS versions can be obtained at the
 * Fix `PackedCoordinateSequence.Float` construction methods (#379, #381)
 * Fix bug in `Quadtree.ensureExtent` (#416)
 * Fix bugs in `LinearLocation` endpoint handling (#421)
+* Fix bug in `MinimumBoundingCircle` maximum diameter algorithm, and provide method for it
 
 ## JTS TestRunner
 

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/ConstructionFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/ConstructionFunctions.java
@@ -24,12 +24,14 @@ public class ConstructionFunctions {
   public static double minimumDiameterLength(Geometry g) {      return (new MinimumDiameter(g)).getDiameter().getLength();  }
 
   public static Geometry minimumRectangle(Geometry g) { return (new MinimumDiameter(g)).getMinimumRectangle();  }
+  
   public static Geometry minimumBoundingCircle(Geometry g) { return (new MinimumBoundingCircle(g)).getCircle();  }
-  public static Geometry maximumDiameter(Geometry g) {      return 
-      g.getFactory().createLineString((new MinimumBoundingCircle(g)).getExtremalPoints());  }
-  public static Geometry farthestPoints(Geometry g) { 
-      return ((new MinimumBoundingCircle(g)).getFarthestPoints());  }
-  public static double maximumDiameterLength(Geometry g) {      return 2 * (new MinimumBoundingCircle(g)).getRadius();  }
+  public static double minimumBoundingCircleDiameterLen(Geometry g) {      return 2 * (new MinimumBoundingCircle(g)).getRadius();  }
+
+  public static Geometry maximumDiameter(Geometry g) {      return (new MinimumBoundingCircle(g)).getMaximumDiameter();  }
+  public static double maximumDiameterLength(Geometry g) {  
+    return (new MinimumBoundingCircle(g)).getMaximumDiameter().getLength();
+  }
   
   public static Geometry boundary(Geometry g) {      return g.getBoundary();  }
   public static Geometry convexHull(Geometry g) {      return g.convexHull();  }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumBoundingCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumBoundingCircleTest.java
@@ -19,14 +19,14 @@ import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
-import junit.framework.TestCase;
 import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
 
 
 /**
  * @version 1.7
  */
-public class MinimumBoundingCircleTest extends TestCase {
+public class MinimumBoundingCircleTest extends GeometryTestCase {
 
   private PrecisionModel precisionModel = new PrecisionModel(1);
   private GeometryFactory geometryFactory = new GeometryFactory(precisionModel, 0);
@@ -75,8 +75,24 @@ public class MinimumBoundingCircleTest extends TestCase {
         new Coordinate(26284.84180271327, 65267.114509082545), 247.4360455914027 );
   }
 
+  public void testMinDiameterLine() {
+    doMinDiameterTest("LINESTRING (100 200, 300 100)", "LINESTRING (100 200, 300 100)");
+  }
+  
+  public void testMinDiameterPolygon() {
+    doMinDiameterTest("POLYGON ((100 200, 300 150, 110 100, 100 200))", "LINESTRING (300 150, 100 200)");
+  }
+  
   static final double TOLERANCE = 1.0e-5;
   
+  private void doMinDiameterTest(String wkt, String expectedWKT) {
+    MinimumBoundingCircle mbc = new MinimumBoundingCircle(read(wkt));
+    Geometry diamActual = mbc.getMaximumDiameter();
+    Geometry expected = read(expectedWKT);
+
+    checkEqual(expected, diamActual);
+  }
+
   private void doMinimumBoundingCircleTest(String wkt, String expectedWKT) throws ParseException 
   {
   	doMinimumBoundingCircleTest(wkt, expectedWKT, null, -1);
@@ -84,18 +100,17 @@ public class MinimumBoundingCircleTest extends TestCase {
   
   private void doMinimumBoundingCircleTest(String wkt, String expectedWKT,
   		Coordinate expectedCentre, double expectedRadius)
-  throws ParseException 
   {
-  	MinimumBoundingCircle mbc = new MinimumBoundingCircle(reader.read(wkt));
+  	MinimumBoundingCircle mbc = new MinimumBoundingCircle(read(wkt));
   	Coordinate[] exPts = mbc.getExtremalPoints();
-  	Geometry actual = geometryFactory.createMultiPoint(exPts);
+  	Geometry actual = geometryFactory.createMultiPointFromCoords(exPts);
   	double actualRadius = mbc.getRadius();
   	Coordinate actualCentre = mbc.getCentre();
   	//System.out.println( 
   	//		"   Centre = " + actualCentre
   	//		+ "   Radius = " + actualRadius);
 
-  	Geometry expected = reader.read(expectedWKT);
+  	Geometry expected = read(expectedWKT);
   	boolean isEqual = actual.equals(expected);
   	// need this hack because apparently equals does not work for MULTIPOINT EMPTY
   	if (actual.isEmpty() && expected.isEmpty())


### PR DESCRIPTION
Fix computation
Add `getMinimumDiameter` method to replace `getFarthestPoints`

Signed-off-by: Martin Davis <mtnclimb@gmail.com>