### PR TITLE
Fix Snap Rounding bug causing nodes to be created at every vertex

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/noding/snapround/MCIndexPointSnapper.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/snapround/MCIndexPointSnapper.java
@@ -84,8 +84,24 @@ public class MCIndexPointSnapper
       this.hotPixelVertexIndex = hotPixelVertexIndex;
     }
 
-    public boolean isNodeAdded() { return isNodeAdded; }
+    /**
+     * Reports whether the HotPixel caused a node to be added in any target
+     * segmentString (including its own). If so, the HotPixel must be added as a
+     * node as well.
+     * 
+     * @return true if a node was added in any target segmentString.
+     */
+    public boolean isNodeAdded() {
+      return isNodeAdded;
+    }
 
+    /**
+     * Check if a segment of the monotone chain intersects
+     * the hot pixel vertex and introduce a snap node if so.
+     * Optimized to avoid noding segments which
+     * contain the vertex (which otherwise 
+     * would cause every vertex to be noded).
+     */
     public void select(MonotoneChain mc, int startIndex)
     {
     	NodedSegmentString ss = (NodedSegmentString) mc.getContext();
@@ -99,13 +115,14 @@ public class MCIndexPointSnapper
        * Sep 22 2012 - MD - currently do need to snap to every vertex,
        * since otherwise the testCollapse1 test in SnapRoundingTest fails.
        */
-      if (parentEdge != null) {
-        if (ss == parentEdge && 
-            (startIndex == hotPixelVertexIndex
-                ))
+      if (parentEdge == ss) {
+        // exit if hotpixel is equal to endpoint of target segment
+        if (startIndex == hotPixelVertexIndex
+            || startIndex + 1 == hotPixelVertexIndex)
           return;
       }
-      isNodeAdded = hotPixel.addSnappedNode(ss, startIndex);
+      // snap and record if a node was created
+      isNodeAdded |= hotPixel.addSnappedNode(ss, startIndex);
     }
 
   }

--- a/modules/core/src/test/java/org/locationtech/jts/noding/snapround/SnapRoundingTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/noding/snapround/SnapRoundingTest.java
@@ -80,7 +80,12 @@ public class SnapRoundingTest  extends TestCase {
     };
     runRounding(collapse2);
   }
-  
+
+  public void testLineWithManySelfSnaps() {
+    String[] line = { "LINESTRING (0 0, 6 4, 8 11, 13 13, 14 12, 11 12, 7 7, 7 3, 4 2)" };
+    runRounding(line);
+  }
+
   public void testBadNoding1() {
     String[] badNoding1 = {
       "LINESTRING ( 76 47, 81 52, 81 53, 85 57, 88 62, 89 64, 57 80, 82 55, 101 74, 76 99, 92 67, 94 68, 99 71, 103 75, 139 111 )"


### PR DESCRIPTION
Fix Snap Rounding bug causing nodes to be created at every vertex.
This is a long-standing bug which is critical for optimizing the number of noded strings
created by snap-rounding.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>