### PR TITLE
Avoid using ArrayList in MonotoneChain builders

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/index/MonotoneChainIndexer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/index/MonotoneChainIndexer.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geomgraph.Quadrant;
+import org.locationtech.jts.util.IntArrayList;
 
 
 /**
@@ -61,6 +62,23 @@ public class MonotoneChainIndexer {
   }
 
   public int[] getChainStartIndices(Coordinate[] pts)
+  {
+    // find the startpoint (and endpoints) of all monotone chains in this edge
+    int start = 0;
+    IntArrayList startIndexList = new IntArrayList(pts.length / 2);
+    // use heuristic to size initial array
+    //startIndexList.ensureCapacity(pts.length / 4);
+    startIndexList.add(start);
+    do {
+      int last = findChainEnd(pts, start);
+      startIndexList.add(last);
+      start = last;
+    } while (start < pts.length - 1);
+    // copy list to an array of ints, for efficiency
+    return startIndexList.toArray();
+  }  
+  
+  public int[] OLDgetChainStartIndices(Coordinate[] pts)
   {
     // find the startpoint (and endpoints) of all monotone chains in this edge
     int start = 0;

--- a/modules/core/src/main/java/org/locationtech/jts/index/chain/MonotoneChainBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/index/chain/MonotoneChainBuilder.java
@@ -1,5 +1,3 @@
-
-
 /*
  * Copyright (c) 2016 Vivid Solutions.
  *
@@ -27,63 +25,48 @@ import org.locationtech.jts.geomgraph.Quadrant;
  */
 public class MonotoneChainBuilder {
 
-  public static int[] toIntArray(List list)
-  {
-    int[] array = new int[list.size()];
-    for (int i = 0; i < array.length; i++) {
-      array[i] = ((Integer) list.get(i)).intValue();
-    }
-    return array;
-  }
-
+  /**
+   * Computes a list of the {@link MonotoneChain}s
+   * for a list of coordinates.
+   * 
+   * @param pts the list of points to compute chains for
+   * @return a list of the monotone chains for the points 
+   */
   public static List getChains(Coordinate[] pts)
   {
     return getChains(pts, null);
   }
 
   /**
-   * Return a list of the {@link MonotoneChain}s
-   * for the given list of coordinates.
+   * Computes a list of the {@link MonotoneChain}s
+   * for a list of coordinates, 
+   * attaching a context data object to each.
+   * 
+   * @param pts the list of points to compute chains for
+   * @param context a data object to attach to each chain
+   * @return a list of the monotone chains for the points 
    */
   public static List getChains(Coordinate[] pts, Object context)
   {
     List mcList = new ArrayList();
-    int[] startIndex = getChainStartIndices(pts);
-    for (int i = 0; i < startIndex.length - 1; i++) {
-      MonotoneChain mc = new MonotoneChain(pts, startIndex[i], startIndex[i + 1], context);
-      mcList.add(mc);
-    }
-    return mcList;
-  }
-
-  /**
-   * Return an array containing lists of start/end indexes of the monotone chains
-   * for the given list of coordinates.
-   * The last entry in the array points to the end point of the point array,
-   * for use as a sentinel.
-   */
-  public static int[] getChainStartIndices(Coordinate[] pts)
-  {
-    // find the startpoint (and endpoints) of all monotone chains in this edge
-    int start = 0;
-    List startIndexList = new ArrayList();
-    startIndexList.add(start);
+    int chainStart = 0;
     do {
-      int last = findChainEnd(pts, start);
-      startIndexList.add(last);
-      start = last;
-    } while (start < pts.length - 1);
-    // copy list to an array of ints, for efficiency
-    int[] startIndex = toIntArray(startIndexList);
-    return startIndex;
+      int chainEnd = findChainEnd(pts, chainStart);
+      MonotoneChain mc = new MonotoneChain(pts, chainStart, chainEnd, context);
+      mcList.add(mc);
+      chainStart = chainEnd;
+    } while (chainStart < pts.length -1);
+    return mcList;
   }
 
   /**
    * Finds the index of the last point in a monotone chain
    * starting at a given point.
-   * Any repeated points (0-length segments) will be included
+   * Repeated points (0-length segments) are included
    * in the monotone chain returned.
    * 
+   * @param pts the points to scan
+   * @param start the index of the start of this chain
    * @return the index of the last point in the monotone chain 
    * starting at <code>start</code>.
    */
