### PR TITLE
MinimumBoundingCircle.getMaximumDiameter() to handle case where extremalPts are acute triangle

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumBoundingCircle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumBoundingCircle.java
@@ -162,10 +162,14 @@ public class MinimumBoundingCircle
   private static Coordinate[] farthestPoints(Coordinate[] pts) {
     double dist01 = pts[0].distance(pts[1]);
     double dist12 = pts[1].distance(pts[2]);
-    if (dist01 >= dist12) {
+    double dist20 = pts[2].distance(pts[0]);
+    if (dist01 >= dist12 && dist01 >= dist20) {
       return new Coordinate[] { pts[0], pts[1] };
     }
-    return new Coordinate[] { pts[1], pts[2] };
+    if (dist12 >= dist01 && dist12 >= dist20) {
+      return new Coordinate[] { pts[1], pts[2] };
+    }
+    return new Coordinate[] { pts[2], pts[0] };
   }
 
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumBoundingCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumBoundingCircleTest.java
@@ -82,6 +82,7 @@ public class MinimumBoundingCircleTest extends GeometryTestCase {
   public void testMinDiameterPolygon() {
     doMinDiameterTest("POLYGON ((100 200, 300 150, 110 100, 100 200))", "LINESTRING (300 150, 100 200)");
     doMinDiameterTest("POLYGON ((110 200, 300 150, 100 100, 110 200))", "LINESTRING (300 150, 100 100)");
+    doMinDiameterTest("POLYGON ((0 0, 6 0, 5 5, 0 0))", "LINESTRING (5 5, 0 0)");
   }
   
   static final double TOLERANCE = 1.0e-5;


### PR DESCRIPTION
Hello,

It seemed that ```MinimumBoundingCircle.getMaximumDiameter()``` returns farther pair only among ```extremalPts[0]-[1]``` and ```extremalPts[1]-[2]``` if ```extremalPts.length == 3```.

I thought this can cause unexpected result  when ```extremalPts``` consists of 3 points forming acute triangle, and the longest segment is ```extremalPts[2]-[0]```. 
(Please take a look at the case added at ```MinimumBoundingCircleTest.testMinDiameterPolygon()```.)

So I'm suggesting a change for ```farthestPoints()``` to handle this case as well by checking all three segment length.

Maybe I have misunderstood the purpose of ```getMaximumDiameter()```, but if I have understood the method description comments correctly, this fix could be helpful.
Thank you :)
