### PR TITLE
Fix RelateOp for empty geometry and closed linear geometry

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/BoundaryOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/BoundaryOp.java
@@ -21,6 +21,7 @@ import org.locationtech.jts.algorithm.BoundaryNodeRule;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateArrays;
 import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Dimension;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -67,6 +68,37 @@ public class BoundaryOp
   {
     BoundaryOp bop = new BoundaryOp(g, bnRule);
     return bop.getBoundary();
+  }
+  
+  /**
+   * Tests if a geometry has a boundary (it is non-empty).
+   * The semantics are:
+   * <ul>
+   * <li>Empty geometries do not have boundaries. 
+   * <li>Points do not have boundaries.
+   * <li>For linear geometries the existence of the boundary 
+   * is determined by the {@link BoundaryNodeRule}.
+   * <li>Non-empty polygons always have a boundary.
+   * </ul>
+   * 
+   * @param geom the geometry providing the boundary
+   * @param boundaryNodeRule  the Boundary Node Rule to use
+   * @return true if the boundary exists
+   */
+  public static boolean hasBoundary(Geometry geom, BoundaryNodeRule boundaryNodeRule) {
+    // Note that this does not handle geometry collections with a non-empty linear element
+    if (geom.isEmpty()) return false;
+    switch (geom.getDimension()) {
+    case Dimension.P: return false;
+    /**
+     * Linear geometries might have an empty boundary due to boundary node rule.
+     */
+    case Dimension.L:
+      Geometry boundary = BoundaryOp.getBoundary(geom, boundaryNodeRule);
+      return ! boundary.isEmpty();
+    case Dimension.A: return true;
+    }
+    return true;
   }
   
   private Geometry geom;

--- a/modules/core/src/test/java/org/locationtech/jts/operation/BoundaryTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/BoundaryTest.java
@@ -17,8 +17,8 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
-import junit.framework.TestCase;
 import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
 
 
 /**
@@ -28,7 +28,7 @@ import junit.textui.TestRunner;
  * @version 1.7
  */
 public class BoundaryTest
-    extends TestCase
+    extends GeometryTestCase
 {
   private static final double TOLERANCE = 0.00005;
 
@@ -121,8 +121,48 @@ public class BoundaryTest
                     "POINT (100 100)"  );
   }
 
-
-
+  public void testHasBoundaryPoint()
+      throws Exception
+  {
+    checkHasBoundary( "POINT (0 0)", false);
+  }
+  
+  public void testHasBoundaryPointEmpty()
+      throws Exception
+  {
+    checkHasBoundary( "POINT EMPTY", false);
+  }
+  
+  public void testHasBoundaryRingClosed()
+      throws Exception
+  {
+    checkHasBoundary( "LINESTRING (100 100, 20 20, 200 20, 100 100)", false);
+  }
+  
+  public void testHasBoundaryMultiLineStringClosed()
+      throws Exception
+  {
+    checkHasBoundary( "MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))", false);
+  }
+  
+  public void testHasBoundaryMultiLineStringOpen()
+      throws Exception
+  {
+    checkHasBoundary( "MULTILINESTRING ((0 0, 0 2), (0 1, 1 1, 1 0, 0 0))");
+  }
+  
+  public void testHasBoundaryPolygon()
+      throws Exception
+  {
+    checkHasBoundary( "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))");
+  }
+  
+  public void testHasBoundaryPolygonEmpty()
+      throws Exception
+  {
+    checkHasBoundary( "POLYGON EMPTY", false);
+  }
+  
   private void runBoundaryTest(String wkt, BoundaryNodeRule bnRule, String wktExpected)
       throws ParseException
   {
@@ -136,4 +176,20 @@ public class BoundaryTest
     assertTrue(boundary.equalsExact(expected));
   }
 
