### PR TITLE
Add DistanceOp line-line short-circuit optimizations

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance/DistanceOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance/DistanceOp.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.locationtech.jts.algorithm.Distance;
 import org.locationtech.jts.algorithm.PointLocator;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineSegment;
 import org.locationtech.jts.geom.LineString;
@@ -383,7 +384,19 @@ public class DistanceOp
     Coordinate[] coord1 = line1.getCoordinates();
       // brute force approach!
     for (int i = 0; i < coord0.length - 1; i++) {
+      
+      // short-circuit if line segment is far from line
+      Envelope env0 = new Envelope(coord0[i], coord0[i + 1]);
+      if (env0.distance(line1.getEnvelopeInternal()) > minDistance)
+        continue;
+      
       for (int j = 0; j < coord1.length - 1; j++) {
+        
+        // short-circuit if line segments are far apart
+        Envelope env1 = new Envelope(coord1[j], coord1[j + 1]);
+        if (env0.distance(env1) > minDistance)
+          continue;
+
         double dist = Distance.segmentToSegment(
                                         coord0[i], coord0[i + 1],
                                         coord1[j], coord1[j + 1] );


### PR DESCRIPTION
Add DistanceOp line-line short-circuit optimizations.
These optimizations add a couple of tests for envelope distance, short-circuiting if the distance is greater than the current minimum.
In a test computing distances from US states to European countries, the performance improved by over 10 times.

Also done in [GEOS 314](https://github.com/libgeos/geos/pull/314)

Signed-off-by: Martin Davis <mtnclimb@gmail.com>