### PR TITLE
Fix Distance3Dop geometries order

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/Distance3DOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance3d/Distance3DOp.java
@@ -34,7 +34,7 @@ import org.locationtech.jts.operation.distance.GeometryLocation;
  * The distance computation also finds a pair of points in the input geometries
  * which have the minimum distance between them. If a point lies in the interior
  * of a line segment, the coordinate computed is a close approximation to the
- * exact point.
+ * exact point for X and Y ordinates. Z ordinate is not interpolated.
  * <p>
  * The algorithms used are straightforward O(n^2) comparisons. This worst-case
  * performance could be improved on by using Voronoi techniques or spatial
@@ -189,7 +189,7 @@ public class Distance3DOp {
 		minDistanceLocation = new GeometryLocation[2];
 		
 		int geomIndex = mostPolygonalIndex();
-		boolean flip = geomIndex == 0;
+		boolean flip = geomIndex == 1;
 		computeMinDistanceMultiMulti(geom[geomIndex], geom[1-geomIndex], flip);
 	}
 

--- a/modules/core/src/test/java/org/locationtech/jts/operation/distance3d/Distance3DOpTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/distance3d/Distance3DOpTest.java
@@ -12,6 +12,9 @@
 
 package org.locationtech.jts.operation.distance3d;
 
+import static java.lang.Double.NaN;
+
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.io.ParseException;
@@ -52,51 +55,63 @@ public class Distance3DOpTest extends TestCase
 		checkDistance(	"MULTILINESTRING EMPTY", "POLYGON EMPTY",	0);
 		checkDistance(	"MULTIPOLYGON EMPTY", "POINT (0 0 0)",	0);
 	}
-	
+
 	public void testPartiallyEmpty()
 	{
-		checkDistance(	"GEOMETRYCOLLECTION( MULTIPOINT (0 0 0), POLYGON EMPTY)", "POINT (0 1 0)",	1);
-		checkDistance(	"GEOMETRYCOLLECTION( MULTIPOINT (11 11 0), POLYGON EMPTY)", 
-				"GEOMETRYCOLLECTION( MULTIPOINT EMPTY, LINESTRING (10 10 0, 10 20 0 ))",	
-				1);
+		checkDistance(	"GEOMETRYCOLLECTION( MULTIPOINT (0 0 0), POLYGON EMPTY)", "POINT (0 1 0)",	1,
+				coord(0, 0, 0), coord(0, 1, 0));
+		checkDistance(	"GEOMETRYCOLLECTION( MULTIPOINT (11 11 0), POLYGON EMPTY)",
+				"GEOMETRYCOLLECTION( MULTIPOINT EMPTY, LINESTRING (10 10 0, 10 20 0 ))",
+				1,
+				coord(11, 11, 0), coord(10, 11, NaN));
 	}
-	
+
 	public void testPointPointFlat() {
-		checkDistance(	"POINT (10 10 0 )",
-				"POINT (20 20 0 )",
-				14.1421356);
-		checkDistance(	"POINT (10 10 0 )",
-				"POINT (20 20 0 )",
-				14.1421356);
+		checkDistance(	"POINT (10 10 0 )", "POINT (20 20 0 )", 14.1421356,
+				coord(10, 10, 0), coord(20, 20, 0));
+		checkDistance(	"POINT (5 10 0 )", "POINT (15 20 0 )", 14.1421356,
+				coord(5, 10, 0), coord(15, 20, 0));
 	}
-	
+
 	public void testPointPoint() {
 		checkDistance(	"POINT (0 0 0 )",
-						"POINT (0 0 1 )",
-				1);
+				"POINT (0 0 1 )",
+				1,
+				coord(0, 0, 0),
+				coord(0, 0, 1));
 		checkDistance(	"POINT (10 10 1 )",
 				"POINT (11 11 2 )",
-				1.7320508075688772);
+				1.7320508075688772,
+				coord(10, 10, 1),
+				coord(11, 11, 2));
 		checkDistance(	"POINT (10 10 0 )",
 				"POINT (10 20 10 )",
-				14.142135623730951);
+				14.142135623730951,
+				coord(10, 10, 0),
+				coord(10, 20, 10));
 	}
