### PR TITLE
Improve WKBWriter to write empty polygons with zero rings

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKBWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKBWriter.java
@@ -45,9 +45,7 @@ import org.locationtech.jts.util.Assert;
  * <ul>
  * <li><b>Point</b>: a <code>WKBPoint</code> with <code>NaN</code> ordinate values</li> 
  * <li><b>LineString</b>: a <code>WKBLineString</code> with zero points</li>
- * <li><b>Polygon</b>: currently output as a <code>WKBPolygon</code> with one <code>LinearRing</code> with zero points.
- * <i>Note: This is different to other systems.  It will change to a <code>WKBPolygon</code> with zero <code>LinearRing</code>s.</i>
- * </li>
+ * <li><b>Polygon</b>: a <code>WKBPolygon</code> with zero rings</li>
  * <li><b>Multi geometries</b>: a <code>WKBMulti</code> geometry of appropriate type with zero elements</li>
  * <li><b>GeometryCollections</b>: a <code>WKBGeometryCollection</code> with zero elements</li>
  * </ul></li>
@@ -363,6 +361,11 @@ public class WKBWriter
   {
     writeByteOrder(os);
     writeGeometryType(WKBConstants.wkbPolygon, poly, os);
+    //--- write empty polygons with no rings (OCG extension)
+    if (poly.isEmpty()) {
+      writeInt(0, os);
+      return;
+    }
     writeInt(poly.getNumInteriorRing() + 1, os);
     writeCoordinateSequence(poly.getExteriorRing().getCoordinateSequence(), true, os);
     for (int i = 0; i < poly.getNumInteriorRing(); i++) {

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKBWriterTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKBWriterTest.java
@@ -77,16 +77,40 @@ public class WKBWriterTest extends GeometryTestCase {
   }
     
   public void testPointEmpty2D() {
-    checkWKB("POINT EMPTY", 2, ByteOrderValues.LITTLE_ENDIAN, "0101000000000000000000F87F000000000000F87F" );    
+    checkWKB("POINT EMPTY", 2, "0101000000000000000000F87F000000000000F87F" );    
   }
   
   public void testPointEmpty3D() {
-    checkWKB("POINT EMPTY", 3, ByteOrderValues.LITTLE_ENDIAN, "0101000080000000000000F87F000000000000F87F000000000000F87F" );    
+    checkWKB("POINT EMPTY", 3, "0101000080000000000000F87F000000000000F87F000000000000F87F" );    
   }
   
-  void checkWKB(String wkt, int dimension, int byteOrder, String expectedWKBHex) {
+  public void testPolygonEmpty2DSRID() {
+    checkWKB("POLYGON EMPTY", 2, ByteOrderValues.LITTLE_ENDIAN, 4326, "0103000020E610000000000000" );    
+  }
+  
+  public void testPolygonEmpty2D() {
+    checkWKB("POLYGON EMPTY", 2, "010300000000000000" );    
+  }
+  
+  public void testPolygonEmpty3D() {
+    checkWKB("POLYGON EMPTY", 3, "010300008000000000" );    
+  }
+  
+  void checkWKB(String wkt, int dimension, String expectedWKBHex) {
+    checkWKB(wkt, dimension, ByteOrderValues.LITTLE_ENDIAN, -1, expectedWKBHex);
+  }
+    
+  void checkWKB(String wkt, int dimension, int byteOrder, int srid, String expectedWKBHex) {
     Geometry geom = read(wkt);
-    WKBWriter wkbWriter = new WKBWriter(dimension, byteOrder);
+    
+    // set SRID if not -1
+    boolean includeSRID = false;
+    if (srid >= 0) {
+      includeSRID = true;
+      geom.setSRID(srid);
+    }
+    
+    WKBWriter wkbWriter = new WKBWriter(dimension, byteOrder, includeSRID);
     byte[] wkb = wkbWriter.write(geom);
     String wkbHex = WKBWriter.toHex(wkb);
     


### PR DESCRIPTION
Improve WKBWriter to write empty polygons with zero rings (a more compact representation).

Fixes #508
 
Signed-off-by: Martin Davis <mtnclimb@gmail.com>