### PR TITLE
Fix buffer fillet generation to avoid extra segments

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetSegmentGenerator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetSegmentGenerator.java
@@ -598,23 +598,17 @@ class OffsetSegmentGenerator
 
     if (nSegs < 1) return;    // no segments because angle is less than increment - nothing to do!
 
-    double initAngle, currAngleInc;
+     // choose angle increment so that each segment has equal length
+    double angleInc = totalAngle / nSegs;
 
-    // choose angle increment so that each segment has equal length
-    initAngle = 0.0;
-    currAngleInc = totalAngle / nSegs;
-
-    double currAngle = initAngle;
     Coordinate pt = new Coordinate();
-    while (currAngle < totalAngle) {
-      double angle = startAngle + directionFactor * currAngle;
+    for (int i = 0; i < nSegs; i++) {
+      double angle = startAngle + directionFactor * i * angleInc;
       pt.x = p.x + radius * Math.cos(angle);
       pt.y = p.y + radius * Math.sin(angle);
       segList.addPt(pt);
-      currAngle += currAngleInc;
     }
   }
-
 
   /**
    * Creates a CW circle around a point

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/BufferTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/BufferTest.java
@@ -39,6 +39,23 @@ public class BufferTest extends GeometryTestCase {
     testMultiLineString_separateBuffers_floatingSingle();
   }
   
+  /**
+   * This tests that the algorithm used to generate fillet curves
+   * does not suffer from numeric "slop-over".
+   * See GEOS PR #282.
+   */
+  public void testQuadrantSegmentCount() {
+    Geometry g = read("POINT ( 100 100 )");
+    //checkPointBufferSegmentCount(g, 80, 53);
+    checkPointBufferSegmentCount(g, 80, 129);
+  }
+  
+  private void checkPointBufferSegmentCount(Geometry g, double dist, int quadSegs) {
+    Geometry buf = g.buffer(dist, quadSegs);
+    int segsExpected = 4 * quadSegs + 1;
+    assertEquals(segsExpected, buf.getNumPoints());
+  }
+
   public void testMultiLineString_depthFailure() throws Exception {
     new BufferValidator(
       15,

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/BufferTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/BufferTest.java
@@ -44,9 +44,9 @@ public class BufferTest extends GeometryTestCase {
    * does not suffer from numeric "slop-over".
    * See GEOS PR #282.
    */
-  public void testQuadrantSegmentCount() {
+  public void testPointBufferSegmentCount() {
     Geometry g = read("POINT ( 100 100 )");
-    //checkPointBufferSegmentCount(g, 80, 53);
+    checkPointBufferSegmentCount(g, 80, 53);
     checkPointBufferSegmentCount(g, 80, 129);
   }
   


### PR DESCRIPTION
**Original report: [GEOS 743](https://trac.osgeo.org/geos/ticket/743)**

Due to numeric precision roundoff, it can happen that for large quadrant segment values an extra segment is generated in the buffer fillet curve.  This is most obvious when computing point buffers.  

This fixes the fillet algorithm to be insensitive to numeric roundoff.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>