### PR TITLE
Fix OrdinateFormat to avoid NO locale bug

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/OrdinateFormat.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/OrdinateFormat.java
@@ -14,6 +14,8 @@ package org.locationtech.jts.io;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  * Formats numeric values for ordinates
@@ -34,6 +36,8 @@ import java.text.DecimalFormatSymbols;
  */
 public class OrdinateFormat
 {
+  private static final String DECIMAL_PATTERN = "0";
+
   /**
    * The output representation of {@link Double#POSITIVE_INFINITY}
    */
@@ -91,14 +95,21 @@ public class OrdinateFormat
   }
 
   private static DecimalFormat createFormat(int maximumFractionDigits) {
-    // specify decimal separator explicitly to work in all locales
-    DecimalFormatSymbols symbols = new DecimalFormatSymbols();
-    symbols.setDecimalSeparator('.');
-    DecimalFormat format = new DecimalFormat("0", symbols);
+    // ensure format uses standard WKY number format
+    NumberFormat nf = NumberFormat.getInstance(Locale.US);
+    // This is expected to succeed for Locale.US
+    DecimalFormat format;
+    try {
+      format = (DecimalFormat) nf;
+    }
+    catch (ClassCastException ex) {
+      throw new RuntimeException("Unable to create DecimalFormat for Locale.US");
+    }
+    format.applyPattern(DECIMAL_PATTERN);
     format.setMaximumFractionDigits(maximumFractionDigits);
     return format;
   }
-
+  
   /**
    * Returns a string representation of the given ordinate numeric value.
    * 

--- a/modules/core/src/test/java/org/locationtech/jts/io/OrdinateFormatTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/OrdinateFormatTest.java
@@ -1,5 +1,7 @@
 package org.locationtech.jts.io;
 
+import java.util.Locale;
+
 import junit.framework.TestCase;
 import junit.textui.TestRunner;
 
@@ -66,6 +68,18 @@ public class OrdinateFormatTest extends TestCase {
   }
   
   private void checkFormat(double d, int maxFractionDigits, String expected) {
+    OrdinateFormat format = OrdinateFormat.create(maxFractionDigits);
+    String actual = format.format(d);
+    assertEquals(expected, actual);
+  }
+  
+  private void checkFormatAllLocales(double d, int maxFractionDigits, String expected) {
+    OrdinateFormat format = OrdinateFormat.create(maxFractionDigits);
+    String actual = format.format(d);
+    assertEquals(expected, actual);
+  }
+  
+  private void checkFormatLocales(Locale locale, double d, int maxFractionDigits, String expected) {
     OrdinateFormat format = OrdinateFormat.create(maxFractionDigits);
     String actual = format.format(d);
     assertEquals(expected, actual);


### PR DESCRIPTION
An issue with the format of WKT numbers in the Locale NO was [reported ](https://www.eclipse.org/lists/jts-dev/msg00288.html)on the JTS Dev list.  It is caused by a known JDK [isssue](https://bugs.openjdk.java.net/browse/JDK-8214926).

The fix is to set the Locale used by `OrdinateFormat` to be `Locale.US`.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>