### PR TITLE
Preserve line order in OverlayNG

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/EdgeMerger.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/EdgeMerger.java
@@ -12,13 +12,11 @@
 package org.locationtech.jts.operation.overlayng;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.locationtech.jts.util.Assert;
-import org.locationtech.jts.util.Debug;
 
 /**
  * Performs merging on the noded edges of the input geometries.
@@ -78,7 +76,6 @@ class EdgeMerger {
         //Debug.println(edge.toLineString());
       }
     }
-    //return new ArrayList<Edge>(edgeMap.values());
     return mergedEdges;
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/EdgeMerger.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/EdgeMerger.java
@@ -39,25 +39,22 @@ import org.locationtech.jts.util.Debug;
  * no other coincident edge, or if all coincident edges have the same direction).
  * This ensures that the overlay output line direction will be as consistent
  * as possible with input lines.
+ * <p>
+ * The merger also preserves the order of the edges in the input.
+ * This means that for polygon-line overlay
+ * the result lines will be in the same order as in the input
+ * (possibly with multiple result lines for a single input line).
  * 
  * @author mdavis
  *
  */
 class EdgeMerger {
-
+ 
   public static List<Edge> merge(List<Edge> edges) {
-    EdgeMerger merger = new EdgeMerger(edges);
-    return merger.merge();
-  }
+    // use a list to collect the final edges, to preserve order
+    List<Edge> mergedEdges = new ArrayList<Edge>();
+    Map<EdgeKey, Edge> edgeMap = new HashMap<EdgeKey, Edge>();
 
-  private Collection<Edge> edges;
-  private Map<EdgeKey, Edge> edgeMap = new HashMap<EdgeKey, Edge>();
-  
-  public EdgeMerger(List<Edge> edges) {
-    this.edges = edges;
-  }
-  
-  public ArrayList<Edge> merge() {
     for (Edge edge : edges) {
       EdgeKey edgeKey = EdgeKey.create(edge);
       Edge baseEdge = edgeMap.get(edgeKey);
@@ -66,6 +63,7 @@ class EdgeMerger {
         edgeMap.put(edgeKey, edge);
         //Debug.println("edge added: " + edge);
         //Debug.println(edge.toLineString());
+        mergedEdges.add(edge);
       }
       else {
         // found an existing edge
@@ -80,7 +78,8 @@ class EdgeMerger {
         //Debug.println(edge.toLineString());
       }
     }
-    return new ArrayList<Edge>(edgeMap.values());
+    //return new ArrayList<Edge>(edgeMap.values());
+    return mergedEdges;
   }
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/LineBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/LineBuilder.java
@@ -305,6 +305,10 @@ class LineBuilder {
    * by the start edge direction. This implies
    * that if all edges are reversed, the created line
    * will be reversed to match.
+   * This ensures the orientation of linework is faithful to the input
+   * in the case of polygon-line overlay.
+   * However, this does not provide a consistent orientation 
+   * in the case of line-line intersection(where A and B might have different orientations).
    * (Other more complex strategies would be possible.
    * E.g. using the direction of the majority of segments,
    * or preferring the direction of the A edges.)

--- a/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGTest.java
@@ -569,6 +569,14 @@ public class OverlayNGTest extends GeometryTestCase {
     checkEqual(expected, actual);
   }
   
+  public void testPolygonLineIntersectionOrder() {
+    Geometry a = read("POLYGON ((1 1, 1 9, 9 9, 9 7, 3 7, 3 3, 9 3, 9 1, 1 1))");
+    Geometry b = read("MULTILINESTRING ((2 10, 2 0), (4 10, 4 0))");
+    Geometry expected = read("MULTILINESTRING ((2 9, 2 1), (4 9, 4 7), (4 3, 4 1))");
+    Geometry actual = intersection(a, b, 1);
+    checkEqualExact(expected, actual);    
+  }
+  
   //============================================================
   
   

--- a/modules/core/src/test/java/test/jts/GeometryTestCase.java
+++ b/modules/core/src/test/java/test/jts/GeometryTestCase.java
@@ -57,7 +57,7 @@ public abstract class GeometryTestCase extends TestCase{
 
   /**
    * Checks that the normalized values of the expected and actual
-   * geometries are exactly equals.
+   * geometries are exactly equal.
    * 
    * @param expected the expected value
    * @param actual the actual value
@@ -68,6 +68,21 @@ public abstract class GeometryTestCase extends TestCase{
     boolean equal = actualNorm.equalsExact(expectedNorm);
     if (! equal) {
       System.out.format(CHECK_EQUAL_FAIL, expectedNorm, actualNorm );
+    }
+    assertTrue(equal);
+  }
+
+  /**
+   * Checks that the values of the expected and actual
+   * geometries are exactly equal.
+   * 
+   * @param expected the expected value
+   * @param actual the actual value
+   */
+  protected void checkEqualExact(Geometry expected, Geometry actual) {
+    boolean equal = actual.equalsExact(expected);
+    if (! equal) {
+      System.out.format(CHECK_EQUAL_FAIL, expected, actual );
     }
     assertTrue(equal);
   }


### PR DESCRIPTION
This change preserves the order of input lines in the result of a area-line overlay.  This matches the behaviour of the original overlay code.  It enables simpler and more efficient processing of overlay results, since that can rely on line ordering (for example, see [GeoSwift 212](https://github.com/GEOSwift/GEOSwift/issues/212). 