-	
+
 	public void testPointSegFlat() {
 		checkDistance(	"LINESTRING (10 10 0, 10 20 0 )",
 				"POINT (20 15 0 )",
-				10);
+				10,
+				coord(10, 15, NaN),
+				coord(20, 15, 0));
 	}
-	
+
 	public void testPointSeg() {
 		checkDistance(	"LINESTRING (0 0 0, 10 10 10 )",
 				"POINT (5 5 5 )",
-				0);
+				0,
+				coord(5, 5, NaN),
+				coord(5, 5, 5));
 		checkDistance(	"LINESTRING (10 10 10, 20 20 20 )",
 				"POINT (11 11 10 )",
-				0.816496580927726);
+				0.816496580927726,
+				coord(11, 11, NaN),
+				coord(11, 11, 10));
 	}
-	
+
 	public void testPointSegRobust() {
 		checkDistance(	"LINESTRING (0 0 0, 10000000 10000000 1 )",
 				"POINT (9999999 9999999 .9999999 )",
@@ -105,7 +120,7 @@ public class Distance3DOpTest extends TestCase
 				"POINT (5000000 5000000 .5 )",
 				0 );
 	}
-	
+
 	public void testCrossSegmentsFlat() {
 		checkDistance(	"LINESTRING (0 0 0, 10 10 0 )",
 				"LINESTRING (10 0 0, 0 10 0 )",
@@ -114,7 +129,7 @@ public class Distance3DOpTest extends TestCase
 				"LINESTRING (10 0 10, 0 10 10 )",
 		0);
 	}
-	
+
 	public void testCrossSegments() {
 		checkDistance(	"LINESTRING (0 0 0, 10 10 0 )",
 				"LINESTRING (10 0 1, 0 10 1 )",
@@ -126,7 +141,7 @@ public class Distance3DOpTest extends TestCase
 				"LINESTRING (10 10 20, 20 20 10 )",
 		0);
 	}
