### PR TITLE
Fix UnaryUnion empty handling, add GeometryFactory createEmpty

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryFactory.java
@@ -252,6 +252,11 @@ public class GeometryFactory
     return precisionModel;
   }
 
+  /**
+   * Constructs an empty {@link Point} geometry.
+   * 
+   * @return an empty Point
+   */
   public Point createPoint() {
 	return createPoint(getCoordinateSequenceFactory().create(new Coordinate[]{}));
   }
@@ -278,6 +283,11 @@ public class GeometryFactory
   	return new Point(coordinates, this);
   }
   
+  /**
+   * Constructs an empty {@link MultiLineString} geometry.
+   * 
+   * @return an empty MultiLineString
+   */
   public MultiLineString createMultiLineString() {
     return new MultiLineString(null, this);
   }
@@ -293,6 +303,11 @@ public class GeometryFactory
   	return new MultiLineString(lineStrings, this);
   }
   
+  /**
+   * Constructs an empty {@link GeometryCollection} geometry.
+   * 
+   * @return an empty GeometryCollection
+   */
   public GeometryCollection createGeometryCollection() {
     return new GeometryCollection(null, this);
   }
@@ -308,6 +323,11 @@ public class GeometryFactory
   	return new GeometryCollection(geometries, this);
   }
   
+  /**
+   * Constructs an empty {@link MultiPolygon} geometry.
+   * 
+   * @return an empty MultiPolygon
+   */
   public MultiPolygon createMultiPolygon() {
     return new MultiPolygon(null, this);
   }
@@ -327,6 +347,11 @@ public class GeometryFactory
     return new MultiPolygon(polygons, this);
   }
   
+  /**
+   * Constructs an empty {@link LinearRing} geometry.
+   * 
+   * @return an empty LinearRing
+   */
   public LinearRing createLinearRing() {
     return createLinearRing(getCoordinateSequenceFactory().create(new Coordinate[]{}));
   }
@@ -356,6 +381,11 @@ public class GeometryFactory
     return new LinearRing(coordinates, this);
   }
   
+  /**
+   * Constructs an empty {@link MultiPoint} geometry.
+   * 
+   * @return an empty MultiPoint
+   */
   public MultiPoint createMultiPoint() {
     return new MultiPoint(null, this);
   }
@@ -477,6 +507,11 @@ public class GeometryFactory
     return createPolygon(shell, null);
   }
   
+  /**
+   * Constructs an empty {@link Polygon} geometry.
+   * 
+   * @return an empty polygon
+   */
   public Polygon createPolygon() {
     return createPolygon(null, null);
   }
@@ -559,6 +594,11 @@ public class GeometryFactory
     return geom0;
   }
   
+  /**
+   * Constructs an empty {@link LineString} geometry.
+   * 
+   * @return an empty LineString
+   */
   public LineString createLineString() {
     return createLineString(getCoordinateSequenceFactory().create(new Coordinate[]{}));
   }
@@ -582,6 +622,24 @@ public class GeometryFactory
 	return new LineString(coordinates, this);
   }
 
+  /**
+   * Creates an empty atomic geometry of the given dimension.
+   * If passed a dimension of -1 will create an empty {@link GeometryCollection}.
+   * 
+   * @param dimension the required dimension (-1, 0, 1 or 2)
+   * @return an empty atomic geometry of given dimension
+   */
+  public Geometry createEmpty(int dimension) {
+    switch (dimension) {
+    case -1: return createGeometryCollection();
+    case 0: return createPoint();
+    case 1: return createLineString();
+    case 2: return createPolygon();
+    default:
+      throw new IllegalArgumentException("Invalid dimension: " + dimension);
+    }
+  }
+  
   /**
    * Creates a deep copy of the input {@link Geometry}.
    * The {@link CoordinateSequenceFactory} defined for this factory

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlay/OverlayOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlay/OverlayOp.java
@@ -639,22 +639,13 @@ public class OverlayOp
    */
   public static Geometry createEmptyResult(int overlayOpCode, Geometry a, Geometry b, GeometryFactory geomFact)
   {
-  	Geometry result = null;
-  	switch (resultDimension(overlayOpCode, a, b)) {
-  	case -1:
-  		result = geomFact.createGeometryCollection();
-  		break;
-  	case 0:
-  		result =  geomFact.createPoint();
-  		break;
-  	case 1:
-  		result =  geomFact.createLineString();
-  		break;
-  	case 2:
-  		result =  geomFact.createPolygon();
-  		break;
-  	}
-		return result;
+    Geometry result = null;
+    int resultDim = resultDimension(overlayOpCode, a, b);
+
+    /**
+     * Handles resultSDim = -1, although should not happen
+     */
+    return result =  geomFact.createEmpty(resultDim);
   }
   
   private static int resultDimension(int opCode, Geometry g0, Geometry g1)

