### PR TITLE
Enforce polygon ring orientation with GeometryFactory

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/geom/GeometryFactoryTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/GeometryFactoryTest.java
@@ -12,6 +12,7 @@
 
 package org.locationtech.jts.geom;
 
+import org.locationtech.jts.algorithm.Orientation;
 import org.locationtech.jts.geom.impl.CoordinateArraySequenceFactory;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.locationtech.jts.io.ParseException;
@@ -49,22 +50,22 @@ public class GeometryFactoryTest extends TestCase {
     checkCreateGeometryExact("MULTIPOLYGON (((100 200, 200 200, 200 100, 100 100, 100 200)), ((300 200, 400 200, 400 100, 300 100, 300 200)))");
     checkCreateGeometryExact("GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)), LINESTRING (250 100, 350 200), POINT (350 150))");
   }
-  
+
   public void testCreateEmpty() {
     checkEmpty( geometryFactory.createEmpty(0), Point.class);
     checkEmpty( geometryFactory.createEmpty(1), LineString.class);
     checkEmpty( geometryFactory.createEmpty(2), Polygon.class);
-    
+
     checkEmpty( geometryFactory.createPoint(), Point.class);
     checkEmpty( geometryFactory.createLineString(), LineString.class);
     checkEmpty( geometryFactory.createPolygon(), Polygon.class);
-    
+
     checkEmpty( geometryFactory.createMultiPoint(), MultiPoint.class);
     checkEmpty( geometryFactory.createMultiLineString(), MultiLineString.class);
     checkEmpty( geometryFactory.createMultiPolygon(), MultiPolygon.class);
     checkEmpty( geometryFactory.createGeometryCollection(), GeometryCollection.class);
   }
