### PR TITLE
use mvn site to generate javadoc jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
     Build everything and skip tests:
        mvn clean install -DskipTests
 
+    Build javadocs (shows up as a jar):
+       mvn site
+       
     Setup for eclipse development:
        mvn eclipse:eclipse
 
@@ -243,6 +246,7 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <phase>site</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Move javadoc to phase site:

* mvn clean install - just builds jar and source jar
* mvn site - builds javadoc jar

Note the javadoc generation has warnings and errors at present...