### PR TITLE
Make Geometry.reverse() consistent

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -49,7 +49,7 @@ import org.locationtech.jts.util.Assert;
  *
  * <H3>Overlay Methods</H3>
  *
- * The overlay methods 
+ * The overlay methods
  * return the most specific class possible to represent the result. If the
  * result is homogeneous, a <code>Point</code>, <code>LineString</code>, or
  * <code>Polygon</code> will be returned if the result contains a single
@@ -109,44 +109,44 @@ import org.locationtech.jts.util.Assert;
  *  report the location of the collapse. <P>
  *
  * <h3>Geometry Equality</h3>
- * 
- * There are two ways of comparing geometries for equality: 
+ *
+ * There are two ways of comparing geometries for equality:
  * <b>structural equality</b> and <b>topological equality</b>.
- * 
+ *
  * <h4>Structural Equality</h4>
  *
- * Structural Equality is provided by the 
- * {@link #equalsExact(Geometry)} method.  
+ * Structural Equality is provided by the
+ * {@link #equalsExact(Geometry)} method.
  * This implements a comparison based on exact, structural pointwise
- * equality. 
- * The {@link #equals(Object)} is a synonym for this method, 
+ * equality.
+ * The {@link #equals(Object)} is a synonym for this method,
  * to provide structural equality semantics for
  * use in Java collections.
  * It is important to note that structural pointwise equality
  * is easily affected by things like
  * ring order and component order.  In many situations
  * it will be desirable to normalize geometries before
- * comparing them (using the {@link #norm()} 
+ * comparing them (using the {@link #norm()}
  * or {@link #normalize()} methods).
  * {@link #equalsNorm(Geometry)} is provided
  * as a convenience method to compute equality over
  * normalized geometries, but it is expensive to use.
  * Finally, {@link #equalsExact(Geometry, double)}
  * allows using a tolerance value for point comparison.
- * 
- * 
+ *
+ *
  * <h4>Topological Equality</h4>
- * 
- * Topological Equality is provided by the 
- * {@link #equalsTopo(Geometry)} method. 
+ *
+ * Topological Equality is provided by the
+ * {@link #equalsTopo(Geometry)} method.
  * It implements the SFS definition of point-set equality
  * defined in terms of the DE-9IM matrix.
  * To support the SFS naming convention, the method
- * {@link #equals(Geometry)} is also provided as a synonym.  
+ * {@link #equals(Geometry)} is also provided as a synonym.
  * However, due to the potential for confusion with {@link #equals(Object)}
  * its use is discouraged.
  * <p>
- * Since {@link #equals(Object)} and {@link #hashCode()} are overridden, 
+ * Since {@link #equals(Object)} and {@link #hashCode()} are overridden,
  * Geometries can be used effectively in Java collections.
  *
  *@version 1.7
@@ -155,7 +155,7 @@ public abstract class Geometry
     implements Cloneable, Comparable, Serializable
 {
   private static final long serialVersionUID = 8763622679187376702L;
-    
+
   static final int SORTINDEX_POINT = 0;
   static final int SORTINDEX_MULTIPOINT = 1;
   static final int SORTINDEX_LINESTRING = 2;
@@ -164,7 +164,7 @@ public abstract class Geometry
   static final int SORTINDEX_POLYGON = 5;
   static final int SORTINDEX_MULTIPOLYGON = 6;
   static final int SORTINDEX_GEOMETRYCOLLECTION = 7;
-  
+
   private final static GeometryComponentFilter geometryChangedFilter = new GeometryComponentFilter() {
     public void filter(Geometry geom) {
       geom.geometryChangedAction();
@@ -262,12 +262,12 @@ public abstract class Geometry
     /**
    *  Sets the ID of the Spatial Reference System used by the <code>Geometry</code>.
    *  <p>
-   *  <b>NOTE:</b> This method should only be used for exceptional circumstances or 
-   *  for backwards compatibility.  Normally the SRID should be set on the 
+   *  <b>NOTE:</b> This method should only be used for exceptional circumstances or
+   *  for backwards compatibility.  Normally the SRID should be set on the
    *  {@link GeometryFactory} used to create the geometry.
-   *  SRIDs set using this method will <i>not</i> be propagated to 
+   *  SRIDs set using this method will <i>not</i> be propagated to
    *  geometries returned by constructive methods.
-   *  
+   *
    *  @see GeometryFactory
    */
   public void setSRID(int SRID) {
@@ -350,19 +350,19 @@ public abstract class Geometry
    *@return null if this Geometry is empty
    */
   public abstract Coordinate getCoordinate();
-  
+
   /**
-   *  Returns an array containing the values of all the vertices for 
+   *  Returns an array containing the values of all the vertices for
    *  this geometry.
    *  If the geometry is a composite, the array will contain all the vertices
    *  for the components, in the order in which the components occur in the geometry.
    *  <p>
-   *  In general, the array cannot be assumed to be the actual internal 
+   *  In general, the array cannot be assumed to be the actual internal
    *  storage for the vertices.  Thus modifying the array
-   *  may not modify the geometry itself. 
+   *  may not modify the geometry itself.
    *  Use the {@link CoordinateSequence#setOrdinate} method
    *  (possibly on the components) to modify the underlying data.
-   *  If the coordinates are modified, 
+   *  If the coordinates are modified,
    *  {@link #geometryChanged} must be called afterwards.
    *
    *@return    the vertices of this <code>Geometry</code>
@@ -461,7 +461,7 @@ public abstract class Geometry
 
   /**
    * Tests whether this is a rectangular {@link Polygon}.
-   * 
+   *
    * @return true if the geometry is a rectangle.
    */
   public boolean isRectangle()
@@ -510,7 +510,7 @@ public abstract class Geometry
    */
   public Point getCentroid()
   {
-    if (isEmpty()) 
+    if (isEmpty())
       return factory.createPoint();
     Coordinate centPt = Centroid.getCentroid(this);
     return createPointFromInternalCoord(centPt, this);
@@ -535,15 +535,15 @@ public abstract class Geometry
 
   /**
    * Returns the dimension of this geometry.
-   * The dimension of a geometry is is the topological 
+   * The dimension of a geometry is is the topological
    * dimension of its embedding in the 2-D Euclidean plane.
    * In the JTS spatial model, dimension values are in the set {0,1,2}.
    * <p>
-   * Note that this is a different concept to the dimension of 
-   * the vertex {@link Coordinate}s.  
+   * Note that this is a different concept to the dimension of
+   * the vertex {@link Coordinate}s.
    * The geometry dimension can never be greater than the coordinate dimension.
-   * For example, a 0-dimensional geometry (e.g. a Point) 
-   * may have a coordinate dimension of 3 (X,Y,Z). 
+   * For example, a 0-dimensional geometry (e.g. a Point)
+   * may have a coordinate dimension of 3 (X,Y,Z).
    *
    *@return the topological dimension of this geometry.
    */
@@ -572,35 +572,35 @@ public abstract class Geometry
   public abstract int getBoundaryDimension();
 
   /**
-   *  Gets a Geometry representing the envelope (bounding box) of 
-   *  this <code>Geometry</code>. 
+   *  Gets a Geometry representing the envelope (bounding box) of
+   *  this <code>Geometry</code>.
    *  <p>
    *  If this <code>Geometry</code> is:
    *  <ul>
-   *  <li>empty, returns an empty <code>Point</code>. 
+   *  <li>empty, returns an empty <code>Point</code>.
    *  <li>a point, returns a <code>Point</code>.
-   *  <li>a line parallel to an axis, a two-vertex <code>LineString</code> 
+   *  <li>a line parallel to an axis, a two-vertex <code>LineString</code>
    *  <li>otherwise, returns a
-   *  <code>Polygon</code> whose vertices are (minx miny, maxx miny, 
+   *  <code>Polygon</code> whose vertices are (minx miny, maxx miny,
    *  maxx maxy, minx maxy, minx miny).
    *  </ul>
    *
    *@return a Geometry representing the envelope of this Geometry
-   *      
-   * @see GeometryFactory#toGeometry(Envelope) 
+   *
+   * @see GeometryFactory#toGeometry(Envelope)
    */
   public Geometry getEnvelope() {
     return getFactory().toGeometry(getEnvelopeInternal());
   }
 
   /**
-   * Gets an {@link Envelope} containing 
+   * Gets an {@link Envelope} containing
    * the minimum and maximum x and y values in this <code>Geometry</code>.
-   * If the geometry is empty, an empty <code>Envelope</code> 
+   * If the geometry is empty, an empty <code>Envelope</code>
    * is returned.
    * <p>
    * The returned object is a copy of the one maintained internally,
-   * to avoid aliasing issues.  
+   * to avoid aliasing issues.
    * For best performance, clients which access this
    * envelope frequently should cache the return value.
    *
@@ -616,7 +616,7 @@ public abstract class Geometry
 
   /**
    * Notifies this geometry that its coordinates have been changed by an external
-   * party (for example, via a {@link CoordinateFilter}). 
+   * party (for example, via a {@link CoordinateFilter}).
    * When this method is called the geometry will flush
    * and/or update any derived information it has cached (such as its {@link Envelope} ).
    * The operation is applied to all component Geometries.
@@ -629,7 +629,7 @@ public abstract class Geometry
    * Notifies this Geometry that its Coordinates have been changed by an external
    * party. When #geometryChanged is called, this method will be called for
    * this Geometry and its component Geometries.
-   * 
+   *
    * @see #apply(GeometryComponentFilter)
    */
   protected void geometryChangedAction() {
@@ -642,7 +642,7 @@ public abstract class Geometry
    * The <code>disjoint</code> predicate has the following equivalent definitions:
    * <ul>
    * <li>The two geometries have no point in common
-   * <li>The DE-9IM Intersection Matrix for the two geometries matches 
+   * <li>The DE-9IM Intersection Matrix for the two geometries matches
    * <code>[FF*FF****]</code>
    * <li><code>! g.intersects(this) = true</code>
    * <br>(<code>disjoint</code> is the inverse of <code>intersects</code>)
@@ -664,7 +664,7 @@ public abstract class Geometry
    * <p>
    * The <code>touches</code> predicate has the following equivalent definitions:
    * <ul>
-   * <li>The geometries have at least one point in common, 
+   * <li>The geometries have at least one point in common,
    * but their interiors do not intersect.
    * <li>The DE-9IM Intersection Matrix for the two geometries matches
    * at least one of the following patterns
@@ -677,7 +677,7 @@ public abstract class Geometry
    * If both geometries have dimension 0, the predicate returns <code>false</code>,
    * since points have only interiors.
    * This predicate is symmetric.
-   * 
+   *
    *
    *@param  g  the <code>Geometry</code> with which to compare this <code>Geometry</code>
    *@return        <code>true</code> if the two <code>Geometry</code>s touch;
@@ -795,7 +795,7 @@ public abstract class Geometry
    * <ul>
    * <li>Every point of this geometry is a point of the other geometry,
    * and the interiors of the two geometries have at least one point in common.
-   * <li>The DE-9IM Intersection Matrix for the two geometries matches 
+   * <li>The DE-9IM Intersection Matrix for the two geometries matches
    * <code>[T*F**F***]</code>
    * <li><code>g.contains(this) = true</code>
    * <br>(<code>within</code> is the converse of {@link #contains})
@@ -805,7 +805,7 @@ public abstract class Geometry
    * In other words, if a geometry A is a subset of
    * the points in the boundary of a geometry B, <code>A.within(B) = false</code>
    * (As a concrete example, take A to be a LineString which lies in the boundary of a Polygon B.)
-   * For a predicate with similar behaviour but avoiding 
+   * For a predicate with similar behaviour but avoiding
    * this subtle limitation, see {@link #coveredBy}.
    *
    *@param  g  the <code>Geometry</code> with which to compare this <code>Geometry</code>
@@ -827,7 +827,7 @@ public abstract class Geometry
    * <ul>
    * <li>Every point of the other geometry is a point of this geometry,
    * and the interiors of the two geometries have at least one point in common.
-   * <li>The DE-9IM Intersection Matrix for the two geometries matches 
+   * <li>The DE-9IM Intersection Matrix for the two geometries matches
    * the pattern
    * <code>[T*****FF*]</code>
    * <li><code>g.within(this) = true</code>
@@ -837,7 +837,7 @@ public abstract class Geometry
    * contain their boundary".  In other words, if a geometry A is a subset of
    * the points in the boundary of a geometry B, <code>B.contains(A) = false</code>.
    * (As a concrete example, take A to be a LineString which lies in the boundary of a Polygon B.)
-   * For a predicate with similar behaviour but avoiding 
+   * For a predicate with similar behaviour but avoiding
    * this subtle limitation, see {@link #covers}.
    *
    *@param  g  the <code>Geometry</code> with which to compare this <code>Geometry</code>
@@ -852,7 +852,7 @@ public abstract class Geometry
       return false;
     }
     // optimization - P cannot contain a non-zero-length L
-    // Note that a point can contain a zero-length lineal geometry, 
+    // Note that a point can contain a zero-length lineal geometry,
     // since the line has no boundary due to Mod-2 Boundary Rule
     if (g.getDimension() == 1 && getDimension() < 1 && g.getLength() > 0.0) {
       return false;
@@ -905,7 +905,7 @@ public abstract class Geometry
    * <li>Every point of the other geometry is a point of this geometry.
    * <li>The DE-9IM Intersection Matrix for the two geometries matches
    * at least one of the following patterns:
-   *  <ul> 
+   *  <ul>
    *   <li><code>[T*****FF*]</code>
    *   <li><code>[*T****FF*]</code>
    *   <li><code>[***T**FF*]</code>
@@ -1025,15 +1025,15 @@ public abstract class Geometry
   }
 
   /**
-  * Tests whether this geometry is 
+  * Tests whether this geometry is
   * topologically equal to the argument geometry.
    * <p>
    * This method is included for backward compatibility reasons.
    * It has been superseded by the {@link #equalsTopo(Geometry)} method,
    * which has been named to clearly denote its functionality.
    * <p>
-   * This method should NOT be confused with the method 
-   * {@link #equals(Object)}, which implements 
+   * This method should NOT be confused with the method
+   * {@link #equals(Object)}, which implements
    * an exact equality comparison.
    *
    *@param  g  the <code>Geometry</code> with which to compare this <code>Geometry</code>
@@ -1055,20 +1055,20 @@ public abstract class Geometry
    * <li>The two geometries have at least one point in common,
    * and no point of either geometry lies in the exterior of the other geometry.
    * <li>The DE-9IM Intersection Matrix for the two geometries matches
-   * the pattern <code>T*F**FFF*</code> 
+   * the pattern <code>T*F**FFF*</code>
    * <pre>
    * T*F
    * **F
    * FF*
    * </pre>
    * </ul>
-   * <b>Note</b> that this method computes <b>topologically equality</b>. 
+   * <b>Note</b> that this method computes <b>topologically equality</b>.
    * For structural equality, see {@link #equalsExact(Geometry)}.
    *
    *@param g the <code>Geometry</code> with which to compare this <code>Geometry</code>
    *@return <code>true</code> if the two <code>Geometry</code>s are topologically equal
    *
-   *@see #equalsExact(Geometry) 
+   *@see #equalsExact(Geometry)
    */
   public boolean equalsTopo(Geometry g)
   {
@@ -1077,31 +1077,31 @@ public abstract class Geometry
       return false;
     return relate(g).isEquals(getDimension(), g.getDimension());
   }
-  
+
   /**
    * Tests whether this geometry is structurally and numerically equal
    * to a given <code>Object</code>.
-   * If the argument <code>Object</code> is not a <code>Geometry</code>, 
+   * If the argument <code>Object</code> is not a <code>Geometry</code>,
    * the result is <code>false</code>.
    * Otherwise, the result is computed using
    * {@link #equalsExact(Geometry)}.
    * <p>
    * This method is provided to fulfill the Java contract
-   * for value-based object equality. 
-   * In conjunction with {@link #hashCode()} 
-   * it provides semantics which are most useful 
+   * for value-based object equality.
+   * In conjunction with {@link #hashCode()}
+   * it provides semantics which are most useful
    * for using
    * <code>Geometry</code>s as keys and values in Java collections.
    * <p>
    * Note that to produce the expected result the input geometries
-   * should be in normal form.  It is the caller's 
+   * should be in normal form.  It is the caller's
    * responsibility to perform this where required
    * (using {@link Geometry#norm()}
    * or {@link #normalize()} as appropriate).
-   * 
+   *
    * @param o the Object to compare
-   * @return true if this geometry is exactly equal to the argument 
-   * 
+   * @return true if this geometry is exactly equal to the argument
+   *
    * @see #equalsExact(Geometry)
    * @see #hashCode()
    * @see #norm()
@@ -1113,17 +1113,17 @@ public abstract class Geometry
     Geometry g = (Geometry) o;
     return equalsExact(g);
   }
-  
+
   /**
    * Gets a hash code for the Geometry.
-   * 
+   *
    * @return an integer value suitable for use as a hashcode
    */
   public int hashCode()
   {
     return getEnvelopeInternal().hashCode();
   }
-  
+
   public String toString() {
     return toText();
   }
@@ -1144,25 +1144,25 @@ public abstract class Geometry
 	 * Computes a buffer area around this geometry having the given width. The
 	 * buffer of a Geometry is the Minkowski sum or difference of the geometry
 	 * with a disc of radius <code>abs(distance)</code>.
-	 * <p> 
-	 * Mathematically-exact buffer area boundaries can contain circular arcs. 
+	 * <p>
+	 * Mathematically-exact buffer area boundaries can contain circular arcs.
 	 * To represent these arcs using linear geometry they must be approximated with line segments.
-	 * The buffer geometry is constructed using 8 segments per quadrant to approximate 
+	 * The buffer geometry is constructed using 8 segments per quadrant to approximate
 	 * the circular arcs.
 	 * The end cap style is <code>CAP_ROUND</code>.
 	 * <p>
 	 * The buffer operation always returns a polygonal result. The negative or
 	 * zero-distance buffer of lines and points is always an empty {@link Polygon}.
 	 * This is also the result for the buffers of degenerate (zero-area) polygons.
-	 * 
+	 *
 	 * @param distance
 	 *          the width of the buffer (may be positive, negative or 0)
 	 * @return a polygonal geometry representing the buffer region (which may be
 	 *         empty)
-	 * 
+	 *
 	 * @throws TopologyException
 	 *           if a robustness error occurs
-	 * 
+	 *
 	 * @see #buffer(double, int)
 	 * @see #buffer(double, int, int)
 	 */
@@ -1174,7 +1174,7 @@ public abstract class Geometry
 	 * Computes a buffer area around this geometry having the given width and with
 	 * a specified accuracy of approximation for circular arcs.
 	 * <p>
-	 * Mathematically-exact buffer area boundaries can contain circular arcs. 
+	 * Mathematically-exact buffer area boundaries can contain circular arcs.
 	 * To represent these arcs
 	 * using linear geometry they must be approximated with line segments. The
 	 * <code>quadrantSegments</code> argument allows controlling the accuracy of
@@ -1184,7 +1184,7 @@ public abstract class Geometry
 	 * The buffer operation always returns a polygonal result. The negative or
 	 * zero-distance buffer of lines and points is always an empty {@link Polygon}.
 	 * This is also the result for the buffers of degenerate (zero-area) polygons.
-	 * 
+	 *
 	 * @param distance
 	 *          the width of the buffer (may be positive, negative or 0)
 	 * @param quadrantSegments
@@ -1192,10 +1192,10 @@ public abstract class Geometry
 	 *          circle
 	 * @return a polygonal geometry representing the buffer region (which may be
 	 *         empty)
-	 * 
+	 *
 	 * @throws TopologyException
 	 *           if a robustness error occurs
-	 * 
+	 *
 	 * @see #buffer(double)
 	 * @see #buffer(double, int, int)
 	 */
@@ -1278,24 +1278,34 @@ public abstract class Geometry
   /**
    * Computes a new geometry which has all component coordinate sequences
    * in reverse order (opposite orientation) to this one.
-   * 
+   *
    * @return a reversed geometry
    */
-  public abstract Geometry reverse();
-  
+  public Geometry reverse() {
+
+    Geometry res = reverseInternal();
+    if (this.envelope != null)
+      res.envelope = this.envelope.copy();
+    res.setSRID(getSRID());
+
+    return res;
+  }
+
+  protected abstract Geometry reverseInternal();
+
   /**
    * Computes a <code>Geometry</code> representing the point-set which is
    * common to both this <code>Geometry</code> and the <code>other</code> Geometry.
    * <p>
    * The intersection of two geometries of different dimension produces a result
    * geometry of dimension less than or equal to the minimum dimension of the input
-   * geometries. 
+   * geometries.
    * The result geometry may be a heterogeneous {@link GeometryCollection}.
    * If the result is empty, it is an atomic geometry
    * with the dimension of the lowest input dimension.
    * <p>
    * Intersection of {@link GeometryCollection}s is supported
-   * only for homogeneous collection types. 
+   * only for homogeneous collection types.
    * <p>
    * Non-empty heterogeneous {@link GeometryCollection} arguments are not supported.
    *
@@ -1310,7 +1320,7 @@ public abstract class Geometry
   	 * TODO: MD - add optimization for P-A case using Point-In-Polygon
   	 */
     // special case: if one input is empty ==> empty
-    if (this.isEmpty() || other.isEmpty()) 
+    if (this.isEmpty() || other.isEmpty())
       return OverlayOp.createEmptyResult(OverlayOp.INTERSECTION, this, other, factory);
 
     // compute for GCs
@@ -1334,13 +1344,13 @@ public abstract class Geometry
   }
 
   /**
-   * Computes a <code>Geometry</code> representing the point-set 
+   * Computes a <code>Geometry</code> representing the point-set
    * which is contained in both this
    * <code>Geometry</code> and the <code>other</code> Geometry.
    * <p>
    * The union of two geometries of different dimension produces a result
    * geometry of dimension equal to the maximum dimension of the input
-   * geometries. 
+   * geometries.
    * The result geometry may be a heterogeneous
    * {@link GeometryCollection}.
    * If the result is empty, it is an atomic geometry
@@ -1351,12 +1361,12 @@ public abstract class Geometry
    * "noding" means that there will be a node or endpoint in the result for
    * every endpoint or line segment crossing in the input. "Dissolving" means
    * that any duplicate (i.e. coincident) line segments or portions of line
-   * segments will be reduced to a single line segment in the result. 
+   * segments will be reduced to a single line segment in the result.
    * If <b>merged</b> linework is required, the {@link LineMerger}
    * class can be used.
    * <p>
    * Non-empty {@link GeometryCollection} arguments are not supported.
-   * 
+   *
    * @param other
    *          the <code>Geometry</code> with which to compute the union
    * @return a point-set combining the points of this <code>Geometry</code> and the
@@ -1373,14 +1383,14 @@ public abstract class Geometry
     if (this.isEmpty() || other.isEmpty()) {
       if (this.isEmpty() && other.isEmpty())
         return OverlayOp.createEmptyResult(OverlayOp.UNION, this, other, factory);
-        
+
     // special case: if either input is empty ==> other input
       if (this.isEmpty()) return other.copy();
       if (other.isEmpty()) return copy();
     }
-    
+
     // TODO: optimize if envelopes of geometries do not intersect
-    
+
     checkNotGeometryCollection(this);
     checkNotGeometryCollection(other);
     return SnapIfNeededOverlayOp.overlayOp(this, other, OverlayOp.UNION);
@@ -1388,8 +1398,8 @@ public abstract class Geometry
 
   /**
    * Computes a <code>Geometry</code> representing the closure of the point-set
-   * of the points contained in this <code>Geometry</code> that are not contained in 
-   * the <code>other</code> Geometry. 
+   * of the points contained in this <code>Geometry</code> that are not contained in
+   * the <code>other</code> Geometry.
    * <p>
    * If the result is empty, it is an atomic geometry
    * with the dimension of the left-hand input.
@@ -1416,10 +1426,10 @@ public abstract class Geometry
 
   /**
    * Computes a <code>Geometry </code> representing the closure of the point-set
-   * which is the union of the points in this <code>Geometry</code> which are not 
+   * which is the union of the points in this <code>Geometry</code> which are not
    * contained in the <code>other</code> Geometry,
    * with the points in the <code>other</code> Geometry not contained in this
-   * <code>Geometry</code>. 
+   * <code>Geometry</code>.
    * If the result is empty, it is an atomic geometry
    * with the dimension of the highest input dimension.
    * <p>
@@ -1439,7 +1449,7 @@ public abstract class Geometry
       // both empty - check dimensions
       if (this.isEmpty() && other.isEmpty())
         return OverlayOp.createEmptyResult(OverlayOp.SYMDIFFERENCE, this, other, factory);
-        
+
     // special case: if either input is empty ==> result = other arg
       if (this.isEmpty()) return other.copy();
       if (other.isEmpty()) return copy();
@@ -1451,30 +1461,30 @@ public abstract class Geometry
   }
 
 	/**
-	 * Computes the union of all the elements of this geometry. 
+	 * Computes the union of all the elements of this geometry.
 	 * <p>
 	 * This method supports
-	 * {@link GeometryCollection}s 
+	 * {@link GeometryCollection}s
 	 * (which the other overlay operations currently do not).
 	 * <p>
 	 * The result obeys the following contract:
 	 * <ul>
 	 * <li>Unioning a set of {@link LineString}s has the effect of fully noding
 	 * and dissolving the linework.
-	 * <li>Unioning a set of {@link Polygon}s always 
+	 * <li>Unioning a set of {@link Polygon}s always
 	 * returns a {@link Polygonal} geometry (unlike {@link #union(Geometry)},
 	 * which may return geometries of lower dimension if a topology collapse occurred).
 	 * </ul>
-	 * 
+	 *
 	 * @return the union geometry
      * @throws TopologyException if a robustness error occurs
-	 * 
+	 *
 	 * @see UnaryUnionOp
 	 */
 	public Geometry union() {
 		return UnaryUnionOp.union(this);
 	}
-  
+
   /**
    * Returns true if the two <code>Geometry</code>s are exactly equal,
    * up to a specified distance tolerance.
@@ -1486,7 +1496,7 @@ public abstract class Geometry
    * within the given tolerance distance, in exactly the same order.
    * </ul>
    * This method does <i>not</i>
-   * test the values of the <code>GeometryFactory</code>, the <code>SRID</code>, 
+   * test the values of the <code>GeometryFactory</code>, the <code>SRID</code>,
    * or the <code>userData</code> fields.
    * <p>
    * To properly test equality between different geometries,
@@ -1497,7 +1507,7 @@ public abstract class Geometry
    *   are considered equal
    * @return <code>true</code> if this and the other <code>Geometry</code>
    *   have identical structure and point values, up to the distance tolerance.
-   *   
+   *
    * @see #equalsExact(Geometry)
    * @see #normalize()
    * @see #norm()
@@ -1518,7 +1528,7 @@ public abstract class Geometry
    * (such as using geometries as keys in collections).
    * <p>
    * This method does <i>not</i>
-   * test the values of the <code>GeometryFactory</code>, the <code>SRID</code>, 
+   * test the values of the <code>GeometryFactory</code>, the <code>SRID</code>,
    * or the <code>userData</code> fields.
    * <p>
    * To properly test equality between different geometries,
@@ -1527,13 +1537,13 @@ public abstract class Geometry
    *@param  other  the <code>Geometry</code> with which to compare this <code>Geometry</code>
    *@return <code>true</code> if this and the other <code>Geometry</code>
    *      have identical structure and point values.
-   *      
+   *
    * @see #equalsExact(Geometry, double)
    * @see #normalize()
    * @see #norm()
    */
-  public boolean equalsExact(Geometry other) 
-  { 
+  public boolean equalsExact(Geometry other)
+  {
     return this == other || equalsExact(other, 0);
   }
 
@@ -1544,11 +1554,11 @@ public abstract class Geometry
    * versions of both geometries before computing
    * {@link #equalsExact(Geometry)}.
    * <p>
-   * This method is relatively expensive to compute.  
-   * For maximum performance, the client 
+   * This method is relatively expensive to compute.
+   * For maximum performance, the client
    * should instead perform normalization on the individual geometries
    * at an appropriate point during processing.
-   * 
+   *
    * @param g a Geometry
    * @return true if the input geometries are exactly equal in their normalized form
    */
@@ -1557,13 +1567,13 @@ public abstract class Geometry
     if (g == null) return false;
     return norm().equalsExact(g.norm());
   }
-  
+
 
   /**
    *  Performs an operation with or on this <code>Geometry</code>'s
-   *  coordinates. 
+   *  coordinates.
    *  If this method modifies any coordinate values,
-   *  {@link #geometryChanged} must be called to update the geometry state. 
+   *  {@link #geometryChanged} must be called to update the geometry state.
    *  Note that you cannot use this method to
    *  modify this Geometry if its underlying CoordinateSequence's #get method
    *  returns a copy of the Coordinate, rather than the actual Coordinate stored
@@ -1576,8 +1586,8 @@ public abstract class Geometry
 
   /**
    *  Performs an operation on the coordinates in this <code>Geometry</code>'s
-   *  {@link CoordinateSequence}s. 
-   *  If the filter reports that a coordinate value has been changed, 
+   *  {@link CoordinateSequence}s.
+   *  If the filter reports that a coordinate value has been changed,
    *  {@link #geometryChanged} will be called automatically.
    *
    *@param  filter  the filter to apply
@@ -1625,7 +1635,7 @@ public abstract class Geometry
       return null;
     }
   }
-  
+
   /**
    * Creates a deep copy of this {@link Geometry} object.
    * Coordinate sequences contained in it are copied.
@@ -1634,7 +1644,7 @@ public abstract class Geometry
    * <p>
    * <b>NOTE:</b> the userData object reference (if present) is copied,
    * but the value itself is not copied.
-   * If a deep copy is required this must be performed by the caller. 
+   * If a deep copy is required this must be performed by the caller.
    *
    * @return a deep copy of this geometry
    */
@@ -1642,17 +1652,17 @@ public abstract class Geometry
     Geometry copy = copyInternal();
     copy.envelope = envelope == null ? null : envelope.copy();
     copy.SRID = this.SRID;
-    copy.userData = this.userData; 
+    copy.userData = this.userData;
     return copy;
   }
-  
+
   /**
    * An internal method to copy subclass-specific geometry data.
-   * 
+   *
    * @return a copy of the target geometry object.
    */
   protected abstract Geometry copyInternal();
-  
+
   /**
    *  Converts this <code>Geometry</code> to <b>normal form</b> (or <b>
    *  canonical form</b> ). Normal form is a unique representation for <code>Geometry</code>
@@ -1672,8 +1682,8 @@ public abstract class Geometry
 
   /**
    * Creates a new Geometry which is a normalized
-   * copy of this Geometry. 
-   * 
+   * copy of this Geometry.
+   *
    * @return a normalized copy of this geometry.
    * @see #normalize()
    */
@@ -1683,7 +1693,7 @@ public abstract class Geometry
     copy.normalize();
     return copy;
   }
-  
+
   /**
    *  Returns whether this <code>Geometry</code> is greater than, equal to,
    *  or less than another <code>Geometry</code>. <P>
@@ -1807,7 +1817,7 @@ public abstract class Geometry
   /**
    * Tests whether this is an instance of a general {@link GeometryCollection},
    * rather than a homogeneous subclass.
-   * 
+   *
    * @return true if this is a heterogeneous GeometryCollection
    */
   protected boolean isGeometryCollection()
@@ -1890,7 +1900,7 @@ public abstract class Geometry
     if (tolerance == 0) { return a.equals(b); }
     return a.distance(b) <= tolerance;
   }
-  
+
   abstract protected int getSortIndex();
 
   private Point createPointFromInternalCoord(Coordinate coord, Geometry exemplar)

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
@@ -13,8 +13,7 @@
  */
 package org.locationtech.jts.geom;
 
-import java.util.Arrays;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.locationtech.jts.util.Assert;
 
@@ -22,7 +21,7 @@ import org.locationtech.jts.util.Assert;
 /**
  * Models a collection of {@link Geometry}s of
  * arbitrary type and dimension.
- * 
+ *
  *
  *@version 1.7
  */
@@ -218,7 +217,7 @@ public class GeometryCollection extends Geometry {
   public Object clone() {
     return copy();
   }
-  
+
   protected GeometryCollection copyInternal() {
     Geometry[] geometries = new Geometry[this.geometries.length];
     for (int i = 0; i < geometries.length; i++) {
@@ -266,11 +265,11 @@ public class GeometryCollection extends Geometry {
     return 0;
 
   }
-  
+
   protected int getSortIndex() {
     return Geometry.SORTINDEX_GEOMETRYCOLLECTION;
   }
-  
+
   /**
    * Creates a {@link GeometryCollection} with
    * every component reversed.
@@ -278,14 +277,18 @@ public class GeometryCollection extends Geometry {
    *
    * @return a {@link GeometryCollection} in the reverse order
    */
-  public Geometry reverse()
+  public Geometry reverse() {
+    return super.reverse();
+  }
+
+  protected Geometry reverseInternal()
   {
-    int n = geometries.length;
-    Geometry[] revGeoms = new Geometry[n];
-    for (int i = 0; i < geometries.length; i++) {
-      revGeoms[i] = geometries[i].reverse();
+    int numGeometries = geometries.length;
+    Collection<Geometry> reversed = new ArrayList<>(numGeometries);
+    for (int i = 0; i < numGeometries; i++) {
+      reversed.add(geometries[i].reverse());
     }
-    return getFactory().createGeometryCollection(revGeoms);
+    return getFactory().buildGeometry(reversed);
   }
 }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
@@ -13,7 +13,10 @@
  */
 package org.locationtech.jts.geom;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.TreeSet;
 
 import org.locationtech.jts.util.Assert;
 
@@ -276,6 +279,7 @@ public class GeometryCollection extends Geometry {
    * The order of the components in the collection are not reversed.
    *
    * @return a {@link GeometryCollection} in the reverse order
+   * @deprecated
    */
   public Geometry reverse() {
     return super.reverse();

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
@@ -18,21 +18,21 @@ import org.locationtech.jts.operation.BoundaryOp;
  *  Models an OGC-style <code>LineString</code>.
  *  A LineString consists of a sequence of two or more vertices,
  *  along with all points along the linearly-interpolated curves
- *  (line segments) between each 
+ *  (line segments) between each
  *  pair of consecutive vertices.
  *  Consecutive vertices may be equal.
- *  The line segments in the line may intersect each other (in other words, 
+ *  The line segments in the line may intersect each other (in other words,
  *  the linestring may "curl back" in itself and self-intersect.
- *  Linestrings with exactly two identical points are invalid. 
- *  <p> 
- * A linestring must have either 0 or 2 or more points.  
- * If these conditions are not met, the constructors throw 
+ *  Linestrings with exactly two identical points are invalid.
+ *  <p>
+ * A linestring must have either 0 or 2 or more points.
+ * If these conditions are not met, the constructors throw
  * an {@link IllegalArgumentException}
  *
  *@version 1.7
  */
-public class LineString 
-	extends Geometry 
+public class LineString
+	extends Geometry
 	implements Lineal
 {
   private static final long serialVersionUID = 3110669828065365560L;
@@ -62,9 +62,9 @@ public class LineString
 
   /**
    * Constructs a <code>LineString</code> with the given points.
-   *  
+   *
    *@param  points the points of the linestring, or <code>null</code>
-   *      to create the empty geometry. 
+   *      to create the empty geometry.
    * @throws IllegalArgumentException if too few points are provided
    */
   public LineString(CoordinateSequence points, GeometryFactory factory) {
@@ -78,7 +78,7 @@ public class LineString
       points = getFactory().getCoordinateSequenceFactory().create(new Coordinate[]{});
     }
     if (points.size() == 1) {
-      throw new IllegalArgumentException("Invalid number of points in LineString (found " 
+      throw new IllegalArgumentException("Invalid number of points in LineString (found "
       		+ points.size() + " - must be 0 or >= 2)");
     }
     this.points = points;
@@ -180,12 +180,15 @@ public class LineString
    *
    * @return a {@link LineString} with coordinates in the reverse order
    */
-  public Geometry reverse()
+  public Geometry reverse() {
+    return super.reverse();
+  }
+
+  protected Geometry reverseInternal()
   {
     CoordinateSequence seq = points.copy();
     CoordinateSequences.reverse(seq);
-    LineString revLine = getFactory().createLineString(seq);
-    return revLine;
+    return getFactory().createLineString(seq);
   }
 
   /**
@@ -233,7 +236,7 @@ public class LineString
       }
   }
 
-  public void apply(CoordinateSequenceFilter filter) 
+  public void apply(CoordinateSequenceFilter filter)
   {
     if (points.size() == 0)
       return;
@@ -264,7 +267,7 @@ public class LineString
   public Object clone() {
     return copy();
   }
-  
+
   protected LineString copyInternal() {
     return new LineString(points.copy(), factory);
   }
@@ -322,7 +325,7 @@ public class LineString
     LineString line = (LineString) o;
     return comp.compare(this.points, line.points);
   }
-  
+
   protected int getSortIndex() {
     return Geometry.SORTINDEX_LINESTRING;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
@@ -179,6 +179,7 @@ public class LineString
    * order of this objects
    *
    * @return a {@link LineString} with coordinates in the reverse order
+   * @deprecated
    */
   public Geometry reverse() {
     return super.reverse();

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
@@ -21,9 +21,9 @@ package org.locationtech.jts.geom;
  * and the interior of the ring must not self-intersect.
  * Either orientation of the ring is allowed.
  * <p>
- * A ring must have either 0 or 4 or more points.  
+ * A ring must have either 0 or 4 or more points.
  * The first and last points must be equal (in 2D).
- * If these conditions are not met, the constructors throw 
+ * If these conditions are not met, the constructors throw
  * an {@link IllegalArgumentException}
  *
  * @version 1.7
@@ -35,7 +35,7 @@ public class LinearRing extends LineString
    * Empty rings with 0 vertices are also valid.
    */
   public static final int MINIMUM_VALID_SIZE = 4;
-  
+
   private static final long serialVersionUID = -4261142084085851829L;
 
   /**
@@ -50,7 +50,7 @@ public class LinearRing extends LineString
    *@param  SRID            the ID of the Spatial Reference System used by this
    *      <code>LinearRing</code>
    * @throws IllegalArgumentException if the ring is not closed, or has too few points
-   * 
+   *
    * @deprecated Use GeometryFactory instead
    */
   public LinearRing(Coordinate points[], PrecisionModel precisionModel,
@@ -76,7 +76,7 @@ public class LinearRing extends LineString
    *
    *@param  points  a sequence points forming a closed and simple linestring, or
    *      <code>null</code> to create the empty geometry.
-   *      
+   *
    * @throws IllegalArgumentException if the ring is not closed, or has too few points
    *
    */
@@ -90,7 +90,7 @@ public class LinearRing extends LineString
       throw new IllegalArgumentException("Points of LinearRing do not form a closed linestring");
     }
     if (getCoordinateSequence().size() >= 1 && getCoordinateSequence().size() < MINIMUM_VALID_SIZE) {
-      throw new IllegalArgumentException("Invalid number of points in LinearRing (found " 
+      throw new IllegalArgumentException("Invalid number of points in LinearRing (found "
       		+ getCoordinateSequence().size() + " - must be 0 or >= 4)");
     }
   }
@@ -108,7 +108,7 @@ public class LinearRing extends LineString
   /**
    * Tests whether this ring is closed.
    * Empty rings are closed by definition.
-   * 
+   *
    * @return true if this ring is closed
    */
   public boolean isClosed() {
@@ -123,20 +123,23 @@ public class LinearRing extends LineString
   public String getGeometryType() {
     return "LinearRing";
   }
-  
+
   protected int getSortIndex() {
     return Geometry.SORTINDEX_LINEARRING;
   }
-  
+
   protected LinearRing copyInternal() {
     return new LinearRing(points.copy(), factory);
   }
 
   public Geometry reverse()
   {
+    return super.reverse();
+  }
+
+  public Geometry reverseInternal() {
     CoordinateSequence seq = points.copy();
     CoordinateSequences.reverse(seq);
-    LinearRing rev = getFactory().createLinearRing(seq);
-    return rev;
+    return getFactory().createLinearRing(seq);
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
@@ -132,6 +132,7 @@ public class LinearRing extends LineString
     return new LinearRing(points.copy(), factory);
   }
 
+  /** @deprecated */
   public Geometry reverse()
   {
     return super.reverse();

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
@@ -102,19 +102,11 @@ public class MultiLineString
    * are reversed.
    *
    * @return a {@link MultiLineString} in the reverse order
+   * @deprecated
    */
   public Geometry reverse() {
     return super.reverse();
   }
-  /*
-  protected Geometry reverseInternal() {
-    int numGeometries = getNumGeometries();
-    LineString[] revLines = new LineString[numGeometries];
-    for (int i = 0; i < numGeometries; i++) {
-      revLines[numGeometries - 1 - i] = (LineString)geometries[i].reverse();
-    }
-    return getFactory().createMultiLineString(revLines);
-  }*/
 
   protected MultiLineString copyInternal() {
     LineString[] lineStrings = new LineString[this.geometries.length];

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
@@ -20,7 +20,7 @@ import org.locationtech.jts.operation.BoundaryOp;
  *
  *@version 1.7
  */
-public class MultiLineString 
+public class MultiLineString
 	extends GeometryCollection
 	implements Lineal
 	{
@@ -103,16 +103,19 @@ public class MultiLineString
    *
    * @return a {@link MultiLineString} in the reverse order
    */
-  public Geometry reverse()
-  {
-    int nLines = geometries.length;
-    LineString[] revLines = new LineString[nLines];
-    for (int i = 0; i < geometries.length; i++) {
-      revLines[nLines - 1 - i] = (LineString)geometries[i].reverse();
+  public Geometry reverse() {
+    return super.reverse();
+  }
+  /*
+  protected Geometry reverseInternal() {
+    int numGeometries = getNumGeometries();
+    LineString[] revLines = new LineString[numGeometries];
+    for (int i = 0; i < numGeometries; i++) {
+      revLines[numGeometries - 1 - i] = (LineString)geometries[i].reverse();
     }
     return getFactory().createMultiLineString(revLines);
-  }
-  
+  }*/
+
   protected MultiLineString copyInternal() {
     LineString[] lineStrings = new LineString[this.geometries.length];
     for (int i = 0; i < lineStrings.length; i++) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
@@ -119,21 +119,12 @@ public class MultiPolygon
    * The order of the components in the collection are not reversed.
    *
    * @return a MultiPolygon in the reverse order
+   * @deprecated
    */
   public Geometry reverse() {
     return super.reverse();
   }
-  /*
-  protected Geometry reverseInternal()
-  {
-    int numGeometries = getNumGeometries();
-    Polygon[] reversed = new Polygon[numGeometries];
-    for (int i = 0; i < numGeometries; i++) {
-      reversed[i] = (Polygon) geometries[i].reverse();
-    }
-    return getFactory().createMultiPolygon(reversed);
-  }
-  */
+
   protected MultiPolygon copyInternal() {
     Polygon[] polygons = new Polygon[this.geometries.length];
     for (int i = 0; i < polygons.length; i++) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
@@ -18,17 +18,17 @@ import java.util.ArrayList;
 /**
  * Models a collection of {@link Polygon}s.
  * <p>
- * As per the OGC SFS specification, 
- * the Polygons in a MultiPolygon may not overlap, 
+ * As per the OGC SFS specification,
+ * the Polygons in a MultiPolygon may not overlap,
  * and may only touch at single points.
  * This allows the topological point-set semantics
  * to be well-defined.
- *  
+ *
  *
  *@version 1.7
  */
-public class MultiPolygon 
-	extends GeometryCollection 
+public class MultiPolygon
+	extends GeometryCollection
 	implements Polygonal
 {
   private static final long serialVersionUID = -551033529766975875L;
@@ -83,7 +83,7 @@ public class MultiPolygon
     return true;
   }
 */
-  
+
   /**
    * Computes the boundary of this geometry
    *
@@ -112,7 +112,7 @@ public class MultiPolygon
     }
     return super.equalsExact(other, tolerance);
   }
-  
+
   /**
    * Creates a {@link MultiPolygon} with
    * every component reversed.
@@ -120,16 +120,20 @@ public class MultiPolygon
    *
    * @return a MultiPolygon in the reverse order
    */
-  public Geometry reverse()
-  {
-    int n = geometries.length;
-    Polygon[] revGeoms = new Polygon[n];
-    for (int i = 0; i < geometries.length; i++) {
-      revGeoms[i] = (Polygon) geometries[i].reverse();
-    }
-    return getFactory().createMultiPolygon(revGeoms);
+  public Geometry reverse() {
+    return super.reverse();
   }
-  
+  /*
+  protected Geometry reverseInternal()
+  {
+    int numGeometries = getNumGeometries();
+    Polygon[] reversed = new Polygon[numGeometries];
+    for (int i = 0; i < numGeometries; i++) {
+      reversed[i] = (Polygon) geometries[i].reverse();
+    }
+    return getFactory().createMultiPolygon(reversed);
+  }
+  */
   protected MultiPolygon copyInternal() {
     Polygon[] polygons = new Polygon[this.geometries.length];
     for (int i = 0; i < polygons.length; i++) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
@@ -190,6 +190,7 @@ public class Point
     return new Point(coordinates.copy(), factory);
   }
 
+  /** @deprecated */
   public Geometry reverse() {
     return super.reverse();
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
@@ -20,13 +20,13 @@ import org.locationtech.jts.util.Assert;
  *
  * A <code>Point</code> is topologically valid if and only if:
  * <ul>
- * <li>the coordinate which defines it (if any) is a valid coordinate 
+ * <li>the coordinate which defines it (if any) is a valid coordinate
  * (i.e. does not have an <code>NaN</code> X or Y ordinate)
  * </ul>
- * 
+ *
  *@version 1.7
  */
-public class Point 
+public class Point
 	extends Geometry
 	implements Puntal
 {
@@ -158,7 +158,7 @@ public class Point
 	    filter.filter(getCoordinate());
 	  }
 
-  public void apply(CoordinateSequenceFilter filter) 
+  public void apply(CoordinateSequenceFilter filter)
   {
 	    if (isEmpty())
         return;
@@ -185,19 +185,23 @@ public class Point
   public Object clone() {
     return copy();
   }
-  
+
   protected Point copyInternal() {
     return new Point(coordinates.copy(), factory);
   }
 
-  public Geometry reverse()
-  {
-    return copy();
+  public Geometry reverse() {
+    return super.reverse();
   }
-  
-  public void normalize() 
-  { 
-    // a Point is always in normalized form 
+
+  protected Geometry reverseInternal()
+  {
+    return getFactory().createPoint(coordinates.copy());
+  }
+
+  public void normalize()
+  {
+    // a Point is always in normalized form
   }
 
   protected int compareToSameClass(Object other) {
@@ -210,7 +214,7 @@ public class Point
     Point point = (Point) other;
     return comp.compare(this.coordinates, point.coordinates);
   }
-  
+
   protected int getSortIndex() {
     return Geometry.SORTINDEX_POINT;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -417,6 +417,7 @@ public class Polygon
       CoordinateSequences.reverse(seq);
   }
 
+  /** @deprecated */
   public Geometry reverse() {
     return super.reverse();
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -21,12 +21,12 @@ import org.locationtech.jts.algorithm.Orientation;
 
 /**
  * Represents a polygon with linear edges, which may include holes.
- * The outer boundary (shell) 
+ * The outer boundary (shell)
  * and inner boundaries (holes) of the polygon are represented by {@link LinearRing}s.
  * The boundary rings of the polygon may have any orientation.
  * Polygons are closed, simple geometries by definition.
  * <p>
- * The polygon model conforms to the assertions specified in the 
+ * The polygon model conforms to the assertions specified in the
  * <A HREF="http://www.opengis.org/techno/specs.htm">OpenGIS Simple Features
  * Specification for SQL</A>.
  * <p>
@@ -37,15 +37,15 @@ import org.locationtech.jts.algorithm.Orientation;
  * (i.e. are closed and do not self-intersect)
  * <li>holes touch the shell or another hole at at most one point
  * (which implies that the rings of the shell and holes must not cross)
- * <li>the interior of the polygon is connected,  
- * or equivalently no sequence of touching holes 
+ * <li>the interior of the polygon is connected,
+ * or equivalently no sequence of touching holes
  * makes the interior of the polygon disconnected
  * (i.e. effectively split the polygon into two pieces).
  * </ul>
  *
  *@version 1.7
  */
-public class Polygon 
+public class Polygon
 	extends Geometry
 	implements Polygonal
 {
@@ -174,7 +174,7 @@ public class Polygon
   public boolean isEmpty() {
     return shell.isEmpty();
   }
-  
+
   public boolean isRectangle()
   {
     if (getNumInteriorRing() != 0) return false;
@@ -307,13 +307,13 @@ public class Polygon
 	    }
 	  }
 
-  public void apply(CoordinateSequenceFilter filter) 
+  public void apply(CoordinateSequenceFilter filter)
   {
 	    shell.apply(filter);
       if (! filter.isDone()) {
         for (int i = 0; i < holes.length; i++) {
           holes[i].apply(filter);
-          if (filter.isDone()) 
+          if (filter.isDone())
             break;
         }
       }
@@ -344,7 +344,7 @@ public class Polygon
 
     return copy();
   }
-  
+
   protected Polygon copyInternal() {
     LinearRing shellCopy = (LinearRing) shell.copy();
     LinearRing[] holeCopies = new LinearRing[this.holes.length];
@@ -394,7 +394,7 @@ public class Polygon
     if (i < nHole2) return -1;
     return 0;
   }
-  
+
   protected int getSortIndex() {
     return Geometry.SORTINDEX_POLYGON;
   }
@@ -418,13 +418,18 @@ public class Polygon
   }
 
   public Geometry reverse() {
-    Polygon poly = (Polygon) copy();
-    poly.shell = (LinearRing) shell.copy().reverse();
-    poly.holes = new LinearRing[holes.length];
+    return super.reverse();
+  }
+
+  protected Geometry reverseInternal()
+  {
+    LinearRing shell = (LinearRing) getExteriorRing().reverse();
+    LinearRing[] holes = new LinearRing[getNumInteriorRing()];
     for (int i = 0; i < holes.length; i++) {
-      poly.holes[i] = (LinearRing) holes[i].copy().reverse();
+      holes[i] = (LinearRing) getInteriorRingN(i).reverse();
     }
-    return poly;// return the clone
+
+    return getFactory().createPolygon(shell, holes);
   }
 }
 

--- a/modules/core/src/main/java/org/locationtech/jts/linearref/ExtractLineByLocation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/linearref/ExtractLineByLocation.java
@@ -16,7 +16,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateList;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
-import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.Lineal;
 import org.locationtech.jts.util.Assert;
 
 /**
@@ -66,10 +66,9 @@ class ExtractLineByLocation
 
   private Geometry reverse(Geometry linear)
   {
-    if (linear instanceof LineString)
-      return ((LineString) linear).reverse();
-    if (linear instanceof MultiLineString)
-      return ((MultiLineString) linear).reverse();
+    if (linear instanceof Lineal)
+      return linear.reverse();
+
     Assert.shouldNeverReachHere("non-linear geometry encountered");
     return null;
   }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/GeometryReverseTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/GeometryReverseTest.java
@@ -1,0 +1,102 @@
+package org.locationtech.jts.geom;
+
+import test.jts.GeometryTestCase;
+import test.jts.GeometryTestData;
+
+public class GeometryReverseTest  extends GeometryTestCase {
+
+  public static void main(String[] args) throws Exception {
+    junit.textui.TestRunner.run(GeometryCopyTest.class);
+  }
+
+  public GeometryReverseTest(String name) {
+    super(name);
+  }
+
+  public void testReverse() {
+    checkReverse( read( GeometryTestData.WKT_POINT ));
+    checkReverse( read( GeometryTestData.WKT_LINESTRING ));
+    checkReverse( read( GeometryTestData.WKT_LINEARRING ));
+    checkReverse( read( GeometryTestData.WKT_POLY ));
+    checkReverse( read( GeometryTestData.WKT_MULTIPOINT ));
+    checkReverse( read( GeometryTestData.WKT_MULTILINESTRING ));
+    checkReverse( read( GeometryTestData.WKT_MULTIPOLYGON ));
+    checkReverse( read( GeometryTestData.WKT_GC ));
+  }
+
+  private void checkReverse(final Geometry g) {
+    int SRID = 123;
+    g.setSRID(SRID );
+
+    //User data left out for now
+    //Object DATA = new Integer(999);
+    //g.setUserData(DATA);
+
+    Geometry reverse = g.reverse();
+
+    assertTrue( g.getGeometryType() + ": Geometry types are not the same", g.getGeometryType() == reverse.getGeometryType());
+    assertEquals(g.getGeometryType() +": Geometry.getSRID() values are not the same", g.getSRID(), reverse.getSRID());
+
+    assertTrue( g.getGeometryType() +": Sequences are not opposite", checkSequences(g, reverse) );
+  }
+
+  private boolean checkSequences(Geometry g1, Geometry g2) {
+    int numGeometries = g1.getNumGeometries();
+    if (numGeometries != g2.getNumGeometries())
+      return false;
+    for (int i = 0; i < numGeometries; i++)
+    {
+      Geometry gt1 = g1.getGeometryN(i);
+      int j = i; //g1 instanceof MultiLineString ? numGeometries - i - 1 : i;
+      Geometry gt2 = g2.getGeometryN(j);
+
+      if (gt1.getGeometryType() != gt2.getGeometryType())
+        return false;
+
+      if (gt1 instanceof Point) {
+        if (!checkSequences(((Point)gt1).getCoordinateSequence(), ((Point)gt2).getCoordinateSequence()))
+          return false;
+      }
+      else if (gt1 instanceof LineString) {
+        if (!checkSequences(((LineString)gt1).getCoordinateSequence(), ((LineString)gt2).getCoordinateSequence()))
+          return false;
+      }
+      else if (gt1 instanceof Polygon) {
+        Polygon pt1 = (Polygon)gt1;
+        Polygon pt2 = (Polygon)gt2;
+        if (!checkSequences(pt1.getExteriorRing().getCoordinateSequence(),
+                            pt2.getExteriorRing().getCoordinateSequence()))
+          return false;
+        for (int k = 0; k < pt1.getNumInteriorRing(); k++) {
+          if (!checkSequences(pt1.getInteriorRingN(k).getCoordinateSequence(),
+                              pt2.getInteriorRingN(k).getCoordinateSequence()))
+            return false;
+        }
+      }
+      else {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean checkSequences(CoordinateSequence c1, CoordinateSequence c2) {
+
+    if (c1.size() != c2.size())
+      return false;
+    if (c1.getDimension() != c2.getDimension())
+      return false;
+    if (c1.getMeasures() != c2.getMeasures())
+      return false;
+
+    for (int i = 0; i < c1.size(); i++)
+    {
+      int j = c1.size() - i - 1;
+      for (int k = 0; k < c1.getDimension(); k++)
+        if (c1.getOrdinate(i, k) != c2.getOrdinate(j, k))
+          if (!(Double.isNaN(c1.getOrdinate(i, k)) && Double.isNaN(c2.getOrdinate(j, k))))
+            return false;
+    }
+    return true;
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/linearref/LengthIndexedLineTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/linearref/LengthIndexedLineTest.java
@@ -50,7 +50,7 @@ public class LengthIndexedLineTest
   public void testExtractLineReverseMulti()
   {
     checkExtractLine("MULTILINESTRING ((0 0, 10 0), (20 0, 25 0, 30 0))",
-                     19, 1, "MULTILINESTRING ((29 0, 25 0, 20 0), (10 0, 1 0))");
+                     19, 1, "MULTILINESTRING ((10 0, 1 0), (29 0, 25 0, 20 0))");
   }
 
   public void testExtractLineNegative()
@@ -151,9 +151,9 @@ public class LengthIndexedLineTest
     double projIndex = indexedLine.project(new Coordinate(5, 5));
     Coordinate projPt = indexedLine.extractPoint(projIndex);
 //    System.out.println(projPt);
-    assertTrue(projPt.equals3D(new Coordinate(5, 5, 5)));  
+    assertTrue(projPt.equals3D(new Coordinate(5, 5, 5)));
   }
-  
+
   /**
    * Tests that if the input does not have Z ordinates, neither does the output.
    *
@@ -164,9 +164,9 @@ public class LengthIndexedLineTest
     LengthIndexedLine indexedLine = new LengthIndexedLine(linearGeom);
     double projIndex = indexedLine.project(new Coordinate(5, 5));
     Coordinate projPt = indexedLine.extractPoint(projIndex);
-    assertTrue(Double.isNaN(projPt.getZ() ));  
+    assertTrue(Double.isNaN(projPt.getZ() ));
   }
-  
+
   private void checkExtractLine(String wkt, double start, double end, String expected)
   {
     Geometry linearGeom = read(wkt);
@@ -186,30 +186,30 @@ public class LengthIndexedLineTest
   protected boolean indexOfAfterCheck(Geometry linearGeom, Coordinate testPt)
   {
     LengthIndexedLine indexedLine = new LengthIndexedLine(linearGeom);
-    
+
     // check locations are consecutive
     double loc1 = indexedLine.indexOf(testPt);
     double loc2 = indexedLine.indexOfAfter(testPt, loc1);
     if (loc2 <= loc1) return false;
-    
+
     // check extracted points are the same as the input
     Coordinate pt1 = indexedLine.extractPoint(loc1);
     Coordinate pt2 = indexedLine.extractPoint(loc2);
     if (! pt1.equals2D(testPt)) return false;
     if (! pt2.equals2D(testPt)) return false;
-    
+
     return true;
   }
 
   protected boolean indexOfAfterCheck(Geometry linearGeom, Coordinate testPt, Coordinate checkPt)
   {
     LengthIndexedLine indexedLine = new LengthIndexedLine(linearGeom);
-    
+
     // check that computed location is after check location
     double checkLoc = indexedLine.indexOf(checkPt);
     double testLoc = indexedLine.indexOfAfter(testPt, checkLoc);
     if (testLoc < checkLoc) return false;
-    
+
     return true;
   }
 


### PR DESCRIPTION
* Add protected reverseInternal function to Geometry,
  implement in Point, LineString, LinearRing, Polygon and
  GeometryCollection
* Remove abstract from Geometry.reverse function,
  implementation calls reverseInternal and copies
  Envelope and SRID values
* To avoid breaking change make Geometry.reverse overrides
  return super.reverse()
* Add unit test

Note:
The reversal of items in MultiLineString has been removed.

closes to #305

Signed-off-by: Felix Obermaier <felix.obermaier@netcologne.de>