### PR TITLE
Fix StackOverflowError in HotPixelIndex

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/noding/snapround/HotPixelIndex.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/snapround/HotPixelIndex.java
@@ -11,7 +11,9 @@
  */
 package org.locationtech.jts.noding.snapround;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Random;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -23,7 +25,7 @@ import org.locationtech.jts.index.kdtree.KdTree;
 /**
  * An index which creates {@link HotPixel}s for provided points,
  * and allows performing range queries on them.
- * 
+ *
  * @author mdavis
  *
  */
@@ -34,30 +36,71 @@ class HotPixelIndex {
   /**
    * Use a kd-tree to index the pixel centers for optimum performance.
    * Since HotPixels have an extent, queries to the
-   * index must enlarge the query range by a suitable value 
+   * index must enlarge the query range by a suitable value
    * (using the pixel width is safest).
    */
   private KdTree index = new KdTree();
-  
+
   public HotPixelIndex(PrecisionModel pm) {
     this.precModel = pm;
     scaleFactor = pm.getScale();
   }
-  
+
+  /**
+   * Utility class to shuffle an array of {@link Coordinate}s using
+   * the Fisher-Yates shuffle algorithm
+   *
+   * @see <a href="https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle">Fihser-Yates shuffle</a>
+   */
+  private static final class CoordinateShuffler implements Iterator<Coordinate> {
+
+    private final Random rnd = new Random(13);
+    private final Coordinate[] coordinates;
+    private final int[] indices;
+    private int index;
+
+    /**
+     * Creates an instance of this class
+     * @param pts An array of {@link Coordinate}s.
+     */
+    public CoordinateShuffler(Coordinate[] pts) {
+      coordinates = pts;
+      indices = new int[pts.length];
+      for (int i = 0; i < pts.length; i++)
+        indices[i] = i;
+      index = pts.length - 1;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return index >= 0;
+    }
+
+    @Override
+    public Coordinate next() {
+      int j = rnd.nextInt(index + 1);
+      Coordinate res = coordinates[indices[j]];
+      indices[j] = indices[index--];
+      return res;
+    }
+  }
+
   /**
    * Adds a list of points as non-node pixels.
-   * 
+   *
    * @param pts the points to add
    */
   public void add(Coordinate[] pts) {
-    for (Coordinate pt : pts) {
-      add(pt);
+
+    Iterator<Coordinate> it = new CoordinateShuffler(pts);
+    while (it.hasNext()) {
+      add(it.next());
     }
   }
-  
+
   /**
    * Adds a list of points as node pixels.
-   * 
+   *
    * @param pts the points to add
    */
   public void addNodes(List<Coordinate> pts) {
@@ -66,21 +109,21 @@ class HotPixelIndex {
       hp.setToNode();
     }
   }
-  
+
   /**
    * Adds a point as a Hot Pixel.
    * If the point has been added already, it is marked as a node.
-   * 
+   *
    * @param p the point to add
    * @return the HotPixel for the point
    */
   public HotPixel add(Coordinate p) {
     // TODO: is there a faster way of doing this?
     Coordinate pRound = round(p);
-    
+
     HotPixel hp = find(pRound);
     /**
-     * Hot Pixels which are added more than once 
+     * Hot Pixels which are added more than once
      * must have more than one vertex in them
      * and thus must be nodes.
      */
@@ -88,7 +131,7 @@ class HotPixelIndex {
       hp.setToNode();
       return hp;
     }
-    
+
     /**
      * A pixel containing the point was not found, so create a new one.
      * It is initially set to NOT be a node
@@ -101,22 +144,22 @@ class HotPixelIndex {
 
   private HotPixel find(Coordinate pixelPt) {
     KdNode kdNode = index.query(pixelPt);
-    if (kdNode == null) 
+    if (kdNode == null)
       return null;
     return (HotPixel) kdNode.getData();
   }
-  
+
   private Coordinate round(Coordinate pt) {
     Coordinate p2 = pt.copy();
     precModel.makePrecise(p2);
     return p2;
   }
-  
+
   /**
    * Visits all the hot pixels which may intersect a segment (p0-p1).
    * The visitor must determine whether each hot pixel actually intersects
    * the segment.
-   *  
+   *
    * @param p0 the segment start point
    * @param p1 the segment end point
    * @param visitor the visitor to apply


### PR DESCRIPTION
Add nested CoordinateShuffler class and wire it `add(Coordinate[] pts)` in order to get a more balanced KdTree. The insertion speed for geometries with many coordinates greatly improves!

relates to #602 

Signed-off-by: Felix Obermaier <felix.obermaier@netcologne.de>