### PR TITLE
Remove enforcing array consistency from CoordinateArraySequence

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
@@ -46,7 +46,7 @@ public class Coordinates {
     }
     return new Coordinate();
   }
-    
+  
   /**
    * Determine dimension based on subclass of {@link Coordinate}.
    * 

--- a/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/impl/CoordinateArraySequence.java
@@ -75,8 +75,11 @@ public class CoordinateArraySequence
   
   /**
    * Constructs a sequence based on the given array 
-   * of {@link Coordinate}s (the
-   * array is not copied).
+   * of {@link Coordinate}s (the array is not copied).
+   * <p>
+   * It is your responsibility to ensure the array contains Coordinates of the
+   * indicated dimension and measures (See 
+   * {@link CoordinateArrays#enforceConsistency(Coordinate[])} ).</p>
    *
    * @param coordinates the coordinate array that will be referenced.
    * @param dimension the dimension of the coordinates
@@ -89,7 +92,7 @@ public class CoordinateArraySequence
       this.coordinates = new Coordinate[0];
     }
     else {
-      this.coordinates = enforceArrayConsistency(coordinates);
+      this.coordinates = coordinates;
     }
   }
 
@@ -158,48 +161,6 @@ public class CoordinateArraySequence
     }
   }
 
-  /**
-   * Ensure array contents of the same type, making use of {@link #createCoordinate()} as needed.
-   * <p>
-   * A new array will be created if needed to return a consistent result.
-   * </p>
-   * 
-   * @param array array containing consistent coordinate instances
-   */
-  protected Coordinate[] enforceArrayConsistency(Coordinate[] array)
-  {
-     Coordinate sample = createCoordinate();
-     Class<?> type = sample.getClass();
-     boolean isConsistent=true;
-     for( int i = 0; i < array.length; i++) {
-       Coordinate coordinate = array[i];
-       if( coordinate != null && !coordinate.getClass().equals(type)) {
-         isConsistent = false;
-         break;
-       }
-     }
-     if( isConsistent ){
-       return array;
-     }
-     else {
-       Class<? extends Coordinate> coordinateType = sample.getClass();
-       Coordinate copy[] = (Coordinate[]) Array.newInstance(coordinateType, array.length);
-       for ( int i = 0; i < copy.length; i++){
-          Coordinate coordinate = array[i];
-          if( coordinate != null && !coordinate.getClass().equals(type)){
-            Coordinate duplicate = createCoordinate();
-            duplicate.setCoordinate(coordinate);
-            copy[i] = duplicate;
-          }
-          else {
-            copy[i] = coordinate;
-          }
-       }
-       return copy;
-     }
-  }
-
-  
   /**
    * @see org.locationtech.jts.geom.CoordinateSequence#getDimension()
    */

--- a/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateArraysTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateArraysTest.java
@@ -120,6 +120,31 @@ public class CoordinateArraysTest extends TestCase {
     }
   }
 
+  public void testEnforceConsistency(){
+    Coordinate array[] = new Coordinate[]{
+        new Coordinate(1.0, 1.0, 0.0),
+        new CoordinateXYM(2.0,2.0,1.0)
+    };
+    Coordinate array2[] = new Coordinate[]{
+            new CoordinateXY(1.0, 1.0),
+            new CoordinateXY(2.0,2.0)
+    };
+    // process into array with dimension 4 and measures 1
+    CoordinateArrays.enforceConsistency(array);
+    assertEquals( 3, CoordinateArrays.dimension(array));
+    assertEquals( 1, CoordinateArrays.measures(array));
+
+    CoordinateArrays.enforceConsistency(array2);
+    
+    Coordinate fixed[] = CoordinateArrays.enforceConsistency(array2,2,0);
+    assertSame( fixed, array2); // no processing required
+
+    fixed = CoordinateArrays.enforceConsistency(array,3,0);
+    assertTrue( fixed != array); // copied into new array
+    assertTrue( array[0] != fixed[0] ); // processing needed to CoordinateXYZM
+    assertTrue( array[1] != fixed[1] ); // processing needed to CoordinateXYZM
+  }
+
   private static void checkCoordinateAt(Coordinate[] seq1, int pos1,
                                         Coordinate[] seq2, int pos2) {
     Coordinate c1 = seq1[pos1], c2 = seq2[pos2];


### PR DESCRIPTION
Removes check on array used for CoordinateArraySequence, documenting instead that the array must be consistent with the dimension and measures provided.  Refactored the protected enforceConsistency method out to the Coordintes utility class for any client code that ends up working with mixed coordines.