### PR TITLE
Add OverlayNGRobust unary union methods for collections

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayNGRobust.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayNGRobust.java
@@ -11,8 +11,11 @@
  */
 package org.locationtech.jts.operation.overlayng;
 
+import java.util.Collection;
+
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.noding.ValidatingNoder;
@@ -54,7 +57,7 @@ import org.locationtech.jts.operation.union.UnionStrategy;
 public class OverlayNGRobust
 {
   /**
-   * Computes unary union using robust computation.
+   * Computes the unary union of a geometry using robust computation.
    * 
    * @param geom the geometry to union
    * @return the union result
@@ -62,22 +65,49 @@ public class OverlayNGRobust
    * @see UnaryUnionOp
    */
   public static Geometry union(Geometry geom) {
-    UnionStrategy unionSRFun = new UnionStrategy() {
-
-      public Geometry union(Geometry g0, Geometry g1) {
-         return overlay(g0, g1, OverlayNG.UNION );
-      }
-
-      @Override
-      public boolean isFloatingPrecision() {
-        return true;
-      }
-      
-    };
     UnaryUnionOp op = new UnaryUnionOp(geom);
-    op.setUnionFunction(unionSRFun);
+    op.setUnionFunction(OVERLAY_UNION);
     return op.union();
   }
+  
+  /**
+   * Computes the unary union of a collection of geometries using robust computation.
+   * 
+   * @param geoms the collection of geometries to union
+   * @return the union result
+   * 
+   * @see UnaryUnionOp
+   */
+  public static Geometry union(Collection<Geometry> geoms) {
+    UnaryUnionOp op = new UnaryUnionOp(geoms);
+    op.setUnionFunction(OVERLAY_UNION);
+    return op.union();
+  }
+  
+  /**
+   * Computes the unary union of a collection of geometries using robust computation.
+   * 
+   * @param geoms the collection of geometries to union
+   * @param geomFact the geometry factory to use
+   * @return the union of the geometries
+   */
+  public static Geometry union(Collection<Geometry> geoms, GeometryFactory geomFact) {
+    UnaryUnionOp op = new UnaryUnionOp(geoms, geomFact);
+    op.setUnionFunction(OVERLAY_UNION);
+    return op.union();
+  }
+  
+  private static UnionStrategy OVERLAY_UNION = new UnionStrategy() {
+
+    public Geometry union(Geometry g0, Geometry g1) {
+       return overlay(g0, g1, OverlayNG.UNION );
+    }
+
+    @Override
+    public boolean isFloatingPrecision() {
+      return true;
+    }
+  };
   
   /**
    * Overlay two geometries, using heuristics to ensure

--- a/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGRobustTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGRobustTest.java
@@ -11,8 +11,9 @@
  */
 package org.locationtech.jts.operation.overlayng;
 
+import java.util.List;
+
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.noding.SegmentNode;
 
 import junit.textui.TestRunner;
@@ -84,5 +85,45 @@ public class OverlayNGRobustTest extends GeometryTestCase {
     catch (Throwable ex) {
       // do nothing - expected result
     }
+  }
+  
+  public void testPolygonsOverlapping( ) {
+    checkUnaryUnion("GEOMETRYCOLLECTION (POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200)), POLYGON ((250 250, 250 150, 150 150, 150 250, 250 250)))", 
+        "POLYGON ((100 200, 150 200, 150 250, 250 250, 250 150, 200 150, 200 100, 100 100, 100 200))");
+  }
+
+  public void testCollection( ) {
+    checkUnaryUnion(new String[] {
+        "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
+        "POLYGON ((300 100, 200 100, 200 200, 300 200, 300 100))",
+        "POLYGON ((100 300, 200 300, 200 200, 100 200, 100 300))",
+        "POLYGON ((300 300, 300 200, 200 200, 200 300, 300 300))"
+        },
+        "POLYGON ((100 100, 100 200, 100 300, 200 300, 300 300, 300 200, 300 100, 200 100, 100 100))");
+  }
+
+  public void testCollectionEmpty( ) {
+    checkUnaryUnion(new String[0],
+        "GEOMETRYCOLLECTION EMPTY");
+  }
+
+  private void checkUnaryUnion(String wkt, String wktExpected) {
+    Geometry geom = read(wkt);
+    Geometry expected = read(wktExpected);
+    Geometry result = OverlayNGRobust.union(geom);
+    checkEqual(expected, result);
+  }
+  
+  private void checkUnaryUnion(String[] wkt,String wktExpected) {
+    List geoms = readList(wkt);
+    Geometry expected = read(wktExpected);
+    Geometry result;
+    if (geoms.isEmpty()) {
+      result = OverlayNGRobust.union(geoms, getGeometryFactory());            
+    }
+    else {
+      result = OverlayNGRobust.union(geoms);      
+    }
+    checkEqual(expected, result);
   }
 }


### PR DESCRIPTION
Add `OverlayNGRobust` unary union methods for collections.

As requested in #668. 
See also #669

Signed-off-by: Martin Davis <mtnclimb@gmail.com>