### PR TITLE
Fix WKBWriter output for POINT EMPTY 3D

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKBWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKBWriter.java
@@ -344,7 +344,8 @@ public class WKBWriter
     writeByteOrder(os);
     writeGeometryType(WKBConstants.wkbPoint, pt, os);
     if (pt.getCoordinateSequence().size() == 0) {
-      writeNaNs(2, os);
+      // write empty point as NaNs (extension to OGC standard)
+      writeNaNs(outputDimension, os);
     } else {
       writeCoordinateSequence(pt.getCoordinateSequence(), false, os);
     }

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKBWriterTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKBWriterTest.java
@@ -12,55 +12,84 @@
 package org.locationtech.jts.io;
 
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 
-import junit.framework.TestCase;
+import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
 
-public class WKBWriterTest extends TestCase {
+/**
+ * Tests for WKB which test output explicitly.
+ * 
+ * @author Martin Davis
+ *
+ */
+public class WKBWriterTest extends GeometryTestCase {
 
-    public WKBWriterTest(String name) {
-        super(name);
-    }
+  public static void main(String args[]) {
+    TestRunner.run(WKBWriterTest.class);
+  }
+  
+  public WKBWriterTest(String name) {
+      super(name);
+  }
+  
+  public void testSRID() throws Exception {
+      GeometryFactory gf = new GeometryFactory();
+      Point p1 = gf.createPoint(new Coordinate(1,2));
+      p1.setSRID(1234);
+      
+      //first write out without srid set
+      WKBWriter w = new WKBWriter();
+      byte[] wkb = w.write(p1);
+      
+      //check the 3rd bit of the second byte, should be unset
+      byte b = (byte) (wkb[1] & 0x20);
+      assertEquals(0, b);
+      
+      //read geometry back in
+      WKBReader r = new WKBReader(gf);
+      Point p2 = (Point) r.read(wkb);
+      
+      assertTrue(p1.equalsExact(p2));
+      assertEquals(0, p2.getSRID());
+      
+      //not write out with srid set
+      w = new WKBWriter(2, true);
+      wkb = w.write(p1);
+      
+      //check the 3rd bit of the second byte, should be set
+      b = (byte) (wkb[1] & 0x20);
+      assertEquals(0x20, b);
+      
+      int srid = ((int) (wkb[5] & 0xff) << 24) | ( (int) (wkb[6] & 0xff) << 16)
+          | ( (int) (wkb[7] & 0xff) << 8) | (( int) (wkb[8] & 0xff) );
+     
+      assertEquals(1234, srid);
+      
+      r = new WKBReader(gf);
+      p2 = (Point) r.read(wkb);
+      
+      //read the geometry back in
+      assertTrue(p1.equalsExact(p2));
+      assertEquals(1234, p2.getSRID());
+  }
     
-    public void testSRID() throws Exception {
-        GeometryFactory gf = new GeometryFactory();
-        Point p1 = gf.createPoint(new Coordinate(1,2));
-        p1.setSRID(1234);
-        
-        //first write out without srid set
-        WKBWriter w = new WKBWriter();
-        byte[] wkb = w.write(p1);
-        
-        //check the 3rd bit of the second byte, should be unset
-        byte b = (byte) (wkb[1] & 0x20);
-        assertEquals(0, b);
-        
-        //read geometry back in
-        WKBReader r = new WKBReader(gf);
-        Point p2 = (Point) r.read(wkb);
-        
-        assertTrue(p1.equalsExact(p2));
-        assertEquals(0, p2.getSRID());
-        
-        //not write out with srid set
-        w = new WKBWriter(2, true);
-        wkb = w.write(p1);
-        
-        //check the 3rd bit of the second byte, should be set
-        b = (byte) (wkb[1] & 0x20);
-        assertEquals(0x20, b);
-        
-        int srid = ((int) (wkb[5] & 0xff) << 24) | ( (int) (wkb[6] & 0xff) << 16)
-            | ( (int) (wkb[7] & 0xff) << 8) | (( int) (wkb[8] & 0xff) );
-       
-        assertEquals(1234, srid);
-        
-        r = new WKBReader(gf);
-        p2 = (Point) r.read(wkb);
-        
-        //read the geometry back in
-        assertTrue(p1.equalsExact(p2));
-        assertEquals(1234, p2.getSRID());
-    }
+  public void testPointEmpty2D() {
+    checkWKB("POINT EMPTY", 2, ByteOrderValues.LITTLE_ENDIAN, "0101000000000000000000F87F000000000000F87F" );    
+  }
+  
+  public void testPointEmpty3D() {
+    checkWKB("POINT EMPTY", 3, ByteOrderValues.LITTLE_ENDIAN, "0101000080000000000000F87F000000000000F87F000000000000F87F" );    
+  }
+  
+  void checkWKB(String wkt, int dimension, int byteOrder, String expectedWKBHex) {
+    Geometry geom = read(wkt);
+    WKBWriter wkbWriter = new WKBWriter(dimension, byteOrder);
+    byte[] wkb = wkbWriter.write(geom);
+    String wkbHex = WKBWriter.toHex(wkb);
+    
+    assertEquals(expectedWKBHex, wkbHex);
+  }
 }


### PR DESCRIPTION
Fix WKBWriter output for a POINT EMPTY in 3D (writing 3 `NaN`s)

Fixes #621 

Signed-off-by: Martin Davis <mtnclimb@gmail.com>