-	
+
 	/**
 	 * Many of these tests exhibit robustness errors 
 	 * due to numerical roundoff in the distance algorithm mathematics.
@@ -137,34 +152,36 @@ public class Distance3DOpTest extends TestCase
 		checkDistance(	"LINESTRING (0 0 0, 10000000 10000000 1 )",
 				"LINESTRING (0 0 1, 10000000 10000000 0 )",
 				0, 0.001);  // expected is 0, but actual is larger
-		
+
 		checkDistance(	"LINESTRING (-10000 -10000 0, 10000 10000 1 )",
 				"LINESTRING (-10000 -10000 1, 10000 10000 0 )",
 				0);
-		
+
 		// previous case with X,Y scaled by 1000 - exposes robustness issue
 		checkDistance(	"LINESTRING (-10000000 -10000000 0, 10000000 10000000 1 )",
 				"LINESTRING (-10000000 -10000000 1, 10000000 10000000 0 )",
 				0, 0.02);  // expected is 0, but actual is larger
-		
+
 		// works because lines are orthogonal, so doesn't hit roundoff problems
 		checkDistance(	"LINESTRING (20000000 10000000 20, 10000000 20000000 10 )",
 				"LINESTRING (10000000 10000000 20, 20000000 20000000 10 )",
 				0);
 	}
-	
+
 	public void testTSegmentsFlat() {
 		checkDistance(	"LINESTRING (10 10 0, 10 20 0 )",
-						"LINESTRING (20 15 0, 25 15 0 )",
-				10);
+				"LINESTRING (20 15 0, 25 15 0 )",
+				10,
+				coord(10, 15, NaN),
+				coord(20, 15, 0));
 	}
-	
+
 	public void testParallelSegmentsFlat() {
 		checkDistance(	"LINESTRING (10 10 0, 20 20 0 )",
 						"LINESTRING (10 20 0, 20 30 0 )",
 						7.0710678118654755);
 	}
-	
+
 	public void testParallelSegments() {
 		checkDistance(	"LINESTRING (0 0 0, 1 0 0 )",
 						"LINESTRING (0 0 1, 1 0 1 )",
@@ -178,17 +195,19 @@ public class Distance3DOpTest extends TestCase
 				// = distance from LINESTRING (10 10 0, 20 20 0 ) to POINT(10 20 10)
 				// = hypotenuse(7.0710678118654755, 10)
 	}
-	
+
 	public void testLineLine()
 	{
 		checkDistance(	"LINESTRING (0 1 2, 1 1 1, 1 0 2 )",
 				"LINESTRING (0 0 0.1, .5 .5 0, 1 1 0, 1.5 1.5 0, 2 2 0 )",
-				1);		
+				1);
 		checkDistance(	"LINESTRING (10 10 20, 20 20 30, 20 20 1, 30 30 5 )",
 				"LINESTRING (1 80 10, 0 39 5, 39 0 5, 80 1 20)",
-				0.7071067811865476);		
+				0.7071067811865476,
+				coord(20, 20, 30),
+				coord(19.5, 19.5, NaN));
 	}
-	
+
 	public void testPointPolygon()
 	{
 		// point above poly
@@ -204,114 +223,128 @@ public class Distance3DOpTest extends TestCase
 				"POLYGON ((0 100 200, 0 200 200, 0 200 100, 0 100 100, 0 100 200))",
 				10);				
 	}
-	
+
 	public void testPointPolygonFlat()
 	{
 		// inside
 		checkDistance(	"POINT (150 150 0)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				0);	
+				0,
+				coord(150, 150, 0),
+				coord(150, 150, 0));
 		// outside
 		checkDistance(	"POINT (250 250 0)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				70.71067811865476);				
+				70.71067811865476,
+				coord(250, 250, 0),
+				coord(200, 200, 0));
 		// on
 		checkDistance(	"POINT (200 200 0)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				0);				
+				0);
 	}
-	
+
 	public void testLinePolygonFlat()
 	{
 		// line inside
 		checkDistance(	"LINESTRING (150 150 0, 160 160 0)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				0);	
+				0);
 		// line outside
 		checkDistance(	"LINESTRING (200 250 0, 260 260 0)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				50);	
+				50,
+				coord(200, 250, 0),
+				coord(200, 200, 0));
 		// line touching
 		checkDistance(	"LINESTRING (200 200 0, 260 260 0)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				0);				
+				0);
 	}
-	
+
 	public void testLinePolygonSimple()
 	{
 		// line crossing inside
 		checkDistance(	"LINESTRING (150 150 10, 150 150 -10)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				0);	
+				0);
 		// vertical line above
 		checkDistance(	"LINESTRING (200 200 10, 260 260 100)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				10);	
+				10);
 		// vertical line touching
 		checkDistance(	"LINESTRING (200 200 0, 260 260 100)",
 				"POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0))",
-				0);				
+				0);
 	}
-	
+
 	String polyHoleFlat = "POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0), (120 180 0, 180 180 0, 180 120 0, 120 120 0, 120 180 0))";
 
 	public void testLinePolygonHoleFlat()
 	{
 		// line crossing hole
-		checkDistance(	"LINESTRING (150 150 10, 150 150 -10)", 	polyHoleFlat, 30);	
+		checkDistance(	"LINESTRING (150 150 10, 150 150 -10)", 	polyHoleFlat, 30,
+				coord(150, 150, 10), coord(150, 180, NaN));
 		// line crossing interior
-		checkDistance(	"LINESTRING (110 110 10, 110 110 -10)",		polyHoleFlat, 0);	
+		checkDistance(	"LINESTRING (110 110 10, 110 110 -10)",		polyHoleFlat, 0,
+				coord(110, 110, -10), coord(110, 110, -10));
 		// vertical line above hole
-		checkDistance(	"LINESTRING (130 130 10, 150 150 100)",		polyHoleFlat, 14.14213562373095);	
+		checkDistance(	"LINESTRING (130 130 10, 150 150 100)",		polyHoleFlat, 14.14213562373095,
+				coord(130, 130, 10), coord(130, 120, NaN));
 		// vertical line touching hole
-		checkDistance(	"LINESTRING (120 180 0, 120 180 100)",		polyHoleFlat, 0);				
+		checkDistance(	"LINESTRING (120 180 0, 120 180 100)",		polyHoleFlat, 0,
+				coord(120, 180, 0), coord(120, 180, 0));
 	}
-	
+
 	public void testPointPolygonHoleFlat()
 	{
 		// point above poly hole
-		checkDistance(	"POINT (130 130 10)", 	polyHoleFlat, 14.14213562373095);	
+		checkDistance(	"POINT (130 130 10)", 	polyHoleFlat, 14.14213562373095,
+				coord(130, 130, 10), coord(130, 120, NaN));
 		// point below poly hole
-		checkDistance(	"POINT (130 130 -10)", 	polyHoleFlat, 14.14213562373095);
+		checkDistance(	"POINT (130 130 -10)", 	polyHoleFlat, 14.14213562373095,
+				coord(130, 130, -10), coord(130, 120, NaN));
 		// point above poly
-		checkDistance(	"POINT (110 110 100)", 	polyHoleFlat, 100);
+		checkDistance(	"POINT (110 110 100)", 	polyHoleFlat, 100,
+				coord(110, 110, 100), coord(110, 110, 100));
 	}
-	
+
 	String poly2HoleFlat = "POLYGON ((100 200 0, 200 200 0, 200 100 0, 100 100 0, 100 200 0), (110 110 0, 110 130 0, 130 130 0, 130 110 0, 110 110 0), (190 110 0, 170 110 0, 170 130 0, 190 130 0, 190 110 0))";	
 
 	/**
-	 * A case proving that polygon/polygon distance requires 
+	 * A case proving that polygon/polygon distance requires
 	 * computing distance between all rings, not just the shells.
 	 */
 	public void testPolygonPolygonLinkedThruHoles()
 	{
 		// note distance is zero!
-		checkDistance(	
+		checkDistance(
 				// polygon with two holes
 				poly2HoleFlat,
 				// polygon parallel to XZ plane with shell passing through holes in other polygon
-				"POLYGON ((120 120 -10, 120 120 100, 180 120 100, 180 120 -10, 120 120 -10))", 
-				0);	
-		
+				"POLYGON ((120 120 -10, 120 120 100, 180 120 100, 180 120 -10, 120 120 -10))",
+				0);
+
 		// confirm that distance of simple poly boundary is non-zero
-		checkDistance(	
+		checkDistance(
 				// polygon with two holes
 				poly2HoleFlat,
 				// boundary of polygon parallel to XZ plane with shell passing through holes
-				"LINESTRING (120 120 -10, 120 120 100, 180 120 100, 180 120 -10, 120 120 -10)", 
-				10);	
+				"LINESTRING (120 120 -10, 120 120 100, 180 120 100, 180 120 -10, 120 120 -10)",
+				10);
 	}
 
