### PR TITLE
Add the check of userData in equals(object o)

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -14,6 +14,7 @@ package org.locationtech.jts.geom;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.locationtech.jts.algorithm.Centroid;
 import org.locationtech.jts.algorithm.ConvexHull;
@@ -1120,7 +1121,8 @@ public abstract class Geometry
   {
     if (! (o instanceof Geometry)) return false;
     Geometry g = (Geometry) o;
-    return equalsExact(g);
+    if (Objects.equals(this.userData, g.userData)) return equalsExact(g);
+    else return false;
   }
 
   /**


### PR DESCRIPTION
This PR proposes to add the equality check for userData in equsl(Object o). This will make sure two geometries are exactly same


Signed-off-by: Jia Yu <jiayu198910@gmail.com>