### PR TITLE
CGAlgorithms: links to alternatives for @deprecated methods and fields

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/CGAlgorithms.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/CGAlgorithms.java
@@ -23,38 +23,51 @@ import org.locationtech.jts.math.MathUtil;
  * double-precision floating point.
  * 
  * @version 1.7
- * @deprecated See Length, Area, Distance, Orientation, PointLocation
+ * @deprecated See {@link Length}, {@link Area}, {@link Distance},
+ *             {@link Orientation}, {@link PointLocation}
  */
 public class CGAlgorithms
 {
 
   /**
    * A value that indicates an orientation of clockwise, or a right turn.
+   * 
+   * @deprecated Use {@link Orientation#CLOCKWISE} instead.
    */
   public static final int CLOCKWISE = -1;
 
   /**
    * A value that indicates an orientation of clockwise, or a right turn.
+   * 
+   * @deprecated Use {@link Orientation#RIGHT} instead.
    */
   public static final int RIGHT = CLOCKWISE;
 
   /**
    * A value that indicates an orientation of counterclockwise, or a left turn.
+   * 
+   * @deprecated Use {@link Orientation#COUNTERCLOCKWISE} instead.
    */
   public static final int COUNTERCLOCKWISE = 1;
 
   /**
    * A value that indicates an orientation of counterclockwise, or a left turn.
+   * 
+   * @deprecated Use {@link Orientation#LEFT} instead.
    */
   public static final int LEFT = COUNTERCLOCKWISE;
 
   /**
    * A value that indicates an orientation of collinear, or no turn (straight).
+   * 
+   * @deprecated Use {@link Orientation#COLLINEAR} instead.
    */
   public static final int COLLINEAR = 0;
 
   /**
    * A value that indicates an orientation of collinear, or no turn (straight).
+   * 
+   * @deprecated Use {@link Orientation#STRAIGHT} instead.
    */
   public static final int STRAIGHT = COLLINEAR;
 
@@ -69,6 +82,8 @@ public class CGAlgorithms
    * @return 1 if q is counter-clockwise (left) from p1-p2
    * @return -1 if q is clockwise (right) from p1-p2
    * @return 0 if q is collinear with p1-p2
+   * @deprecated Use {@link Orientation#index(Coordinate, Coordinate, Coordinate)}
+   *             instead.
    */
   public static int orientationIndex(Coordinate p1, Coordinate p2, Coordinate q)
   {
@@ -122,6 +137,8 @@ public class CGAlgorithms
    * @return true if p is inside ring
    * 
    * @see locatePointInRing
+   * @deprecated Use {@link PointLocation#isInRing(Coordinate, Coordinate[])}
+   *             instead.
    */
   public static boolean isPointInRing(Coordinate p, Coordinate[] ring)
   {
@@ -141,6 +158,9 @@ public class CGAlgorithms
    *          an array of coordinates representing the ring (which must have
    *          first point identical to last point)
    * @return the {@link Location} of p relative to the ring
+   * @deprecated Use
+   *             {@link PointLocation#locateInRing(Coordinate, Coordinate[])}
+   *             instead.
    */
   public static int locatePointInRing(Coordinate p, Coordinate[] ring)
   {
@@ -153,6 +173,8 @@ public class CGAlgorithms
    * 
    * @return true if the point is a vertex of the line or lies in the interior
    *         of a line segment in the linestring
+   * @deprecated Use {@link PointLocation#isOnLine(Coordinate, Coordinate[])}
+   *             instead.
    */
   public static boolean isOnLine(Coordinate p, Coordinate[] pt)
   {
@@ -184,6 +206,7 @@ public class CGAlgorithms
    * @return true if the ring is oriented counter-clockwise.
    * @throws IllegalArgumentException
    *           if there are too few points to determine orientation (&lt; 4)
+   * @deprecated Use {@link Orientation#isCCW(Coordinate[])} instead.
    */
   public static boolean isCCW(Coordinate[] ring)
   {
@@ -265,6 +288,8 @@ public class CGAlgorithms
    * @return 1 if q is counter-clockwise from p1-p2,
    * or -1 if q is clockwise from p1-p2,
    * or 0 if q is collinear with p1-p2
+   * @deprecated Use {@link Orientation#index(Coordinate, Coordinate, Coordinate)}
+   *             instead.
    */
   public static int computeOrientation(Coordinate p1, Coordinate p2,
       Coordinate q)
@@ -284,6 +309,9 @@ public class CGAlgorithms
    * @param B
    *          another point of the line (must be different to A)
    * @return the distance from p to line segment AB
+   * @deprecated Use
+   *             {@link Distance#pointToSegment(Coordinate, Coordinate, Coordinate)}
+   *             instead.
    */
   public static double distancePointLine(Coordinate p, Coordinate A,
       Coordinate B)
@@ -341,6 +369,9 @@ public class CGAlgorithms
    * @param B
    *          another point of the line (must be different to A)
    * @return the distance from p to line AB
+   * @deprecated Use
+   *             {@link Distance#pointToLinePerpendicular(Coordinate, Coordinate, Coordinate)}
+   *             instead.
    */
   public static double distancePointLinePerpendicular(Coordinate p,
       Coordinate A, Coordinate B)
@@ -368,6 +399,9 @@ public class CGAlgorithms
    * @param line
    *          a sequence of contiguous line segments defined by their vertices
    * @return the minimum distance between the point and the line segments
+   * @deprecated Use
+   *             {@link Distance#pointToSegmentString(Coordinate, Coordinate[])}
+   *             instead.
    */
   public static double distancePointLine(Coordinate p, Coordinate[] line)
   {
@@ -398,6 +432,9 @@ public class CGAlgorithms
    *          one point of the line
    * @param D
    *          another point of the line (must be different to A)
+   * @deprecated Use
+   *             {@link Distance#segmentToSegment(Coordinate, Coordinate, Coordinate, Coordinate)}
+   *             instead.
    */
   public static double distanceLineLine(Coordinate A, Coordinate B,
       Coordinate C, Coordinate D)
@@ -476,6 +513,8 @@ public class CGAlgorithms
    * @param ring
    *          the coordinates forming the ring
    * @return the signed area of the ring
+   * @deprecated Use {@link Area#ofRing(Coordinate[])} or
+   *             {@link Area#ofRingSigned(Coordinate[])} instead.
    */
   public static double signedArea(Coordinate[] ring)
   {
@@ -507,6 +546,8 @@ public class CGAlgorithms
    * @param ring
    *          the coordinates forming the ring
    * @return the signed area of the ring
+   * @deprecated Use {@link Area#ofRing(CoordinateSequence)} or
+   *             {@link Area#ofRingSigned(CoordinateSequence)} instead.
    */
   public static double signedArea(CoordinateSequence ring)
   {
@@ -542,6 +583,7 @@ public class CGAlgorithms
    * @param pts
    *          the points specifying the linestring
    * @return the length of the linestring
+   * @deprecated Use {@link Length#ofLine(CoordinateSequence)} instead.
    */
   public static double length(CoordinateSequence pts)
   {


### PR DESCRIPTION
I came across some warnings in one of my projects using JTS warning me about deprecated methods I was using from the CGAlgorithms class. I had trouble finding the actual replacement methods. To spare other users of the library that trouble I added corresponding Javadoc tags @deprecated pointing to the alternative implementations.