### PR TITLE
Fix VariableBufferTest to use an equality tolerance

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/VariableBufferTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/VariableBufferTest.java
@@ -17,6 +17,8 @@ import test.jts.GeometryTestCase;
 
 public class VariableBufferTest extends GeometryTestCase {
 
+  private static final double DEFAULT_TOLERANCE = 1.0e-6;
+
   public VariableBufferTest(String name) {
     super(name);
   }
@@ -82,6 +84,6 @@ public class VariableBufferTest extends GeometryTestCase {
 
   private void checkBuffer(Geometry actual, String wktExpected) {
     Geometry expected = read(wktExpected);
-    checkEqual(expected, actual);
+    checkEqual(expected, actual, DEFAULT_TOLERANCE);
   }
 }

--- a/modules/core/src/test/java/test/jts/GeometryTestCase.java
+++ b/modules/core/src/test/java/test/jts/GeometryTestCase.java
@@ -61,6 +61,17 @@ public abstract class GeometryTestCase extends TestCase{
     assertTrue(equal);
   }
 
+  protected void checkEqual(Geometry expected, Geometry actual, double tolerance) {
+    Geometry actualNorm = actual.norm();
+    Geometry expectedNorm = expected.norm();
+    boolean equal = actualNorm.equalsExact(expectedNorm, tolerance);
+    if (! equal) {
+      System.out.println("FAIL - Expected = " + expectedNorm
+          + " actual = " + actualNorm );
+    }
+    assertTrue(equal);
+  }
+
   protected void checkEqual(Collection expected, Collection actual) {
     checkEqual(toGeometryCollection(expected),toGeometryCollection(actual) );
   }


### PR DESCRIPTION
Issue #501 reported `VariableBufferTest` failing due to a slight variation in FP computation on a Java stack.  This changes the code to use `Geometry.equalsExact` with a distance tolerance, which should fix this problem.
 
Signed-off-by: Martin Davis <mtnclimb@gmail.com>