### PR TITLE
Fix HalfEdge insertion logic

### DIFF
--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -39,6 +39,7 @@ Distributions for older JTS versions can be obtained at the
 * Fix bugs in `LinearLocation` endpoint handling (#421)
 * Fix bug in `MinimumBoundingCircle` maximum diameter algorithm, and provide method for it
 * Improve robustness of `CascadedPolygonUnion` by adding `OverlapUnion`
+* Fix bug in `HalfEdge.insert` method which caused CCW order not to be preserved in some cases
 
 ## JTS TestRunner
 

--- a/modules/core/src/main/java/org/locationtech/jts/edgegraph/HalfEdge.java
+++ b/modules/core/src/main/java/org/locationtech/jts/edgegraph/HalfEdge.java
@@ -24,6 +24,8 @@ import org.locationtech.jts.util.Assert;
  * and terminate at a <b>destination</b> vertex.
  * HalfEdges always occur in symmetric pairs, with the {@link #sym()} method
  * giving access to the oppositely-oriented component.
+ * HalfEdges with the same origin are ordered 
+ * so that the ring of their dest points is oriented CCW.
  * HalfEdges and the methods on them form an edge algebra,
  * which can be used to traverse and query the topology
  * of the graph formed by the edges.
@@ -126,7 +128,7 @@ public class HalfEdge {
   }
   
   /**
-   * Sets the sym edge.
+   * Sets the symmetric (opposite) edge to this edge.
    * 
    * @param e the sym edge to set
    */
@@ -136,7 +138,8 @@ public class HalfEdge {
 
   /**
    * Gets the next edge CCW around the 
-   * destination vertex of this edge.
+   * destination vertex of this edge,
+   * with the dest vertex as its origin.
    * If the vertex has degree 1 then this is the <b>sym</b> edge.
    * 
    * @return the next edge
@@ -147,7 +150,7 @@ public class HalfEdge {
   }
   
   /**
-   * Returns the edge previous to this one
+   * Gets the edge previous to this one
    * (with dest being the same as this orig).
    * 
    * @return the previous edge to this one
@@ -156,13 +159,24 @@ public class HalfEdge {
     return sym.next().sym;
   }
 
+  /**
+   * Gets the next edge CCW around the origin of this edge,
+   * with the same origin.
+   * 
+   * @return the next edge around the origin
+   */
+  public HalfEdge oNext() {
+    return sym.next;
+  }
+  
+  /**
+   * Sets the next edge CCW around the destination vertex of this edge.
+   * 
+   * @param e the next edge
+   */
   public void setNext(HalfEdge e)
   {
     next = e;
-  }
-  
-  public HalfEdge oNext() {
-    return sym.next;
   }
 
   /**
@@ -198,32 +212,65 @@ public class HalfEdge {
   
   /**
    * Inserts an edge
-   * into the ring of edges around the origin vertex of this edge.
+   * into the ring of edges around the origin vertex of this edge,
+   * ensuring that the edges remain ordered CCW.
    * The inserted edge must have the same origin as this edge.
    * 
-   * @param e the edge to insert
+   * @param eAdd the edge to insert
    */
-  public void insert(HalfEdge e) {
-    // if no other edge around origin
+  public void insert(HalfEdge eAdd) {
+    // If this is only edge at origin, insert it after this
     if (oNext() == this) {
       // set linkage so ring is correct
-      insertAfter(e);
+      insertAfter(eAdd);
       return;
     }
     
-    // otherwise, find edge to insert after
-    int ecmp = compareTo(e);
+    // Scan edges
+    // until insertion point is found
+    HalfEdge ePrev = insertionEdge(eAdd);
+    ePrev.insertAfter(eAdd);
+  }
+
+  /**
+   * Finds the insertion edge for a edge
+   * being added to this origin,
+   * ensuring that the star of edges
+   * around the origin remains fully CCW.
+   * 
+   * @param eAdd the edge being added
+   * @return the edge to insert after
+   */
+  private HalfEdge insertionEdge(HalfEdge eAdd) {
     HalfEdge ePrev = this;
     do {
-      HalfEdge oNext = ePrev.oNext();
-      int cmp = oNext.compareTo(e);
-      if (cmp != ecmp || oNext == this) {
-        ePrev.insertAfter(e);
-        return;
+      HalfEdge eNext = ePrev.oNext();
+      /**
+       * Case 1: General case,
+       * with eNext higher than ePrev.
+       * 
+       * Insert edge here if it lies between ePrev and eNext.  
+       */
+      if (eNext.compareTo(ePrev) > 0 
+          && eAdd.compareTo(ePrev) >= 0
+          && eAdd.compareTo(eNext) <= 0) { 
+        return ePrev;         
       }
-      ePrev = oNext;
+      /**
+       * Case 2: Origin-crossing case,
+       * indicated by eNext <= ePrev.
+       * 
+       * Insert edge here if it lies
+       * in the gap between ePrev and eNext across the origin. 
+       */
+      if (eNext.compareTo(ePrev) <= 0
+          && (eAdd.compareTo(eNext) <= 0 || eAdd.compareTo(ePrev) >= 0)) {
+        return ePrev; 
+      }
+      ePrev = eNext;
     } while (ePrev != this);
     Assert.shouldNeverReachHere();
+    return null;
   }
   
   /**
@@ -240,6 +287,36 @@ public class HalfEdge {
     e.sym().setNext(save);
   }
 
+  boolean isCCW() {
+    // degree <= 2 has no orientation
+    if (degree() <= 2) return true;
+    
+    // test each triangle of consecutive direction points to confirm it is CCW
+    HalfEdge e = this;
+    do {
+      HalfEdge eNext = e.oNext();
+      HalfEdge eNext2 = eNext.oNext();
+      if (! isCCW(e, eNext, eNext2)) return false;
+      e = eNext;
+    } while (e != this);
+    return true;
+  }
+
+  /**
+   * Tests if the edges e1,e2,e3 are oriented CCW 
+   * around their origin (using their direction points).
+   * 
+   * @param e1 a half-edge
+   * @param e2 a half-edge
+   * @param e3 a half-edge
+   * @return true if the edge triplet is oriented CCW
+   */
+  private boolean isCCW(HalfEdge e1, HalfEdge e2, HalfEdge e3) {
+    int orientIndex = Orientation.index(
+        e1.dest(), e2.dest(), e3.dest());
+    return orientIndex == Orientation.COUNTERCLOCKWISE;
+  }
+  
   /**
    * Compares edges which originate at the same vertex
    * based on the angle they make at their origin vertex with the positive X-axis.

--- a/modules/core/src/test/java/org/locationtech/jts/edgegraph/EdgeGraphTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/edgegraph/EdgeGraphTest.java
@@ -37,8 +37,23 @@ public class EdgeGraphTest extends TestCase {
         new Coordinate[] { new Coordinate(1, 0),
       new Coordinate(0, 1), new Coordinate(-1, 0)
         });
+    checkCCW(graph, new Coordinate(0, 0), new Coordinate(1, 0));
     checkEdge(graph, new Coordinate(0, 0), new Coordinate(1, 0));
   }
+
+  /**
+   * This test produced an error using the original buggy sorting algorithm
+   * (in {@link HalfEdge#insert(HalfEdge)}).
+   */
+  public void testCCWAfterInserts() {
+    EdgeGraph graph = new EdgeGraph();
+    HalfEdge e1 = addEdge(graph, 50, 39, 35, 42);
+    addEdge(graph, 50, 39, 50, 60);
+    addEdge(graph, 50, 39, 68, 35);
+    checkCCW(e1);
+  }
+
+
 
   private void checkEdgeRing(EdgeGraph graph, Coordinate p,
       Coordinate[] dest) {
@@ -52,13 +67,21 @@ public class EdgeGraphTest extends TestCase {
    
   }
 
-
   private void checkEdge(EdgeGraph graph, Coordinate p0, Coordinate p1) {
     HalfEdge e = graph.findEdge(p0, p1);
     assertNotNull(e);
   }
 
+  private void checkCCW(EdgeGraph graph, Coordinate p0, Coordinate p1) {
+    HalfEdge e = graph.findEdge(p0, p1);
+    assertTrue(e.isCCW());
+  }
 
+
+  private void checkCCW(HalfEdge e) {
+    assertTrue(e.isCCW());
+  }
+  
   private EdgeGraph build(String wkt) throws ParseException {
     return build(new String[] { wkt });
   }
@@ -68,4 +91,7 @@ public class EdgeGraphTest extends TestCase {
     return EdgeGraphBuilder.build(geoms);
   }
 
+  private HalfEdge addEdge(EdgeGraph graph, double p0x, double p0y, double p1x, double p1y) {
+    return graph.addEdge(new Coordinate(p0x, p0y), new Coordinate(p1x, p1y));
+  }
 }


### PR DESCRIPTION
Algorithm is fixed to ensure that edge insertion maintains the CCW ordering of edges.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>