+  private void checkHasBoundary(String wkt)
+  {
+    checkHasBoundary(wkt, BoundaryNodeRule.MOD2_BOUNDARY_RULE, true);
+  }
+  
+  private void checkHasBoundary(String wkt, boolean expected)
+  {
+    checkHasBoundary(wkt, BoundaryNodeRule.MOD2_BOUNDARY_RULE, expected);
+  }
+  
+  private void checkHasBoundary(String wkt, BoundaryNodeRule bnRule, boolean expected)
+  {
+    Geometry g = read(wkt);
+    assertEquals(expected, BoundaryOp.hasBoundary(g, bnRule));
+  }
+  
 }

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relate/RelateBoundaryNodeRuleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relate/RelateBoundaryNodeRuleTest.java
@@ -105,6 +105,32 @@ public class RelateBoundaryNodeRuleTest
     runRelateTest(a, b,  BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE,  "F01FF0102"    );
   }
 
+  public void testPolygonEmptyRing()
+      throws Exception
+  {
+    String a = "POLYGON EMPTY";
+    String b = "LINESTRING (20 100, 20 220, 120 100, 20 100)";
+
+    // closed line has no boundary under SFS rule
+    runRelateTest(a, b,  BoundaryNodeRule.OGC_SFS_BOUNDARY_RULE,   "FFFFFF1F2"    );
+    
+    // closed line has boundary under ENDPOINT rule
+    runRelateTest(a, b,  BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE,  "FFFFFF102"    );
+  }
+
+  public void testPolygonEmptyMultiLineStringClosed()
+      throws Exception
+  {
+    String a = "POLYGON EMPTY";
+    String b = "MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))";
+
+    // closed line has no boundary under SFS rule
+    runRelateTest(a, b,  BoundaryNodeRule.OGC_SFS_BOUNDARY_RULE,   "FFFFFF1F2"    );
+    
+    // closed line has boundary under ENDPOINT rule
+    runRelateTest(a, b,  BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE,  "FFFFFF102"    );
+  }
+
   void runRelateTest(String wkt1, String wkt2, BoundaryNodeRule bnRule, String expectedIM)
       throws ParseException
   {
@@ -113,6 +139,6 @@ public class RelateBoundaryNodeRuleTest
     IntersectionMatrix im = RelateOp.relate(g1, g2, bnRule);
     String imStr = im.toString();
     //System.out.println(imStr);
-    assertTrue(im.matches(expectedIM));
+    assertTrue("Expected " + expectedIM + ", found " + im, im.matches(expectedIM));
   }
 }

--- a/modules/tests/src/test/resources/testxml/general/TestRelateLA.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestRelateLA.xml
@@ -187,4 +187,30 @@
   </test>
 </case>
 
+<case>
+<desc>LA - closed line / empty polygon</desc>
+  <a>
+    LINESTRING(110 60, 20 150, 200 150, 110 60)
+  </a>
+  <b>
+    POLYGON EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
+  </test>
+</case>
+
+<case>
+<desc>LA - closed multiline / empty polygon</desc>
+  <a>
+    MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))
+  </a>
+  <b>
+    POLYGON EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
+  </test>
+</case>
+
 </run>

--- a/modules/tests/src/test/resources/testxml/general/TestRelateLL.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestRelateLL.xml
@@ -307,5 +307,17 @@
   </test>
 </case>
 
+<case>
+<desc>LA - closed multiline / empty line</desc>
+  <a>
+    MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))
+  </a>
+  <b>
+    LINESTRING EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
+  </test>
+</case>
 
 </run>


### PR DESCRIPTION
This fixes a long-standing bug in `relate` which did not compute the correct DE-9IM dimension entry for Exterior-Boundary
for the case of an empty geometry and a closed linear geometry.  

The original code defaulted the value of EB entry to `0`.   The correct algorithm needs to determine the entry based on whether the linear geometry has a non-empty boundary.  In the case of closed linear geometries, the boundary is empty, and the EB entry is `F`.  The boundary also depends on the Boundary Node Rule being used - all cases are now handled.

See [GISSE 384789](https://gis.stackexchange.com/questions/384789/is-this-st-relate-result-expected) for original report of this issue.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>