--- a/modules/core/src/main/java/org/locationtech/jts/operation/union/InputExtracter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/union/InputExtracter.java
@@ -1,0 +1,125 @@
+package org.locationtech.jts.operation.union;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.locationtech.jts.geom.Dimension;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFilter;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.util.Assert;
+
+
+/**
+ * Extracts atomic elements from 
+ * input geometries or collections, 
+ * recording the dimension found.
+ * Empty geometries are discarded since they 
+ * do not contribute to the result of {@link UnaryUnionOp}.
+ * 
+ * @author Martin Davis
+ *
+ */
+class InputExtracter implements GeometryFilter 
+{
+  public static InputExtracter extract(Collection<Geometry> geoms) {
+    InputExtracter extracter = new InputExtracter();
+    extracter.add(geoms);
+    return extracter;
+  }
+  
+  public static InputExtracter extract(Geometry geom) {
+    InputExtracter extracter = new InputExtracter();
+    extracter.add(geom);
+    return extracter;
+  }
+  
+  private GeometryFactory geomFactory = null;
+  private List<Polygon> polygons = new ArrayList<Polygon>();
+  private List<LineString> lines = new ArrayList<LineString>();
+  private List<Point> points = new ArrayList<Point>();
+  
+  /**
+   * The default dimension for an empty GeometryCollection
+   */
+  private int dimension = Dimension.FALSE;
+  
+  public InputExtracter() {
+    
+  }
+  
+  public boolean isEmpty() {
+    return polygons.isEmpty() 
+        && lines.isEmpty()
+        && points.isEmpty();
+  }
+  
+  public int getDimension() {
+    return dimension;
+  }
+  
+  public GeometryFactory getFactory() {
+    return geomFactory;
+  }
+  
+  public List getExtract(int dim) {
+    switch (dim) {
+    case 0: return points;
+    case 1: return lines;
+    case 2: return polygons;
+    }
+    Assert.shouldNeverReachHere("Invalid dimension: "  + dim);
+    return null;
+  }
+  
+  private void add(Collection<Geometry> geoms) {
+    for (Geometry geom : geoms) {
+      add(geom);
+    }
+  }
+  
+  private void add(Geometry geom) {
+    if (geomFactory == null)
+      geomFactory = geom.getFactory();
+    
+    geom.apply(this);
+  }
+
+  @Override
+  public void filter(Geometry geom) {
+    recordDimension( geom.getDimension() );
+    
+    if (geom instanceof GeometryCollection) {
+      return;
+    }
+    /**
+     * Don't keep empty geometries
+     */
+    if (geom.isEmpty()) 
+      return;
+    
+    if (geom instanceof Polygon) {
+      polygons.add((Polygon) geom);
+      return;
+    }
+    else if (geom instanceof LineString) {
+      lines.add((LineString) geom);
+      return;
+    }
+    else if (geom instanceof Point) {
+      points.add((Point) geom);
+      return;
+    }
+    Assert.shouldNeverReachHere("Unhandled geometry type: " + geom.getGeometryType());
+  }
+
+  private void recordDimension(int dim) {
+    if (dim > dimension )
+      dimension = dim;
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/geom/GeometryFactoryTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/GeometryFactoryTest.java
@@ -50,6 +50,26 @@ public class GeometryFactoryTest extends TestCase {
     checkCreateGeometryExact("GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)), LINESTRING (250 100, 350 200), POINT (350 150))");
   }
   
+  public void testCreateEmpty() {
+    checkEmpty( geometryFactory.createEmpty(0), Point.class);
+    checkEmpty( geometryFactory.createEmpty(1), LineString.class);
+    checkEmpty( geometryFactory.createEmpty(2), Polygon.class);
+    
+    checkEmpty( geometryFactory.createPoint(), Point.class);
+    checkEmpty( geometryFactory.createLineString(), LineString.class);
+    checkEmpty( geometryFactory.createPolygon(), Polygon.class);
+    
+    checkEmpty( geometryFactory.createMultiPoint(), MultiPoint.class);
+    checkEmpty( geometryFactory.createMultiLineString(), MultiLineString.class);
+    checkEmpty( geometryFactory.createMultiPolygon(), MultiPolygon.class);
+    checkEmpty( geometryFactory.createGeometryCollection(), GeometryCollection.class);
+  }
+  
+  private void checkEmpty(Geometry geom, Class clz) {
+    assertTrue(geom.isEmpty());
+    assertTrue( geom.getClass() == clz );
+  }
+
   public void testDeepCopy() throws ParseException
   {
     Point g = (Point) read("POINT ( 10 10) ");

--- a/modules/core/src/test/java/org/locationtech/jts/operation/union/UnaryUnionTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/union/UnaryUnionTest.java
@@ -39,6 +39,12 @@ public class UnaryUnionTest extends GeometryTestCase
     doTest(new String[]{}, "GEOMETRYCOLLECTION EMPTY");
   }
 
+  public void testEmptyPolygon()
+  throws Exception
+  {
+    doTest("POLYGON EMPTY", "POLYGON EMPTY");
+  }
+
   public void testPoints()
   throws Exception
   {
@@ -61,14 +67,23 @@ public class UnaryUnionTest extends GeometryTestCase
   private void doTest(String[] inputWKT, String expectedWKT) 
   throws ParseException
   {
-  	Geometry result;
-  	Collection geoms = IOUtil.readWKT(inputWKT);
-  	if (geoms.size() == 0)
-  		result = UnaryUnionOp.union(geoms, geomFact);
-  	else
-  		result = UnaryUnionOp.union(geoms);
-  	
-  	checkEqual(IOUtil.readWKT(expectedWKT), result);
+    Geometry result;
+    Collection geoms = readList(inputWKT);
+    if (geoms.size() == 0)
+      result = UnaryUnionOp.union(geoms, geomFact);
+    else
+      result = UnaryUnionOp.union(geoms);
+    
+    checkEqual(read(expectedWKT), result);
+  }
+
+  private void doTest(String inputWKT, String expectedWKT) 
+  throws ParseException
+  {
+    Geometry geom = read(inputWKT);
+    Geometry result = UnaryUnionOp.union(geom);
+    
+    checkEqual(read(expectedWKT), result);
   }
 
 }

--- a/modules/tests/src/test/resources/testxml/general/TestUnaryUnion.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestUnaryUnion.xml
@@ -145,7 +145,7 @@
 </case>
 
 <case>
-  <desc>mP - multipolygon (invalid) with topology collapse</desc>
+  <desc>mA - multipolygon (invalid) with topology collapse</desc>
   <a>    MULTIPOLYGON (((0 0, 150 0, 150 1, 0 0)), 
   ((180 0, 20 0, 20 100, 180 100, 180 0)))
   </a>
@@ -156,6 +156,82 @@
   </test>
 </case>
 
+<case>
+  <desc>P - empty Point</desc>
+  <a> POINT EMPTY
+  </a>
+  <test>
+    <op name="union" arg1="A">
+  POINT EMPTY
+    </op>
+  </test>
+</case>
+
+<case>
+  <desc>L - empty LineString</desc>
+  <a> LINESTRING EMPTY
+  </a>
+  <test>
+    <op name="union" arg1="A">
+  LINESTRING EMPTY
+    </op>
+  </test>
+</case>
+
+<case>
+  <desc>A - empty Polygon</desc>
+  <a> POLYGON EMPTY
+  </a>
+  <test>
+    <op name="union" arg1="A">
+  POLYGON EMPTY
+    </op>
+  </test>
+</case>
+
+<case>
+  <desc>mP - empty MultiPoint</desc>
+  <a> MULTIPOINT EMPTY
+  </a>
+  <test>
+    <op name="union" arg1="A">
+  POINT EMPTY
+    </op>
+  </test>
+</case>
+
+<case>
+  <desc>mL - empty MultiLineString</desc>
+  <a>    MULTILINESTRING EMPTY
+  </a>
+  <test>
+    <op name="union" arg1="A">
+  LINESTRING EMPTY
+    </op>
+  </test>
+</case>
+
+<case>
+  <desc>mA - empty MultiPolygon</desc>
+  <a>    MULTIPOLYGON EMPTY
+  </a>
+  <test>
+    <op name="union" arg1="A">
+  POLYGON EMPTY
+    </op>
+  </test>
+</case>
+
+<case>
+  <desc>GC - empty GeometryCollection</desc>
+  <a>    GEOMETRYCOLLECTION EMPTY
+  </a>
+  <test>
+    <op name="union" arg1="A">
+  GEOMETRYCOLLECTION EMPTY
+    </op>
+  </test>
+</case>
 
 
 </run>


### PR DESCRIPTION
* fix `UnaryUnion` empty handling, to make it consistent with binary union (i.e. return an empty atomic geometry of appropriate dimension)
* add `GeometryFactory.createEmpty`