### PR TITLE
Remove OverlapUnion optimization from CascadedPolygonUnion

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/union/CascadedPolygonUnion.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/union/CascadedPolygonUnion.java
@@ -363,14 +363,7 @@ public class CascadedPolygonUnion
    */
   private Geometry unionActual(Geometry g0, Geometry g1)
   {
-    Geometry union;
-  
-    if (unionFun.isFloatingPrecision()) {
-      union = OverlapUnion.union(g0, g1, unionFun);
-    }
-    else { 
-      union = unionFun.union(g0, g1);
-    }
+    Geometry union = unionFun.union(g0, g1);
     Geometry unionPoly = restrictToPolygons( union );
   	return unionPoly;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/union/OverlapUnion.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/union/OverlapUnion.java
@@ -74,8 +74,14 @@ import org.locationtech.jts.geom.util.GeometryCombiner;
  * but it could happen due to snapping.  It has been observed 
  * in other APIs (e.g. GEOS) due to more aggressive snapping.
  * It is more likely to happen if a Snap-Rounding overlay is used.
+ * <p>
+ * <b>NOTE: Test has shown that using this heuristic impairs performance.
+ * It has been removed from use.</b>
+ * 
  * 
  * @author mbdavis
+ * 
+ * @deprecated due to impairing performance
  *
  */
 public class OverlapUnion 


### PR DESCRIPTION
The OverlapUnion optimization in fact reduces performance, so is being removed.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>