### PR TITLE
Fix WKT parsing in Turkish locale

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
@@ -18,12 +18,12 @@ import java.io.StreamTokenizer;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.Locale;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
 
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -36,7 +36,6 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.geom.impl.CoordinateArraySequenceFactory;
-import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.locationtech.jts.util.Assert;
 import org.locationtech.jts.util.AssertionFailedException;
 
@@ -612,7 +611,7 @@ S   */
 
     EnumSet<Ordinate> result = EnumSet.of(Ordinate.X, Ordinate.Y);
 
-    String nextWord = lookAheadWord(tokenizer).toUpperCase();
+    String nextWord = lookAheadWord(tokenizer).toUpperCase(Locale.ROOT);
     if (nextWord.equalsIgnoreCase("Z")) {
       tokenizer.nextToken();
       result.add(Ordinate.Z);
@@ -767,7 +766,7 @@ S   */
 
     EnumSet<Ordinate> ordinateFlags = EnumSet.of(Ordinate.X, Ordinate.Y);
     try {
-      type = getNextWord(tokenizer).toUpperCase();
+      type = getNextWord(tokenizer).toUpperCase(Locale.ROOT);
       if (type.endsWith("ZM")) {
         ordinateFlags.add(Ordinate.Z);
         ordinateFlags.add(Ordinate.M);

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
@@ -21,6 +21,7 @@ import junit.textui.TestRunner;
 import test.jts.GeometryTestCase;
 
 import java.util.EnumSet;
+import java.util.Locale;
 
 
 /**
@@ -422,6 +423,18 @@ public class WKTReaderTest extends TestCase {
     CoordinateSequence point2 = geometryFactory.createPoint(new Coordinate(123456789.01234567890, 10)).getCoordinateSequence();
     assertEquals(point1.getOrdinate(0, CoordinateSequence.X), point2.getOrdinate(0, CoordinateSequence.X), 1E-7);
     assertEquals(point1.getOrdinate(0, CoordinateSequence.Y), point2.getOrdinate(0, CoordinateSequence.Y), 1E-7);
+  }
+
+  public void testTurkishLocale() throws Exception {
+      Locale original = Locale.getDefault();
+      try {
+          Locale.setDefault(Locale.forLanguageTag("tr"));
+          Point point = (Point) reader2D.read("point (10 20)");
+          assertEquals(10.0, point.getX(), 1E-7);
+          assertEquals(20.0, point.getY(), 1E-7);
+      } finally {
+          Locale.setDefault(original);
+      }
   }
 
   private static CoordinateSequence createSequence(EnumSet<Ordinate> ordinateFlags, double[] xy) {


### PR DESCRIPTION
Fixes an issues with WKT parser incorrectly comparing lower-case
geometry types in Turkish locales.

Signed-off-by: Igor Motov <igor@elastic.co>