### PR TITLE
Fix GML coordinates and srsName parsing

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/gml2/GeometryStrategies.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/gml2/GeometryStrategies.java
@@ -336,6 +336,11 @@ public class GeometryStrategies{
 				// now to start parse
 				String t = arg.text.toString();
 				t = t.replaceAll("\\s"," ");
+				/**
+				 * Remove spaces after commas, for when they are used as separators (default).
+				 * This prevents coordinates being split by the tuple separator
+				 */
+				t = t.replaceAll(",\\s+", ",");
 				
 				Pattern ptn = (Pattern) patterns.get(toupleSeperator);
 				if(ptn == null){

--- a/modules/core/src/main/java/org/locationtech/jts/io/gml2/GeometryStrategies.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/gml2/GeometryStrategies.java
@@ -14,6 +14,7 @@ package org.locationtech.jts.io.gml2;
 import java.util.HashMap;
 import java.util.List;
 import java.util.WeakHashMap;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.locationtech.jts.geom.Coordinate;
@@ -490,6 +491,7 @@ public class GeometryStrategies{
 		return strats;
 	}
 	
+	
 	static int getSrid(Attributes attrs, int defaultValue){
 		String srs = null;
 		if(attrs.getIndex(GMLConstants.GML_ATTR_SRSNAME)>=0)
@@ -503,20 +505,29 @@ public class GeometryStrategies{
 				try{
 					return Integer.parseInt(srs);
 				}catch(NumberFormatException e){
-					// rip out the end, uri's are used here sometimes
-					int index = srs.lastIndexOf('#');
-					if(index > -1)
-						srs = srs.substring(index);
-					try{
-						return Integer.parseInt(srs);
-					}catch(NumberFormatException e2){
-						// ignore
-					}
+				  String srsNum = extractIntSuffix(srs);
+				  if (srsNum != null) {
+  					try{
+  						return Integer.parseInt(srsNum);
+  					}catch(NumberFormatException e2){
+  						// ignore
+  					}
+				  }
 				}
 			}
 		}
 		
 		return defaultValue;
+	}
+	
+	static Pattern PATT_SUFFIX_INT = Pattern.compile("(\\d+)$");
+
+	static String extractIntSuffix(String s) {
+	  Matcher matcher = PATT_SUFFIX_INT.matcher(s);
+	  if (matcher.find()) {
+	      return matcher.group(1);
+	  }
+	  return null;
 	}
 	
 	/**

--- a/modules/core/src/main/java/org/locationtech/jts/io/gml2/GeometryStrategies.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/gml2/GeometryStrategies.java
@@ -341,7 +341,7 @@ public class GeometryStrategies{
 				 * Remove spaces after commas, for when they are used as separators (default).
 				 * This prevents coordinates being split by the tuple separator
 				 */
-				t = t.replaceAll(",\\s+", ",");
+				t = t.replaceAll("\\s*,\\s*", ",");
 				
 				Pattern ptn = (Pattern) patterns.get(toupleSeperator);
 				if(ptn == null){

--- a/modules/core/src/test/java/org/locationtech/jts/io/gml2/GMLReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/gml2/GMLReaderTest.java
@@ -1,0 +1,70 @@
+package org.locationtech.jts.io.gml2;
+
+import java.io.IOException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.xml.sax.SAXException;
+
+import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
+
+public class GMLReaderTest extends GeometryTestCase {
+  private static final GeometryFactory geometryFactory = new GeometryFactory();
+
+  public static void main(String args[]) {
+    TestRunner.run(GMLReaderTest.class);
+  }
+
+  public GMLReaderTest(String name) { super(name); }
+
+  public void testPoint() {
+    checkRead("<gml:Point>"
+        + "    <gml:coordinates>45.67,88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)");
+  }
+  
+  public void testPointNoNamespace() {
+    checkRead("<Point>"
+        + "    <coordinates>45.67,88.56</coordinates>"
+        + " </Point>", 
+        "POINT (45.67 88.56)");
+  }
+  
+  public void testPointWithCoordSepSpace() {
+    checkRead("<gml:Point>"
+        + "    <gml:coordinates>45.67, 88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)");
+  }
+
+  public void testPointWithCoordSepMultiSpace() {
+    checkRead("<gml:Point>"
+        + "    <gml:coordinates>45.67,     88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)");
+  }
+
+  public void testLineStringWithCoordSepSpace() {
+    checkRead( "<gml:LineString>"
+        + "    <gml:coordinates>45.67, 88.56 55.56,89.44</gml:coordinates>"
+        + " </gml:LineString >",
+        "LINESTRING (45.67 88.56, 55.56 89.44)");
+  }
+
+  private void checkRead(String gml, String wktExpected) {
+    GMLReader gr = new GMLReader();
+    Geometry g = null;
+    try {
+      g = gr.read(gml, geometryFactory);
+    } catch (SAXException | IOException | ParserConfigurationException e) {
+      //e.printStackTrace();
+      fail(e.getMessage());
+    }
+    Geometry expected = read(wktExpected);
+    checkEqual(expected, g);
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/io/gml2/GMLReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/gml2/GMLReaderTest.java
@@ -55,6 +55,13 @@ public class GMLReaderTest extends GeometryTestCase {
         "LINESTRING (45.67 88.56, 55.56 89.44)");
   }
 
+  public void testLineStringWithManySpaces() {
+    checkRead( "<gml:LineString>"
+        + "    <gml:coordinates>45.67,   88.56    55.56,89.44</gml:coordinates>"
+        + " </gml:LineString >",
+        "LINESTRING (45.67 88.56, 55.56 89.44)");
+  }
+
   private void checkRead(String gml, String wktExpected) {
     GMLReader gr = new GMLReader();
     Geometry g = null;

--- a/modules/core/src/test/java/org/locationtech/jts/io/gml2/GMLReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/gml2/GMLReaderTest.java
@@ -43,9 +43,23 @@ public class GMLReaderTest extends GeometryTestCase {
         "POINT (45.67 88.56)");
   }
 
-  public void testPointWithCoordSepMultiSpace() {
+  public void testPointWithCoordSepMultiSpaceAfter() {
     checkRead("<gml:Point>"
         + "    <gml:coordinates>45.67,     88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)");
+  }
+
+  public void testPointWithCoordSepMultiSpaceBefore() {
+    checkRead("<gml:Point>"
+        + "    <gml:coordinates>45.67   ,88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)");
+  }
+
+  public void testPointWithCoordSepMultiSpaceBoth() {
+    checkRead("<gml:Point>"
+        + "    <gml:coordinates>45.67   ,   88.56</gml:coordinates>"
         + " </gml:Point>", 
         "POINT (45.67 88.56)");
   }

--- a/modules/core/src/test/java/org/locationtech/jts/io/gml2/GMLReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/gml2/GMLReaderTest.java
@@ -6,13 +6,15 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.xml.sax.SAXException;
 
 import junit.textui.TestRunner;
 import test.jts.GeometryTestCase;
 
 public class GMLReaderTest extends GeometryTestCase {
-  private static final GeometryFactory geometryFactory = new GeometryFactory();
+  private static final int DEFAULT_SRID = 9876;
+  private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), DEFAULT_SRID);
 
   public static void main(String args[]) {
     TestRunner.run(GMLReaderTest.class);
@@ -48,6 +50,37 @@ public class GMLReaderTest extends GeometryTestCase {
         "POINT (45.67 88.56)");
   }
 
+  public void testPointSRIDInt() {
+    checkRead("<gml:Point srsName='1234'>"
+        + "    <gml:coordinates>45.67,     88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)", 1234);
+  }
+
+  public void testPointSRIDHash() {
+    checkRead("<gml:Point srsName='some.prefix#4326'>"
+        + "    <gml:coordinates>45.67,     88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)",
+        4326);
+  }
+
+  public void testPointSRIDSlash() {
+    checkRead("<gml:Point srsName='http://www.opengis.net/def/crs/EPSG/0/4326'>"
+        + "    <gml:coordinates>45.67,     88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)",
+        4326);
+  }
+
+  public void testPointSRIDColon() {
+    checkRead("<gml:Point srsName='urn:ogc:def:crs:EPSG::4326'>"
+        + "    <gml:coordinates>45.67,     88.56</gml:coordinates>"
+        + " </gml:Point>", 
+        "POINT (45.67 88.56)",
+        4326);
+  }
+
   public void testLineStringWithCoordSepSpace() {
     checkRead( "<gml:LineString>"
         + "    <gml:coordinates>45.67, 88.56 55.56,89.44</gml:coordinates>"
@@ -63,6 +96,10 @@ public class GMLReaderTest extends GeometryTestCase {
   }
 
   private void checkRead(String gml, String wktExpected) {
+    checkRead(gml, wktExpected, DEFAULT_SRID);
+  } 
+  
+  private void checkRead(String gml, String wktExpected, int srid) {
     GMLReader gr = new GMLReader();
     Geometry g = null;
     try {
@@ -73,5 +110,6 @@ public class GMLReaderTest extends GeometryTestCase {
     }
     Geometry expected = read(wktExpected);
     checkEqual(expected, g);
+    assertEquals("SRID incorrect - ", srid, g.getSRID());
   }
 }


### PR DESCRIPTION
* `coordinates` element parsing now handles spaces before and after comma separators
* `srsName` attribute parsing now extracts the final numeric value as the geometry SRID

Signed-off-by: Martin Davis <mtnclimb@gmail.com>