### PR TITLE
Check for invalid polygonal geometry before fixing

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/densify/Densifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/densify/Densifier.java
@@ -185,7 +185,8 @@ public class Densifier {
 		 * @return a valid area geometry
 		 */
 		private Geometry createValidArea(Geometry roughAreaGeom) {
-		  if (! isValidated) return roughAreaGeom;
+		  // if valid no need to process to make valid
+		  if (! isValidated || roughAreaGeom.isValid()) return roughAreaGeom;
 			return roughAreaGeom.buffer(0.0);
 		}
 	}

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifier.java
@@ -199,7 +199,8 @@ static class DPTransformer
    */
   private Geometry createValidArea(Geometry rawAreaGeom)
   {
-  	if ( isEnsureValidTopology)
+    // if geometry is invalid then make it valid
+  	if (isEnsureValidTopology && ! rawAreaGeom.isValid())
   		return rawAreaGeom.buffer(0.0);
   	return rawAreaGeom;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/VWSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/VWSimplifier.java
@@ -204,7 +204,8 @@ public class VWSimplifier
      */
     private Geometry createValidArea(Geometry rawAreaGeom)
     {
-      if (isEnsureValidTopology)
+      // if geometry is invalid then make it valid
+      if (isEnsureValidTopology && ! rawAreaGeom.isValid())
         return rawAreaGeom.buffer(0.0);
       return rawAreaGeom;
     }

--- a/modules/core/src/test/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifierTest.java
@@ -81,7 +81,7 @@ public class DouglasPeuckerSimplifierTest
         DPSimplifierResult.getResult(
       "POLYGON ((80 200, 240 200, 240 60, 80 60, 80 200), (120 120, 220 120, 180 199, 160 200, 140 199, 120 120))",
         10.0))
-        .setExpectedResult("POLYGON ((80 200, 160 200, 240 200, 240 60, 80 60, 80 200), (160 200, 140 199, 120 120, 220 120, 180 199, 160 200)))")
+        .setExpectedResult("POLYGON ((80 200, 240 200, 240 60, 80 60, 80 200), (120 120, 220 120, 180 199, 160 200, 140 199, 120 120))")
         .test();
   }
   public void testFlattishPolygon() throws Exception {

--- a/modules/core/src/test/java/org/locationtech/jts/simplify/VWSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/simplify/VWSimplifierTest.java
@@ -55,7 +55,7 @@ public class VWSimplifierTest
         VWSimplifierResult.getResult(
       "POLYGON ((1721355.3 693015.146, 1721318.687 693046.251, 1721306.747 693063.038, 1721367.025 692978.29, 1721355.3 693015.146))",
         10.0))
-        .setExpectedResult("POLYGON ((1721355.3 693015.146, 1721367.025 692978.29, 1721318.687 693046.251, 1721355.3 693015.146))")
+        .setExpectedResult("POLYGON ((1721355.3 693015.146, 1721318.687 693046.251, 1721367.025 692978.29, 1721355.3 693015.146))")
         .test();
   }
   public void testPolygonSpikeInHole() throws Exception {


### PR DESCRIPTION
Some algorithms (including `DouglasPeuckerSimplifier`, `VWSimplifier`, `Densifier`) may produce invalid polygonal topology, and so include a cleaning step to ensure the result value is valid.  

This PR adds a test to see if the result is actually invalid before running the potentially expensive cleaning process.
