### PR TITLE
Fix IndexedPointInAreaLocator and SortedPackedIntervalRTree to handle empty input

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/locate/IndexedPointInAreaLocator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/locate/IndexedPointInAreaLocator.java
@@ -11,6 +11,7 @@
  */
 package org.locationtech.jts.algorithm.locate;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -106,11 +107,15 @@ public class IndexedPointInAreaLocator
   
   private static class IntervalIndexedGeometry
   {
-    private final SortedPackedIntervalRTree index= new SortedPackedIntervalRTree();
+    private boolean isEmpty = false;
+    private SortedPackedIntervalRTree index= new SortedPackedIntervalRTree();
 
     public IntervalIndexedGeometry(Geometry geom)
     {
-      init(geom);
+      if (geom.isEmpty())
+        isEmpty = true;
+      else
+        init(geom);
     }
     
     private void init(Geometry geom)
@@ -135,6 +140,9 @@ public class IndexedPointInAreaLocator
     
     public List query(double min, double max)
     {
+     if (isEmpty) 
+        return new ArrayList();
+      
       ArrayListVisitor visitor = new ArrayListVisitor();
       index.query(min, max, visitor);
       return visitor.getItems();
@@ -142,6 +150,8 @@ public class IndexedPointInAreaLocator
     
     public void query(double min, double max, ItemVisitor visitor)
     {
+      if (isEmpty) 
+        return;
       index.query(min, max, visitor);
     }
   }

--- a/modules/core/src/main/java/org/locationtech/jts/index/intervalrtree/SortedPackedIntervalRTree.java
+++ b/modules/core/src/main/java/org/locationtech/jts/index/intervalrtree/SortedPackedIntervalRTree.java
@@ -38,6 +38,13 @@ import org.locationtech.jts.io.WKTWriter;
 public class SortedPackedIntervalRTree 
 {
   private List leaves = new ArrayList();
+  
+  /**
+   * If root is null that indicates
+   * that the tree has not yet been built,   
+   * OR nothing has been added to the tree.
+   * In both cases, the tree is still open for insertions.
+   */
 	private IntervalRTreeNode root = null;
 	
 	public SortedPackedIntervalRTree()
@@ -63,7 +70,15 @@ public class SortedPackedIntervalRTree
 	
   private void init()
   {
+    // already built
     if (root != null) return;
+    
+    /**
+     * if leaves is empty then nothing has been inserted.
+     * In this case it is safe to leave the tree in an open state
+     */
+    if (leaves.size() == 0) return;
+    
     buildRoot();
   }
   
@@ -134,7 +149,11 @@ public class SortedPackedIntervalRTree
 	public void query(double min, double max, ItemVisitor visitor)
 	{
     init();
-
+    
+    // if root is null tree must be empty
+    if (root == null) 
+      return;
+    
 		root.query(min, max, visitor);
 	}
   

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/locate/IndexedPointInAreaLocatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/locate/IndexedPointInAreaLocatorTest.java
@@ -14,6 +14,7 @@ package org.locationtech.jts.algorithm.locate;
 import org.locationtech.jts.algorithm.AbstractPointInRingTest;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Location;
 import org.locationtech.jts.io.WKTReader;
 
 import junit.textui.TestRunner;
@@ -43,4 +44,13 @@ public class IndexedPointInAreaLocatorTest extends AbstractPointInRingTest {
     assertEquals(expectedLoc, result);
   }
 
+   /**
+    * See JTS GH Issue #19.
+    * Used to infinite-loop on empty geometries.
+    * 
+    * @throws Exception
+    */
+   public void testEmpty() throws Exception {
+     runPtInRing(Location.EXTERIOR, new Coordinate(0,0), "POLYGON EMPTY");
+  }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/index/intervalrtree/SortedPackedIntervalRTreeTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/index/intervalrtree/SortedPackedIntervalRTreeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.index.intervalrtree;
+
+import org.locationtech.jts.index.ArrayListVisitor;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+public class SortedPackedIntervalRTreeTest extends TestCase {
+  
+  public static void main(String args[]) {
+    TestRunner.run(SortedPackedIntervalRTreeTest.class);
+  }
+
+  public SortedPackedIntervalRTreeTest(String name) { super(name); }
+  
+  /**
+   * See JTS GH Issue #19.
+   * Used to infinite-loop on empty geometries.
+   * 
+   */
+  public void testEmpty() {
+    SortedPackedIntervalRTree spitree = new SortedPackedIntervalRTree();
+    ArrayListVisitor visitor = new ArrayListVisitor();
+    spitree.query(0, 1, visitor);
+  }
+}


### PR DESCRIPTION
`SortedPackedIntervalRTree` had a bug causing an infinite loop when building an empty tree.  This has been fixed.  
`IndexedPointInAreaLocator`depended on this, but has been fixed internally as well.

This also fixes `PreparedPolygon`.

See issue #19 

Signed-off-by: Martin Davis <mtnclimb@gmail.com>