@@ -114,7 +97,4 @@ public class MonotoneChainBuilder {
     return last - 1;
   }
 
-
-  public MonotoneChainBuilder() {
-  }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/util/IntArrayList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/util/IntArrayList.java
@@ -11,6 +11,9 @@
  */
 package org.locationtech.jts.util;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * An extendable array of primitive <code>int</code> values.
  * 
@@ -25,7 +28,7 @@ public class IntArrayList {
    * Constructs an empty list.
    */
   public IntArrayList() {
-    data = new int[10];
+    this(10);
   }
 
   /**
@@ -38,9 +41,9 @@ public class IntArrayList {
   }
 
   /**
-   * Returns the number of ints in this list.
+   * Returns the number of values in this list.
    * 
-   * @return the number of ints in the list
+   * @return the number of values in the list
    */
   public int size() {
     return size;
@@ -48,32 +51,40 @@ public class IntArrayList {
 
   /**
    * Increases the capacity of this list instance, if necessary, 
-   * to ensure that it can hold at least the number of elements specified by the capacity argument.
+   * to ensure that it can hold at least the number of elements 
+   * specified by the capacity argument.
    * 
    * @param capacity the desired capacity
    */
   public void ensureCapacity(final int capacity) {
-    if (capacity <= data.length)
-      return;
-    int[] newData = new int[capacity];
+    if (capacity <= data.length) return;
+    int newLength  = Math.max(capacity, data.length * 2);
     //System.out.println("IntArrayList: copying " + size + " ints to new array of length " + capacity);
-    System.arraycopy(data, 0, newData, 0, size);
-    data = newData;
+    data = Arrays.copyOf(data, newLength);
   }
-
   /**
-   * Adds an int value to the end of this list.
+   * Adds a value to the end of this list.
    * 
    * @param value the value to add
    */
   public void add(final int value) {
-    if (size == data.length) {
-      // Increase size by 2x
-      ensureCapacity(2 * data.length);
-    }
+    ensureCapacity(size + 1);
     data[size] = value;
     ++size;
   }
+  
+  /**
+   * Adds all values in an array to the end of this list.
+   * 
+   * @param values an array of values
+   */
+  public void addAll(final int[] values) {
+    if (values == null) return;
+    if (values.length == 0) return;
+    ensureCapacity(size + values.length);
+    System.arraycopy(values, 0, data, size, values.length);
+    size += values.length;
+   }
   
   /**
    * Returns a int array containing a copy of

--- a/modules/core/src/main/java/org/locationtech/jts/util/IntArrayList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/util/IntArrayList.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019 Martin Davis.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.util;
+
+/**
+ * An extendable array of primitive <code>int</code> values.
+ * 
+ * @author Martin Davis
+ *
+ */
+public class IntArrayList {
+  private int[] data;
+  private int size = 0;
+
+  /**
+   * Constructs an empty list.
+   */
+  public IntArrayList() {
+    data = new int[10];
+  }
+
+  /**
+   * Constructs an empty list with the specified initial capacity
+   * 
+   * @param initialCapacity the initial capacity of the list
+   */
+  public IntArrayList(int initialCapacity) {
+    data = new int[initialCapacity];
+  }
+
+  /**
+   * Returns the number of ints in this list.
+   * 
+   * @return the number of ints in the list
+   */
+  public int size() {
+    return size;
+  }
+
+  /**
+   * Increases the capacity of this list instance, if necessary, 
+   * to ensure that it can hold at least the number of elements specified by the capacity argument.
+   * 
+   * @param capacity the desired capacity
+   */
+  public void ensureCapacity(final int capacity) {
+    if (capacity <= data.length)
+      return;
+    int[] newData = new int[capacity];
+    //System.out.println("IntArrayList: copying " + size + " ints to new array of length " + capacity);
+    System.arraycopy(data, 0, newData, 0, size);
+    data = newData;
+  }
+
+  /**
+   * Adds an int value to the end of this list.
+   * 
+   * @param value the value to add
+   */
+  public void add(final int value) {
+    if (size == data.length) {
+      // Increase size by 2x
+      ensureCapacity(2 * data.length);
+    }
+    data[size] = value;
+    ++size;
+  }
+  
+  /**
+   * Returns a int array containing a copy of
+   * the values in this list.
+   * 
+   * @return an array containing the values in this list
+   */
+  public int[] toArray() {
+    int[] array = new int[size];
+    System.arraycopy(data, 0, array, 0, size);
+    return array;
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/util/IntArrayListTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/util/IntArrayListTest.java
@@ -1,0 +1,50 @@
+package org.locationtech.jts.util;
+
+import junit.framework.TestCase;
+
+public class IntArrayListTest extends TestCase {
+
+  public static void main(String[] args) {
+    junit.textui.TestRunner.run(IntArrayListTest.class);
+  }
+  
+  public IntArrayListTest(String name) {
+    super(name);
+  }
+
+  public void testEmpty() {
+    IntArrayList iar = new IntArrayList();
+    assertEquals(0, iar.size());
+  }
+  
+  public void testAddFew() {
+    IntArrayList iar = new IntArrayList();
+    iar.add(1);
+    iar.add(2);
+    iar.add(3);
+    assertEquals(3, iar.size());
+    
+    int[] data = iar.toArray();
+    assertEquals(3, data.length);
+    assertEquals(1, data[0]);
+    assertEquals(2, data[1]);
+    assertEquals(3, data[2]);
+  }
+  
+  public void testAddMany() {
+    IntArrayList iar = new IntArrayList(20);
+    
+    int max = 100;
+    for (int i = 0; i < max; i++) {
+      iar.add(i);
+    }
+
+    assertEquals(max, iar.size());
+    
+    int[] data = iar.toArray();
+    assertEquals(max, data.length);
+    for (int j = 0; j < max; j++) {
+      assertEquals(j, data[j]);
+    }
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/util/IntArrayListTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/util/IntArrayListTest.java
@@ -47,4 +47,21 @@ public class IntArrayListTest extends TestCase {
       assertEquals(j, data[j]);
     }
   }
+  
+  public void testAddAll() {
+    IntArrayList iar = new IntArrayList();
+    
+    iar.addAll(null);
+    iar.addAll(new int[0]);
+    iar.addAll(new int[] { 1,2,3 });
+    assertEquals(3, iar.size());
+    
+    int[] data = iar.toArray();
+    assertEquals(3, data.length);
+    assertEquals(1, data[0]);
+    assertEquals(2, data[1]);
+    assertEquals(3, data[2]);
+  }
+  
+
 }


### PR DESCRIPTION
As discussed in #463, currently `MonotoneChain` construction uses a temporary `ArrayList` to accumulate int index values.  This causes unnecessary object allocation, and _may_ be slower (although this is not certain).

The use of `ArrayList` is avoided in two ways:
* `MonotoneChainBuilder` can be refactored to avoid using a array of indexes completely, by constructing `MonotoneChain` objects as they determined
* In `MonotoneChainIndexer` the return of an `int[]` is required, but it is changed to use a new utility class `IntArrayList`.  This class uses primitive `int` values, and so should have less memory pressure than an `ArrayList` of `Integer`
