### PR TITLE
Fix HalfEdge valid node check

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/edgegraph/HalfEdge.java
+++ b/modules/core/src/main/java/org/locationtech/jts/edgegraph/HalfEdge.java
@@ -287,34 +287,47 @@ public class HalfEdge {
     e.sym().setNext(save);
   }
 
-  boolean isCCW() {
-    // degree <= 2 has no orientation
-    if (degree() <= 2) return true;
-    
-    // test each triangle of consecutive direction points to confirm it is CCW
-    HalfEdge e = this;
+  /**
+   * Tests whether the edges around the origin
+   * are sorted correctly.
+   * Note that edges must be strictly increasing,
+   * which implies no two edges can have the same direction point.
+   * 
+   * @return true if the origin edges are sorted correctly
+   */
+  boolean isEdgesSorted() {
+    // find lowest edge at origin
+    HalfEdge lowest = findLowest();
+    HalfEdge e = lowest;
+    // check that all edges are sorted
     do {
       HalfEdge eNext = e.oNext();
-      HalfEdge eNext2 = eNext.oNext();
-      if (! isCCW(e, eNext, eNext2)) return false;
+      if (eNext == lowest) break;
+      boolean isSorted = eNext.compareTo(e) > 0;
+      if (! isSorted) {
+        //int comp = eNext.compareTo(e);
+        return false;
+      }
       e = eNext;
-    } while (e != this);
+    } while (e != lowest);
     return true;
-  }
-
+  }  
+  
   /**
-   * Tests if the edges e1,e2,e3 are oriented CCW 
-   * around their origin (using their direction points).
+   * Finds the lowest edge around the origin,
+   * using the standard edge ordering.
    * 
-   * @param e1 a half-edge
-   * @param e2 a half-edge
-   * @param e3 a half-edge
-   * @return true if the edge triplet is oriented CCW
+   * @return the lowest edge around the origin
    */
-  private boolean isCCW(HalfEdge e1, HalfEdge e2, HalfEdge e3) {
-    int orientIndex = Orientation.index(
-        e1.dest(), e2.dest(), e3.dest());
-    return orientIndex == Orientation.COUNTERCLOCKWISE;
+  private HalfEdge findLowest() {
+    HalfEdge lowest = this;
+    HalfEdge e = this.oNext();
+    do {
+      if (e.compareTo(lowest) < 0)
+        lowest = e;
+      e = e.oNext();
+    } while (e != this);
+    return lowest;
   }
   
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/edgegraph/EdgeGraphTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/edgegraph/EdgeGraphTest.java
@@ -37,7 +37,7 @@ public class EdgeGraphTest extends TestCase {
         new Coordinate[] { new Coordinate(1, 0),
       new Coordinate(0, 1), new Coordinate(-1, 0)
         });
-    checkCCW(graph, new Coordinate(0, 0), new Coordinate(1, 0));
+    checkNodeValid(graph, new Coordinate(0, 0), new Coordinate(1, 0));
     checkEdge(graph, new Coordinate(0, 0), new Coordinate(1, 0));
   }
 
@@ -50,9 +50,16 @@ public class EdgeGraphTest extends TestCase {
     HalfEdge e1 = addEdge(graph, 50, 39, 35, 42);
     addEdge(graph, 50, 39, 50, 60);
     addEdge(graph, 50, 39, 68, 35);
-    checkCCW(e1);
+    checkNodeValid(e1);
   }
 
+  public void testCCWAfterInserts2() {
+    EdgeGraph graph = new EdgeGraph();
+    HalfEdge e1 = addEdge(graph, 50, 200, 0, 200);
+    addEdge(graph, 50, 200, 190, 50);
+    addEdge(graph, 50, 200, 200, 200);
+    checkNodeValid(e1);
+  }
 
 
   private void checkEdgeRing(EdgeGraph graph, Coordinate p,
@@ -72,14 +79,16 @@ public class EdgeGraphTest extends TestCase {
     assertNotNull(e);
   }
 
-  private void checkCCW(EdgeGraph graph, Coordinate p0, Coordinate p1) {
+  private void checkNodeValid(EdgeGraph graph, Coordinate p0, Coordinate p1) {
     HalfEdge e = graph.findEdge(p0, p1);
-    assertTrue(e.isCCW());
+    boolean isNodeValid = e.isEdgesSorted();
+    assertTrue("Found non-sorted edges around node " + e, isNodeValid); 
   }
 
 
-  private void checkCCW(HalfEdge e) {
-    assertTrue(e.isCCW());
+  private void checkNodeValid(HalfEdge e) {
+    boolean isNodeValid = e.isEdgesSorted();
+    assertTrue("Found non-sorted edges around node " + e, isNodeValid); 
   }
   
   private EdgeGraph build(String wkt) throws ParseException {
@@ -94,4 +103,5 @@ public class EdgeGraphTest extends TestCase {
   private HalfEdge addEdge(EdgeGraph graph, double p0x, double p0y, double p1x, double p1y) {
     return graph.addEdge(new Coordinate(p0x, p0y), new Coordinate(p1x, p1y));
   }
+
 }


### PR DESCRIPTION
This fixes (finally!) the check for a valid HalfEdge node.  The check needs to check the sort order of the edges.  The previous implementation checking orientation of the edge dest points was incorrect.
 
Signed-off-by: Martin Davis <mtnclimb@gmail.com>