-	
+
 	public void testMultiPoint()
 	{
 		checkDistance(
 				"MULTIPOINT ((0 0 0), (0 0 100), (100 100 100))",
 				"MULTIPOINT ((100 100 99), (50 50 50), (25 100 33))",
-				1
-				);
+				1,
+				coord(100, 100, 100),
+				coord(100, 100, 99));
 	}
-	
+
 	public void testMultiLineString()
 	{
 		checkDistance(
@@ -320,7 +353,7 @@ public class Distance3DOpTest extends TestCase
 				1
 				);
 	}
-	
+
 	public void testMultiPolygon()
 	{
 		checkDistance(
@@ -331,28 +364,38 @@ public class Distance3DOpTest extends TestCase
 				10
 				);
 	}
-	
+
 	public void testMultiMixed()
 	{
 		checkDistance(
 				"MULTILINESTRING ((0 0 0, 10 10 10), (0 0 100, 25 25 25, 40 40 50), (100 100 100, 100 101 101))",
 				"MULTIPOINT ((100 100 99), (50 50 50), (25 100 33))",
-				1
-				);
+				1,
+				coord(100, 100, 100), coord(100, 100, 99));
 	}
-	
+
+
 	//==========================================================
 	// Convenience methods
 	//==========================================================
-	
+
 	private static final double DIST_TOLERANCE = 0.00001;
