### PR TITLE
Exposing all packages under org.locationtech.* in OSGI enviroment

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -49,6 +49,7 @@
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Bundle-Version>${project.version}</Bundle-Version>
+                        <Export-Package>org.locationtech.jts.*</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This PR exposes all packages under 'org.locationtech.*' in a OSGI enviroment, as a result the package 'org.locationtech.jts.geom.impl' is also exposed. (By default the maven-bundle-plugin is excluding all packages containing 'impl' or 'internal')

relates to #545

Signed-off-by: Quang Tran <quang.tran@mailbox.org>