### PR TITLE
Enable WKB reading/writing for POINT EMPTY

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKBReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKBReader.java
@@ -13,6 +13,7 @@ package org.locationtech.jts.io;
 
 import java.io.IOException;
 
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
 import org.locationtech.jts.geom.CoordinateSequences;
@@ -254,6 +255,9 @@ public class WKBReader
   private Point readPoint() throws IOException
   {
     CoordinateSequence pts = readCoordinateSequence(1);
+    if (Double.isNaN(pts.getX(0)) || Double.isNaN(pts.getY(0))) {
+      return factory.createPoint();
+    }
     return factory.createPoint(pts);
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKBWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKBWriter.java
@@ -330,11 +330,13 @@ public class WKBWriter
 
   private void writePoint(Point pt, OutStream os) throws IOException
   {
-    if (pt.getCoordinateSequence().size() == 0)
-      throw new IllegalArgumentException("Empty Points cannot be represented in WKB");
     writeByteOrder(os);
     writeGeometryType(WKBConstants.wkbPoint, pt, os);
-    writeCoordinateSequence(pt.getCoordinateSequence(), false, os);
+    if (pt.getCoordinateSequence().size() == 0) {
+      writeNaNs(2, os);
+    } else {
+      writeCoordinateSequence(pt.getCoordinateSequence(), false, os);
+    }
   }
 
   private void writeLineString(LineString line, OutStream os)
@@ -393,6 +395,15 @@ public class WKBWriter
   {
     ByteOrderValues.putInt(intValue, buf, byteOrder);
     os.write(buf, 4);
+  }
+
+  private void writeNaNs(int numNaNs, OutStream os)
+      throws IOException
+  {
+    for (int i = 0; i < numNaNs; i++) {
+      ByteOrderValues.putDouble(Double.NaN, buf, byteOrder);
+      os.write(buf, 8);
+    }
   }
 
   private void writeCoordinateSequence(CoordinateSequence seq, boolean writeSize, OutStream os)

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKBTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKBTest.java
@@ -50,15 +50,19 @@ public class WKBTest
     runWKBTest("MULTIPOINT ((0 0), (1 4), (100 200))");
   }
 
-	public void testPointPCS() throws IOException, ParseException {
-		runWKBTestPackedCoordinate("POINT (1 2)");
-	}
-	
-	public void testPoint() throws IOException, ParseException {
-		runWKBTest("POINT (1 2)");
-	}
+  public void testPointPCS() throws IOException, ParseException {
+    runWKBTestPackedCoordinate("POINT (1 2)");
+  }
 
-	public void testLineString()
+  public void testPoint() throws IOException, ParseException {
+    runWKBTest("POINT (1 2)");
+  }
+
+  public void testPointEmpty() throws IOException, ParseException {
+    runWKBTest("POINT EMPTY");
+  }
+
+  public void testLineString()
       throws IOException, ParseException
   {
     runWKBTest("LINESTRING (1 2, 10 20, 100 200)");


### PR DESCRIPTION
Although the WKB spec does not support empty points, ESRI and others
serialize them as points with NaN coordinates.  Empty points are the
only valid geometry that were not serializable: this commit enables
serialization for them, so users can serialize all valid geometries
with WKB.