-  
+
   private void checkEmpty(Geometry geom, Class clz) {
     assertTrue(geom.isEmpty());
     assertTrue( geom.getClass() == clz );
@@ -77,7 +78,7 @@ public class GeometryFactoryTest extends TestCase {
     g.getCoordinateSequence().setOrdinate(0, 0, 99);
     assertTrue(! g.equalsExact(g2));
   }
-  
+
   public void testMultiPointCS()
   {
     GeometryFactory gf = new GeometryFactory(new PackedCoordinateSequenceFactory());
@@ -86,18 +87,18 @@ public class GeometryFactoryTest extends TestCase {
     mpSeq.setOrdinate(0, 1, -2);
     mpSeq.setOrdinate(0, 2, 10);
     mpSeq.setOrdinate(0, 3, 20);
-    
+
     MultiPoint mp = gf.createMultiPoint(mpSeq);
     CoordinateSequence pSeq = ((Point)mp.getGeometryN(0)).getCoordinateSequence();
     assertEquals(4, pSeq.getDimension());
     for (int i = 0; i < 4; i++)
       assertEquals(mpSeq.getOrdinate(0, i), pSeq.getOrdinate(0, i));
   }
-  
+
   /**
      * CoordinateArraySequences default their dimension to 3 unless explicitly told otherwise.
      * This test ensures that GeometryFactory.createGeometry() recreates the input dimension properly.
-   * 
+   *
    * @throws ParseException
    */
   public void testCopyGeometryWithNonDefaultDimension() throws ParseException
@@ -106,23 +107,181 @@ public class GeometryFactoryTest extends TestCase {
     CoordinateSequence mpSeq = gf.getCoordinateSequenceFactory().create(1, 2);
     mpSeq.setOrdinate(0, 0, 50);
     mpSeq.setOrdinate(0, 1, -2);
-    
+
     Point g = gf.createPoint(mpSeq);
     CoordinateSequence pSeq = ((Point) g.getGeometryN(0)).getCoordinateSequence();
     assertEquals(2, pSeq.getDimension());
-    
+
     Point g2 = (Point) geometryFactory.createGeometry(g);
     assertEquals(2, g2.getCoordinateSequence().getDimension());
 
   }
-  
+
+  public void testShellRingOrientationSetting() {
+
+    // check default
+    GeometryFactory gf = new GeometryFactory();
+    assertEquals(GeometryFactory.RING_ORIENTATION_DONTCARE,  gf.getRingOrientationForPolygonShell());
+
+    // Check for valid ring orientation values
+    gf = new GeometryFactory();
+    testShellRingOrientationSetter(gf, GeometryFactory.RING_ORIENTATION_DONTCARE, 0);
+    gf = new GeometryFactory();
+    testShellRingOrientationSetter(gf, GeometryFactory.RING_ORIENTATION_CW, 0);
+    gf = new GeometryFactory();
+    testShellRingOrientationSetter(gf, GeometryFactory.RING_ORIENTATION_RIGHT_HAND_RULE, 0);
+    gf = new GeometryFactory();
+    testShellRingOrientationSetter(gf, GeometryFactory.RING_ORIENTATION_CCW, 0);
+    gf = new GeometryFactory();
+    testShellRingOrientationSetter(gf, GeometryFactory.RING_ORIENTATION_LEFT_HAND_RULE, 0);
+
+    // check for invalid arguments
+    gf = new GeometryFactory();
+    testShellRingOrientationSetter(gf, -1, 1);
+    testShellRingOrientationSetter(gf, 3, 1);
+
+    // check preventation of setting after first usage
+    int ro = gf.getRingOrientationForPolygonShell();
+    // don't fail if value does not change
+    testShellRingOrientationSetter(gf, ro, 0);
+    testShellRingOrientationSetter(gf, GeometryFactory.RING_ORIENTATION_LEFT_HAND_RULE, 2);
+  }
+
+  public void testShellRingOrientationEnforcement()
+  {
+    assertTrue(testShellRingOrientationEnforcement(GeometryFactory.RING_ORIENTATION_DONTCARE));
+    assertTrue(testShellRingOrientationEnforcement(GeometryFactory.RING_ORIENTATION_CCW));
+    assertTrue(testShellRingOrientationEnforcement(GeometryFactory.RING_ORIENTATION_CW));
+  }
+
+  private static boolean testShellRingOrientationEnforcement(int ringOrientation) {
+    GeometryFactory gf = new GeometryFactory();
+    gf.setRingOrientationForPolygonShell(ringOrientation);
+    CoordinateSequenceFactory cf = gf.getCoordinateSequenceFactory();
+
+    CoordinateSequence origShellSequence = createRing(cf, 0, ringOrientation);
+    CoordinateSequence[] origHolesSequences = new CoordinateSequence[] {
+      createRing(cf, 1, ringOrientation),
+      createRing(cf, 2, ringOrientation) };
+
+    LinearRing shell = gf.createLinearRing(origShellSequence.copy());
+    LinearRing[] holes = new LinearRing[] {
+      gf.createLinearRing(origHolesSequences[0].copy()),
+      gf.createLinearRing(origHolesSequences[1].copy()) };
+
+    Polygon polygon = gf.createPolygon(shell, holes);
+    switch (ringOrientation) {
+      case GeometryFactory.RING_ORIENTATION_CW:
+        if (Orientation.isCCW(polygon.getExteriorRing().getCoordinateSequence()))
+          return false;
+        if (!Orientation.isCCW(polygon.getInteriorRingN(0).getCoordinateSequence()))
+          return false;
+        if (!Orientation.isCCW(polygon.getInteriorRingN(1).getCoordinateSequence()))
+          return false;
+        break;
+      case GeometryFactory.RING_ORIENTATION_CCW:
+        if (!Orientation.isCCW(polygon.getExteriorRing().getCoordinateSequence()))
+          return false;
+        if (Orientation.isCCW(polygon.getInteriorRingN(0).getCoordinateSequence()))
+          return false;
+        if (Orientation.isCCW(polygon.getInteriorRingN(1).getCoordinateSequence()))
+          return false;
+        break;
+      case GeometryFactory.RING_ORIENTATION_DONTCARE:
+        if (Orientation.isCCW(polygon.getExteriorRing().getCoordinateSequence()) !=
+            Orientation.isCCW(origShellSequence))
+          return false;
+        if (Orientation.isCCW(polygon.getInteriorRingN(0).getCoordinateSequence()) !=
+          Orientation.isCCW(origHolesSequences[0]))
+          return false;
+        if (Orientation.isCCW(polygon.getInteriorRingN(1).getCoordinateSequence()) !=
+          Orientation.isCCW(origHolesSequences[1]))
+          return false;
+        break;
+    }
+
+    // Set up a polygon with hole using buffer
+    Coordinate pt = new Coordinate(0, 0);
+    Geometry c = gf.createPoint(pt);
+    Geometry b = c.buffer(10d);
+    Geometry s = c.buffer(6d);
+    Polygon test = (Polygon)b.difference(s);
+
+    if (ringOrientation == GeometryFactory.RING_ORIENTATION_CW) {
+      if (Orientation.isCCW(test.getExteriorRing().getCoordinateSequence()))
+        return false;
+      if (!Orientation.isCCW(test.getInteriorRingN(0).getCoordinateSequence()))
+        return false;
+    } else if (ringOrientation == GeometryFactory.RING_ORIENTATION_CCW) {
+      if (!Orientation.isCCW(test.getExteriorRing().getCoordinateSequence()))
+        return false;
+      if (Orientation.isCCW(test.getInteriorRingN(0).getCoordinateSequence()))
+        return false;
+    }
+    return true;
+  }
+
+  private static Coordinate[] createCcwRing(int number) {
+    if (number == 0)
+      return new Coordinate[]{
+        new Coordinate(0, 0), new Coordinate(10, 0),
+        new Coordinate(10, 10), new Coordinate(0, 10),
+        new Coordinate(0, 0)};
+    if (number == 1)
+      return new Coordinate[]{
+        new Coordinate(2, 1), new Coordinate(9, 1),
+        new Coordinate(9, 8), new Coordinate(2, 1)
+      };
+
+    return new Coordinate[]{
+      new Coordinate(1, 2), new Coordinate(8, 9),
+      new Coordinate(1, 9), new Coordinate(1, 2)
+    };
+  }
+
+  private static boolean reverseSequence = false;
+
+  private static CoordinateSequence createRing(CoordinateSequenceFactory factory, int ring, int orientation) {
+    Coordinate[] coordinates = createCcwRing(ring);
+    if (orientation == GeometryFactory.RING_ORIENTATION_CW)
+      CoordinateArrays.reverse(coordinates);
+    if (orientation == GeometryFactory.RING_ORIENTATION_DONTCARE)
+    {
+      if (reverseSequence) CoordinateArrays.reverse(coordinates);
+      reverseSequence = !reverseSequence;
+    }
+
+    return factory.create(coordinates);
+  }
+
+  private static void testShellRingOrientationSetter(GeometryFactory gf, int ringOrientation, int failKind) {
+    try {
+      gf.setRingOrientationForPolygonShell(ringOrientation);
+      if (failKind != 0) fail();
+      assertEquals(ringOrientation, gf.getRingOrientationForPolygonShell());
+    }
+    catch (IllegalArgumentException iae)
+    {
+      if (failKind != 1) fail();
+      return;
+    }
+    catch (IllegalStateException isa)
+    {
+      if (failKind != 2) fail();
+      return;
+    }
+    catch (Exception e) {
+      fail();
+    }
+  }
+
   private void checkCreateGeometryExact(String wkt) throws ParseException
   {
     Geometry g = read(wkt);
     Geometry g2 = geometryFactory.createGeometry(g);
     assertTrue(g.equalsExact(g2));
   }
-  
+
   private Geometry read(String wkt) throws ParseException
   {
     return reader.read(wkt);

--- a/modules/core/src/test/java/org/locationtech/jts/geom/MiscellaneousTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/MiscellaneousTest.java
@@ -89,7 +89,7 @@ public class MiscellaneousTest extends TestCase {
 
     assertTrue(geometryFactory.createLinearRing((CoordinateSequence)null).isEmpty());
     assertTrue(geometryFactory.createLineString((Coordinate[])null).isEmpty());
-    assertTrue(geometryFactory.createPolygon(null, null).isEmpty());
+    assertTrue(geometryFactory.createPolygon((LinearRing)null, null).isEmpty());
     assertTrue(geometryFactory.createMultiPolygon(null).isEmpty());
     assertTrue(geometryFactory.createMultiLineString(null).isEmpty());
     assertTrue(geometryFactory.createMultiPoint((Point[]) null).isEmpty());
@@ -97,7 +97,7 @@ public class MiscellaneousTest extends TestCase {
     assertEquals(-1, (geometryFactory.createPoint((Coordinate)null)).getBoundaryDimension());
     assertEquals(-1, (geometryFactory.createLinearRing((CoordinateSequence)null)).getBoundaryDimension());
     assertEquals(0, (geometryFactory.createLineString((Coordinate[])null)).getBoundaryDimension());
-    assertEquals(1, (geometryFactory.createPolygon(null, null)).getBoundaryDimension());
+    assertEquals(1, (geometryFactory.createPolygon((LinearRing)null, null)).getBoundaryDimension());
     assertEquals(1, (geometryFactory.createMultiPolygon(null)).getBoundaryDimension());
     assertEquals(0, (geometryFactory.createMultiLineString(null)).getBoundaryDimension());
     assertEquals(-1, (geometryFactory.createMultiPoint((Point[]) null)).getBoundaryDimension());
@@ -105,7 +105,7 @@ public class MiscellaneousTest extends TestCase {
     assertEquals(0, (geometryFactory.createPoint((Coordinate)null)).getNumPoints());
     assertEquals(0, (geometryFactory.createLinearRing((CoordinateSequence)null)).getNumPoints());
     assertEquals(0, (geometryFactory.createLineString((Coordinate[])null)).getNumPoints());
-    assertEquals(0, (geometryFactory.createPolygon(null, null)).getNumPoints());
+    assertEquals(0, (geometryFactory.createPolygon((LinearRing)null, null)).getNumPoints());
     assertEquals(0, (geometryFactory.createMultiPolygon(null)).getNumPoints());
     assertEquals(0, (geometryFactory.createMultiLineString(null)).getNumPoints());
     assertEquals(0, (geometryFactory.createMultiPoint((Point[]) null)).getNumPoints());
@@ -113,7 +113,7 @@ public class MiscellaneousTest extends TestCase {
     assertEquals(0, (geometryFactory.createPoint((Coordinate)null)).getCoordinates().length);
     assertEquals(0, (geometryFactory.createLinearRing((CoordinateSequence)null)).getCoordinates().length);
     assertEquals(0, (geometryFactory.createLineString((Coordinate[])null)).getCoordinates().length);
-    assertEquals(0, (geometryFactory.createPolygon(null, null)).getCoordinates().length);
+    assertEquals(0, (geometryFactory.createPolygon((LinearRing)null, null)).getCoordinates().length);
     assertEquals(0, (geometryFactory.createMultiPolygon(null)).getCoordinates().length);
     assertEquals(0, (geometryFactory.createMultiLineString(null)).getCoordinates().length);
     assertEquals(0, (geometryFactory.createMultiPoint((Point[]) null)).getCoordinates().length);
@@ -206,7 +206,7 @@ public class MiscellaneousTest extends TestCase {
   }
 
   public void testEmptyPolygon() throws Exception {
-    Polygon p = geometryFactory.createPolygon(null, null);
+    Polygon p = geometryFactory.createPolygon((LinearRing) null, null);
     assertEquals(2, p.getDimension());
     assertEquals(new Envelope(), p.getEnvelopeInternal());
     assertTrue(p.isSimple());

--- a/modules/lab/src/main/java/org/locationtech/jtslab/geom/util/GeometryEditorEx.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/geom/util/GeometryEditorEx.java
@@ -30,13 +30,13 @@ import org.locationtech.jts.util.Assert;
 
 
 /**
- * A class which supports creating new {@link Geometry}s 
+ * A class which supports creating new {@link Geometry}s
  * which are modifications of existing ones,
  * maintaining the same type structure.
  * Geometry objects are intended to be treated as immutable.
  * This class "modifies" Geometrys
  * by traversing them, applying a user-defined
- * {@link GeometryEditorOperation}, {@link CoordinateSequenceOperation} or {@link CoordinateOperation}  
+ * {@link GeometryEditorOperation}, {@link CoordinateSequenceOperation} or {@link CoordinateOperation}
  * and creating new Geometrys with the same structure but
  * (possibly) modified components.
  * <p>
@@ -58,19 +58,19 @@ import org.locationtech.jts.util.Assert;
  * If changing the structure is required, use a {@link GeometryTransformer}.
  * <p>
  * This class supports creating an edited Geometry
- * using a different <code>GeometryFactory</code> via the {@link #GeometryEditor(GeometryFactory)}
- * constructor.  
- * Examples of situations where this is required is if the geometry is 
+ * using a different <code>GeometryFactory</code> via the {@link #GeometryEditorEx(GeometryFactory)}
+ * constructor.
+ * Examples of situations where this is required is if the geometry is
  * transformed to a new SRID and/or a new PrecisionModel.
  * <p>
  * <b>Usage Notes</b>
  * <ul>
  * <li>The resulting Geometry is not checked for validity.
- * If validity needs to be enforced, the new Geometry's 
+ * If validity needs to be enforced, the new Geometry's
  * {@link Geometry#isValid} method should be called.
  * <li>By default the UserData of the input geometry is not copied to the result.
  * </ul>
- * 
+ *
  * @see GeometryTransformer
  * @see Geometry#isValid
  *
@@ -108,9 +108,9 @@ public class GeometryEditorEx
 
   /**
    * Creates a GeometryEditor which edits geometries using
-   * a given {@link GeometryOperation}
+   * a given {@link GeometryEditorOperation}
    * and the same {@link GeometryFactory} as the input Geometry.
-   * 
+   *
    * @param operation the edit operation to use
    */
   public GeometryEditorEx(GeometryEditorOperation operation)
@@ -120,12 +120,12 @@ public class GeometryEditorEx
 
   /**
    * Creates a GeometryEditor which edits geometries using
-   * a given {@link GeometryOperation}
+   * a given {@link GeometryEditorOperation}
    * and the given {@link GeometryFactory}.
-   * 
+   *
    * @param operation the edit operation to use
    * @param targetFactory the GeometryFactory to create  edited Geometrys with
-   * 
+   *
    */
   public GeometryEditorEx(GeometryEditorOperation operation, GeometryFactory targetFactory)
   {
@@ -137,14 +137,14 @@ public class GeometryEditorEx
   /**
    * Sets whether the User Data is copied to the edit result.
    * Only the object reference is copied.
-   * 
+   *
    * @param isUserDataCopied true if the input user data should be copied.
    */
   public void setCopyUserData(boolean isUserDataCopied)
   {
     this.isUserDataCopied = isUserDataCopied;
   }
-  
+
   /**
    * Edit a {@link Geometry}.
    * Clients can create subclasses of {@link GeometryEditorOperation} or
@@ -157,14 +157,14 @@ public class GeometryEditorEx
   {
     // nothing to do
     if (geometry == null) return null;
-    
+
     Geometry result = editInternal(geometry);
     if (isUserDataCopied) {
       result.setUserData(geometry.getUserData());
     }
     return result;
   }
-  
+
   private Geometry editInternal(Geometry geometry)
   {
     // if client did not supply a GeometryFactory, use the one from the input Geometry
@@ -203,7 +203,7 @@ public class GeometryEditorEx
     }
     return newGeom;
   }
-  
+
   private LineString editLineString(LineString geom) {
     LineString newGeom = (LineString) operation.edit(geom, targetFactory);
     if (newGeom == null) {
@@ -216,7 +216,7 @@ public class GeometryEditorEx
     }
     return newGeom;
   }
-  
+
   private LinearRing editLinearRing(LinearRing geom) {
     LinearRing newGeom = (LinearRing) operation.edit(geom, targetFactory);
     if (newGeom == null) {
@@ -229,7 +229,7 @@ public class GeometryEditorEx
     }
     return newGeom;
   }
-  
+
   private Polygon editPolygon(Polygon polygon) {
     Polygon newPolygon = (Polygon) operation.edit(polygon, targetFactory);
     // create one if needed
@@ -246,7 +246,7 @@ public class GeometryEditorEx
 
     LinearRing shell = (LinearRing) edit(newPolygon.getExteriorRing());
     if (shell == null || shell.isEmpty()) {
-      return targetFactory.createPolygon(null, null);
+      return targetFactory.createPolygon((LinearRing) null, null);
     }
 
     ArrayList holes = new ArrayList();
@@ -268,11 +268,11 @@ public class GeometryEditorEx
     // MD - not sure why this is done - could just check original collection?
     GeometryCollection collectionForType = (GeometryCollection) operation.edit(collection,
         targetFactory);
-    
+
     if (collectionForType != collection) {
       return collectionForType;
     }
-    
+
     // edit the component geometries
     ArrayList geometries = new ArrayList();
     for (int i = 0; i < collectionForType.getNumGeometries(); i++) {
@@ -315,7 +315,7 @@ public class GeometryEditorEx
      * It may be <code>null</code> if the geometry is to be deleted.
      *
      * @param geometry the Geometry to modify
-     * @param factory the factory with which to construct the modified Geometry
+     * @param targetFactory the factory with which to construct the modified Geometry
      * (may be different to the factory of the input geometry)
      * @return a new Geometry which is a modification of the input Geometry
      * @return null if the Geometry is to be deleted completely
@@ -326,9 +326,9 @@ public class GeometryEditorEx
   /**
    * A GeometryEditorOperation which does not modify
    * the input geometry.
-   * This can be used for simple changes of 
+   * This can be used for simple changes of
    * GeometryFactory (including PrecisionModel and SRID).
-   * 
+   *
    * @author mbdavis
    *
    */
@@ -340,7 +340,7 @@ public class GeometryEditorEx
   		return geometry;
   	}
   }
-  
+
   /**
    * A {@link GeometryEditorOperation} which edits the coordinate list of a {@link Geometry}.
    * Operates on Geometry subclasses which contains a single coordinate list.
@@ -384,7 +384,7 @@ public class GeometryEditorEx
     public abstract Coordinate[] edit(Coordinate[] coordinates,
                                       Geometry geometry);
   }
-  
+
   /**
    * A {@link GeometryEditorOperation} which edits the {@link CoordinateSequence}
    * of a {@link Geometry}.
@@ -418,7 +418,7 @@ public class GeometryEditorEx
     /**
      * Edits a {@link CoordinateSequence} from a {@link Geometry}.
      *
-     * @param coordseq the coordinate array to operate on
+     * @param coordSeq the coordinate array to operate on
      * @param geometry the geometry containing the coordinate list
      * @return an edited coordinate sequence (which may be the same as the input)
      */


### PR DESCRIPTION
JTS currently does not rely on/enforce a specific polygon ring orientation.
The OGC Simple Features - Common Architecture v1.2.1 spec (6.1.11.1) specifies
that a polygons exterior ring should be CCW, whereas inner rings should be CW.
Unfortunately, for JTS it is the other way around.

Another reason for this enhancement is, that there are data sources that require
a specific ring orientation for polygons. Oracle, SqlServer (at least for geography)
require CCW, GeoJSON requires CW.

NetTopologySuite/NetTopologySuite#360