### PR TITLE
Fix bug in DistanceOp for geometries with empty components

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/locate/IndexedPointInAreaLocator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/locate/IndexedPointInAreaLocator.java
@@ -41,7 +41,10 @@ import org.locationtech.jts.index.intervalrtree.SortedPackedIntervalRTree;
  * <p>
  * {@link Polygonal} and {@link LinearRing} geometries
  * are supported.
- * 
+ * <p>
+ * The index is lazy-loaded, which allows
+ * creating instances even if they are not used.
+ * <p>
  * Thread-safe and immutable.
  *
  * @author Martin Davis
@@ -66,8 +69,6 @@ public class IndexedPointInAreaLocator
     if (! (g instanceof Polygonal  || g instanceof LinearRing))
       throw new IllegalArgumentException("Argument must be Polygonal or LinearRing");
     geom = g;
-//    index = new IntervalIndexedGeometry(geom);
-
   }
     
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance/ConnectedElementLocationFilter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance/ConnectedElementLocationFilter.java
@@ -27,6 +27,7 @@ import org.locationtech.jts.geom.Polygon;
  * (e.g. a polygon, linestring or point)
  * and returns them in a list. The elements of the list are 
  * {@link org.locationtech.jts.operation.distance.GeometryLocation}s.
+ * Empty geometries do not provide a location item.
  *
  * @version 1.7
  */
@@ -56,6 +57,8 @@ public class ConnectedElementLocationFilter
 
   public void filter(Geometry geom)
   {
+    // empty geometries do not provide a location
+    if (geom.isEmpty()) return;
     if (geom instanceof Point
       || geom instanceof LineString
       || geom instanceof Polygon )

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance/DistanceOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance/DistanceOp.java
@@ -38,6 +38,8 @@ import org.locationtech.jts.geom.util.PolygonExtracter;
  * the coordinate computed is a close
  * approximation to the exact point.
  * <p>
+ * Empty geometry collection components are ignored.
+ * <p>
  * The algorithms used are straightforward O(n^2)
  * comparisons.  This worst-case performance could be improved on
  * by using Voronoi techniques or spatial indexes.

--- a/modules/tests/src/test/resources/testxml/general/TestDistance.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestDistance.xml
@@ -57,4 +57,11 @@
 <test><op name="distance" arg1="A" arg2="B" >    0.0   </op></test>
 </case>
 
+<case>
+  <desc>mAmA - multipolygon with empty component</desc>
+  <a> MULTIPOLYGON (EMPTY, ((98 200, 200 200, 200 99, 98 99, 98 200))) </a>
+  <b> POLYGON ((300 200, 400 200, 400 100, 300 100, 300 200)) </b>
+<test><op name="distance" arg1="A" arg2="B" >    100.0   </op></test>
+</case>
+
 </run>


### PR DESCRIPTION
Reported as GEOS [295](https://github.com/libgeos/geos/issues/295).

Signed-off-by: Martin Davis <mtnclimb@gmail.com>