### PR TITLE
Add UnaryUnionNG functions for collections

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/UnaryUnionNG.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/UnaryUnionNG.java
@@ -13,13 +13,16 @@ package org.locationtech.jts.operation.overlayng;
 
 import static org.locationtech.jts.operation.overlayng.OverlayNG.UNION;
 
+import java.util.Collection;
+
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.operation.union.UnaryUnionOp;
 import org.locationtech.jts.operation.union.UnionStrategy;
 
 /**
- * Unions a collection of geometries in an
+ * Unions a geometry or collection of geometries in an
  * efficient way, using {@link OverlayNG}
  * to ensure robust computation.
  * <p>
@@ -35,14 +38,49 @@ import org.locationtech.jts.operation.union.UnionStrategy;
 public class UnaryUnionNG {
   
   /**
-   * Unions a collection of geometries
+   * Unions a geometry (which is often a collection)
    * using a given precision model.
    * 
    * @param geom the geometry to union
    * @param pm the precision model to use
-   * @return the union of the geometries
+   * @return the union of the geometry
    */
   public static Geometry union(Geometry geom, PrecisionModel pm) {
+    UnaryUnionOp op = new UnaryUnionOp(geom);
+    op.setUnionFunction( createUnionStrategy(pm) );
+    return op.union();
+  }
+  
+  /**
+   * Unions a collection of geometries
+   * using a given precision model.
+   * 
+   * @param geoms the collection of geometries to union
+   * @param pm the precision model to use
+   * @return the union of the geometries
+   */
+  public static Geometry union(Collection<Geometry> geoms, PrecisionModel pm) {
+    UnaryUnionOp op = new UnaryUnionOp(geoms);
+    op.setUnionFunction( createUnionStrategy(pm) );
+    return op.union();
+  }
+  
+  /**
+   * Unions a collection of geometries
+   * using a given precision model.
+   * 
+   * @param geoms the collection of geometries to union
+   * @param geomFact the geometry factory to use
+   * @param pm the precision model to use
+   * @return the union of the geometries
+   */
+  public static Geometry union(Collection<Geometry> geoms, GeometryFactory geomFact, PrecisionModel pm) {
+    UnaryUnionOp op = new UnaryUnionOp(geoms, geomFact);
+    op.setUnionFunction( createUnionStrategy(pm) );
+    return op.union();
+  }
+  
+  private static UnionStrategy createUnionStrategy(PrecisionModel pm) {
     UnionStrategy unionSRFun = new UnionStrategy() {
 
       public Geometry union(Geometry g0, Geometry g1) {
@@ -55,9 +93,7 @@ public class UnaryUnionNG {
       }
       
     };
-    UnaryUnionOp op = new UnaryUnionOp(geom);
-    op.setUnionFunction( unionSRFun );
-    return op.union();
+    return unionSRFun;
   }
   
   private UnaryUnionNG() {

--- a/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/UnaryUnionNGTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/UnaryUnionNGTest.java
@@ -11,6 +11,8 @@
  */
 package org.locationtech.jts.operation.overlayng;
 
+import java.util.List;
+
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.PrecisionModel;
 
@@ -45,11 +47,42 @@ public class UnaryUnionNGTest extends GeometryTestCase
         "POLYGON ((100 200, 150 200, 150 250, 250 250, 250 150, 200 150, 200 100, 100 100, 100 200))");
   }
 
+  public void testCollection( ) {
+    checkUnaryUnion(new String[] {
+        "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
+        "POLYGON ((300 100, 200 100, 200 200, 300 200, 300 100))",
+        "POLYGON ((100 300, 200 300, 200 200, 100 200, 100 300))",
+        "POLYGON ((300 300, 300 200, 200 200, 200 300, 300 300))"
+        },
+        1, 
+        "POLYGON ((100 100, 100 200, 100 300, 200 300, 300 300, 300 200, 300 100, 200 100, 100 100))");
+  }
+
+  public void testCollectionEmpty( ) {
+    checkUnaryUnion(new String[0],
+        1, 
+        "GEOMETRYCOLLECTION EMPTY");
+  }
+
   private void checkUnaryUnion(String wkt, double scaleFactor, String wktExpected) {
     Geometry geom = read(wkt);
     Geometry expected = read(wktExpected);
     PrecisionModel pm = new PrecisionModel(scaleFactor);
     Geometry result = UnaryUnionNG.union(geom, pm);
+    checkEqual(expected, result);
+  }
+  
+  private void checkUnaryUnion(String[] wkt, double scaleFactor, String wktExpected) {
+    List geoms = readList(wkt);
+    Geometry expected = read(wktExpected);
+    PrecisionModel pm = new PrecisionModel(scaleFactor);
+    Geometry result;
+    if (geoms.isEmpty()) {
+      result = UnaryUnionNG.union(geoms, getGeometryFactory(), pm);            
+    }
+    else {
+      result = UnaryUnionNG.union(geoms, pm);      
+    }
     checkEqual(expected, result);
   }
 }

--- a/modules/core/src/test/java/test/jts/GeometryTestCase.java
+++ b/modules/core/src/test/java/test/jts/GeometryTestCase.java
@@ -55,6 +55,10 @@ public abstract class GeometryTestCase extends TestCase{
     readerWKT = new WKTReader(geomFactory);
   }
 
+  protected GeometryFactory getGeometryFactory() {
+    return geomFactory;
+  }
+  
   /**
    * Checks that the normalized values of the expected and actual
    * geometries are exactly equal.


### PR DESCRIPTION
Adds `UnaryUnionNG` functions for collections, to match `UnaryUnionOp` API.
As requested in #668.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>