-	
+
 	private void checkDistance(String wkt1, String wkt2, double expectedDistance)
 	{
 		checkDistance(wkt1, wkt2, expectedDistance, DIST_TOLERANCE);
 	}
 
-	private void checkDistance(String wkt1, String wkt2, double expectedDistance, double tolerance)
+	private void checkDistance(String wkt1, String wkt2, double expectedDistance, Coordinate... expectedCoordinates)
+	{
+		checkDistance(wkt1, wkt2, expectedDistance, expectedCoordinates, DIST_TOLERANCE);
+	}
+
+	private void checkDistance(String wkt1, String wkt2, double expectedDistance, double tolerance) {
+		checkDistance(wkt1, wkt2, expectedDistance, new Coordinate[0], tolerance);
+	}
+
+	private void checkDistance(String wkt1, String wkt2, double expectedDistance, Coordinate[] expectedCoords, double tolerance)
 	{
 		Geometry g1;
 		Geometry g2;
@@ -367,15 +410,39 @@ public class Distance3DOpTest extends TestCase
 			throw new RuntimeException(e.toString());
 		}
 		// check both orders for arguments
-		checkDistance(g1, g2, expectedDistance, tolerance);
-		checkDistance(g2, g1, expectedDistance, tolerance);
+		checkDistance(g1, g2, expectedDistance, expectedCoords, tolerance);
+		checkDistance(g2, g1, expectedDistance, reversed(expectedCoords), tolerance);
 	}
 
-	private void checkDistance(Geometry g1, Geometry g2, double expectedDistance, double tolerance)
+	private void checkDistance(Geometry g1, Geometry g2, double expectedDistance, Coordinate[] expectedCoords, double tolerance)
 	{
 		Distance3DOp distOp = new Distance3DOp(g1, g2);
 		double dist = distOp.distance();
 		assertEquals(expectedDistance, dist, tolerance);
+
+		if (expectedCoords.length == 2) {
+			Coordinate[] nearestCoords = distOp.nearestPoints();
+			assertTrue(nearestCoords[0].equals2D(expectedCoords[0], tolerance));
+			assertTrue(nearestCoords[1].equals2D(expectedCoords[1], tolerance));
+			if (!Double.isNaN(expectedCoords[0].getZ())) {
+				assertTrue(nearestCoords[0].equalInZ(expectedCoords[0], tolerance));
+			}
+			if (!Double.isNaN(expectedCoords[1].getZ())) {
+				assertTrue(nearestCoords[1].equalInZ(expectedCoords[1], tolerance));
+			}
+		}
 	}
-	
+
+	private Coordinate coord(double x, double y, double z) {
+		return new Coordinate(x, y, z);
+	}
+
+	private Coordinate[] reversed(Coordinate[] coordinates) {
+		Coordinate[] reversed = new Coordinate[coordinates.length];
+		int maxIndex = coordinates.length - 1;
+		for (int i = 0; i < coordinates.length; i++) {
+			reversed[i] = coordinates[maxIndex - i];
+		}
+		return reversed;
+	}
 }


### PR DESCRIPTION
Coordinates returned by `Distance3Dop.nearestPoints()` had a reversed order. 
Additionally, the javadoc has been clarified to note that `Distance3Dop` does not interpolate Z ordinate which was not obvious.