### PR TITLE
Fix Densifier to use correct Coordinate class, add Coordinate create methods

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
@@ -400,6 +400,15 @@ public class Coordinate implements Comparable<Coordinate>, Cloneable, Serializab
   public Coordinate copy() {
     return new Coordinate(this);
   }
+  
+  /**
+   * Create a new Coordinate of the same type as this Coordinate, but with no values.
+   * 
+   * @return a new Coordinate
+   */
+  public Coordinate create() {
+      return new Coordinate();
+  }
 
   /**
    * Computes the 2-dimensional Euclidean distance to another location.

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java
@@ -76,7 +76,17 @@ public class CoordinateXY extends Coordinate {
   public CoordinateXY copy() {
     return new CoordinateXY(this);
   }
-    
+  
+  /**
+   * Create a new Coordinate of the same type as this Coordinate, but with no values.
+   * 
+   * @return a new Coordinate
+   */
+  @Override
+  public Coordinate create() {
+      return new CoordinateXY();
+  }
+
   /** The z-ordinate is not supported */
   @Override
   public double getZ() {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java
@@ -86,6 +86,16 @@ public class CoordinateXYM extends Coordinate {
   public CoordinateXYM copy() {
     return new CoordinateXYM(this);
   }
+  
+  /**
+   * Create a new Coordinate of the same type as this Coordinate, but with no values.
+   * 
+   * @return a new Coordinate
+   */
+  @Override
+  public Coordinate create() {
+      return new CoordinateXYM();
+  }
     
   /** The m-measure. */
   protected double m;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYZM.java
@@ -68,6 +68,16 @@ public class CoordinateXYZM extends Coordinate {
   public CoordinateXYZM copy() {
     return new CoordinateXYZM(this);
   }
+  
+  /**
+   * Create a new Coordinate of the same type as this Coordinate, but with no values.
+   * 
+   * @return a new Coordinate
+   */
+  @Override
+  public Coordinate create() {
+      return new CoordinateXYZM();
+  }
 
   /** The m-measure. */
   private double m;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -282,7 +282,7 @@ public class LineSegment
    */
   public Coordinate pointAlong(double segmentLengthFraction)
   {
-    Coordinate coord = new Coordinate();
+    Coordinate coord = p0.create();
     coord.x = p0.x + segmentLengthFraction * (p1.x - p0.x);
     coord.y = p0.y + segmentLengthFraction * (p1.y - p0.y);
     return coord;
@@ -328,7 +328,9 @@ public class LineSegment
     double offsetx = segx - uy;
     double offsety = segy + ux;
 
-    Coordinate coord = new Coordinate(offsetx, offsety);
+    Coordinate coord = p0.create();
+    coord.setX(offsetx);
+    coord.setY(offsety);
     return coord;
   }
 
@@ -406,10 +408,10 @@ public class LineSegment
    */
   public Coordinate project(Coordinate p)
   {
-    if (p.equals(p0) || p.equals(p1)) return new Coordinate(p);
+    if (p.equals(p0) || p.equals(p1)) return p.copy();
 
     double r = projectionFactor(p);
-    Coordinate coord = new Coordinate();
+    Coordinate coord = p.copy();
     coord.x = p0.x + r * (p1.x - p0.x);
     coord.y = p0.y + r * (p1.y - p0.y);
     return coord;
@@ -467,7 +469,10 @@ public class LineSegment
     double rx = ( -A2subB2*x - 2*A*B*y - 2*A*C ) / A2plusB2;
     double ry = ( A2subB2*y - 2*A*B*x - 2*B*C ) / A2plusB2;
     
-    return new Coordinate(rx, ry);
+    Coordinate coord = p.copy();
+    coord.setX(rx);
+    coord.setY(ry);
+    return coord;
   }
   
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/densify/DensifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/densify/DensifierTest.java
@@ -11,7 +11,11 @@
  */
 package org.locationtech.jts.densify;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateXY;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
 
 import junit.textui.TestRunner;
 import test.jts.GeometryTestCase;
@@ -39,6 +43,27 @@ public class DensifierTest extends GeometryTestCase {
     checkDensifyNoValidate("POLYGON ((10 30, 30 30, 30 10, 10 10, 10 30))", 
         10, "POLYGON ((10 30, 16.666666666666668 30, 23.333333333333336 30, 30 30, 30 23.333333333333332, 30 16.666666666666664, 30 10, 23.333333333333332 10, 16.666666666666664 10, 10 10, 10 16.666666666666668, 10 23.333333333333336, 10 30))");
   }
+  
+  public void testDimension2d() {
+      GeometryFactory gf = new GeometryFactory();
+      LineString line = gf
+              .createLineString(new Coordinate[] { new CoordinateXY(1, 2), new CoordinateXY(3, 4) });
+      assertEquals(2, line.getCoordinateSequence().getDimension());
+      
+      line = (LineString) Densifier.densify(line, 0.1);
+      assertEquals(2, line.getCoordinateSequence().getDimension());
+  }
+  
+  public void testDimension3d() {
+      GeometryFactory gf = new GeometryFactory();
+      LineString line = gf
+              .createLineString(new Coordinate[] { new Coordinate(1, 2, 3), new Coordinate(3, 4, 5) });
+      assertEquals(3, line.getCoordinateSequence().getDimension());
+      
+      line = (LineString) Densifier.densify(line, 0.1);
+      assertEquals(3, line.getCoordinateSequence().getDimension());
+  }
+
 
   private void checkDensify(String wkt, double distanceTolerance, String wktExpected) {
     Geometry geom = read(wkt);
@@ -64,5 +89,5 @@ public class DensifierTest extends GeometryTestCase {
     Geometry actual = den.getResultGeometry();
     checkEqual(expected, actual, TOLERANCE);
   }
-
+  
 }


### PR DESCRIPTION
Make sure Densifier insert extra Coordinates of the same type and preserve the dimension. #635

This replaces #636 that missed signature.