### PR TITLE
Adjust reverse and reverseInternal visibility and type narrowing

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
@@ -279,20 +279,19 @@ public class GeometryCollection extends Geometry {
    * The order of the components in the collection are not reversed.
    *
    * @return a {@link GeometryCollection} in the reverse order
-   * @deprecated
    */
-  public Geometry reverse() {
-    return super.reverse();
+  public GeometryCollection reverse() {
+    return (GeometryCollection) super.reverse();
   }
 
-  protected Geometry reverseInternal()
+  protected GeometryCollection reverseInternal()
   {
     int numGeometries = geometries.length;
     Collection<Geometry> reversed = new ArrayList<>(numGeometries);
     for (int i = 0; i < numGeometries; i++) {
       reversed.add(geometries[i].reverse());
     }
-    return getFactory().buildGeometry(reversed);
+    return (GeometryCollection) getFactory().buildGeometry(reversed);
   }
 }
 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
@@ -179,13 +179,12 @@ public class LineString
    * order of this objects
    *
    * @return a {@link LineString} with coordinates in the reverse order
-   * @deprecated
    */
-  public Geometry reverse() {
-    return super.reverse();
+  public LineString reverse() {
+    return (LineString) super.reverse();
   }
 
-  protected Geometry reverseInternal()
+  protected LineString reverseInternal()
   {
     CoordinateSequence seq = points.copy();
     CoordinateSequences.reverse(seq);

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
@@ -132,7 +132,7 @@ public class LinearRing extends LineString
     return new LinearRing(points.copy(), factory);
   }
 
-  public LinearRing reverse()
+  protected LinearRing reverse()
   {
     return (LinearRing) super.reverse();
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
@@ -132,13 +132,12 @@ public class LinearRing extends LineString
     return new LinearRing(points.copy(), factory);
   }
 
-  /** @deprecated */
-  public Geometry reverse()
+  public LinearRing reverse()
   {
-    return super.reverse();
+    return (LinearRing) super.reverse();
   }
 
-  public Geometry reverseInternal() {
+  public LinearRing reverseInternal() {
     CoordinateSequence seq = points.copy();
     CoordinateSequences.reverse(seq);
     return getFactory().createLinearRing(seq);

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiLineString.java
@@ -102,10 +102,9 @@ public class MultiLineString
    * are reversed.
    *
    * @return a {@link MultiLineString} in the reverse order
-   * @deprecated
    */
-  public Geometry reverse() {
-    return super.reverse();
+  public MultiLineString reverse() {
+    return (MultiLineString) super.reverse();
   }
 
   protected MultiLineString copyInternal() {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
@@ -76,6 +76,10 @@ public class MultiPoint
     return getFactory().createGeometryCollection();
   }
 
+  public MultiPoint reverse() {
+    return (MultiPoint) super.reverse();
+  }
+
   public boolean isValid() {
     return true;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPolygon.java
@@ -119,10 +119,9 @@ public class MultiPolygon
    * The order of the components in the collection are not reversed.
    *
    * @return a MultiPolygon in the reverse order
-   * @deprecated
    */
-  public Geometry reverse() {
-    return super.reverse();
+  public MultiPolygon reverse() {
+    return (MultiPolygon) super.reverse();
   }
 
   protected MultiPolygon copyInternal() {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Point.java
@@ -190,12 +190,11 @@ public class Point
     return new Point(coordinates.copy(), factory);
   }
 
-  /** @deprecated */
-  public Geometry reverse() {
-    return super.reverse();
+  public Point reverse() {
+    return (Point) super.reverse();
   }
 
-  protected Geometry reverseInternal()
+  protected Point reverseInternal()
   {
     return getFactory().createPoint(coordinates.copy());
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -417,12 +417,11 @@ public class Polygon
       CoordinateSequences.reverse(seq);
   }
 
-  /** @deprecated */
-  public Geometry reverse() {
-    return super.reverse();
+  public Polygon reverse() {
+    return (Polygon) super.reverse();
   }
 
-  protected Geometry reverseInternal()
+  protected Polygon reverseInternal()
   {
     LinearRing shell = (LinearRing) getExteriorRing().reverse();
     LinearRing[] holes = new LinearRing[getNumInteriorRing()];


### PR DESCRIPTION
This change addresses an unintended consequence where the visibility of these methods as implemented by geometry subclasses was consistent.

* [x] consistent public visibility for reverse() methods
* [x] consistent protected visibility for reverseInternal() methods
* [x] type narrowing for each subclass implementation of reverse()
* [x] subclass implementations of reverse() are not deprecated

Signed-off-by: Jody Garnett <jody.garnett@gmail.com>