### PR TITLE
Improve WKBReader error checking

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/ByteArrayInStream.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/ByteArrayInStream.java
@@ -50,8 +50,9 @@ public class ByteArrayInStream
 	 * into the given byte buffer.
 	 * 
 	 * @param buf the buffer to place the read bytes into
+   * @return the number of bytes read
 	 */
-	public void read(final byte[] buf) {
+	public int read(final byte[] buf) {
 		int numToRead = buf.length;
 		// don't try and copy past the end of the input
 		if ((position + numToRead) > buffer.length) {
@@ -66,5 +67,6 @@ public class ByteArrayInStream
 			System.arraycopy(buffer, position, buf, 0, numToRead);			
 		}
 		position += numToRead;
+		return numToRead;
 	}
 }

--- a/modules/core/src/main/java/org/locationtech/jts/io/ByteOrderDataInStream.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/ByteOrderDataInStream.java
@@ -20,6 +20,7 @@ import java.io.IOException;
  */
 public class ByteOrderDataInStream
 {
+ 
   private int byteOrder = ByteOrderValues.BIG_ENDIAN;
   private InStream stream;
   // buffers to hold primitive datatypes
@@ -83,14 +84,13 @@ public class ByteOrderDataInStream
    * Reads a byte value.
    *
    * @return the value read
-   * @throws IOException
+   * @throws IOException if an I/O error occurred
+   * @throws ParseException if not enough data could be read
    */
   public byte readByte()
-  	throws IOException
+  	throws IOException, ParseException
   {
-    stream.read(buf1);
-    bufLast = buf1;
-    count += 1;
+    read(buf1);
     return buf1[0];
   }
 
@@ -98,14 +98,13 @@ public class ByteOrderDataInStream
    * Reads an int value.
    * 
    * @return the value read
-   * @throws IOException
+   * @throws IOException if an I/O error occurred
+   * @throws ParseException if not enough data could be read
    */
   public int readInt()
-	throws IOException
+	throws IOException, ParseException
   {
-    stream.read(buf4);
-    bufLast = buf4;
-    count += 4;
+    read(buf4);
     return ByteOrderValues.getInt(buf4, byteOrder);
   }
   
@@ -113,14 +112,13 @@ public class ByteOrderDataInStream
    * Reads a long value.
    * 
    * @return the value read
-   * @throws IOException
+   * @throws IOException if an I/O error occurred
+   * @throws ParseException if not enough data could be read
    */
   public long readLong()
-	throws IOException
+	throws IOException, ParseException
   {
-    stream.read(buf8);
-    bufLast = buf8;
-    count += 8;
+    read(buf8);
     return ByteOrderValues.getLong(buf8, byteOrder);
   }
 
@@ -128,15 +126,22 @@ public class ByteOrderDataInStream
    * Reads a double value.
    * 
    * @return the value read
-   * @throws IOException
+   * @throws IOException if an I/O error occurred
+   * @throws ParseException if not enough data could be read
    */
   public double readDouble()
-	throws IOException
+	throws IOException, ParseException
   {
-    stream.read(buf8);
-    bufLast = buf8;
-    count += 8;
+    read(buf8);
     return ByteOrderValues.getDouble(buf8, byteOrder);
   }
 
+  private void read(byte[] buf) throws IOException, ParseException {
+    int num = stream.read(buf);
+    if (num < buf.length) 
+      throw new ParseException("Attempt to read past end of input");
+    bufLast = buf;
+    count += num;
+  }
+  
 }

--- a/modules/core/src/main/java/org/locationtech/jts/io/InStream.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/InStream.java
@@ -26,8 +26,9 @@ public interface InStream
    * and stores them in the supplied buffer.
    *
    * @param buf the buffer to receive the bytes
+   * @return the number of bytes read, or -1 if at end-of-file
    *
    * @throws IOException if an I/O error occurs
    */
-  void read(byte[] buf) throws IOException;
+  int read(byte[] buf) throws IOException;
 }

--- a/modules/core/src/main/java/org/locationtech/jts/io/InputStreamInStream.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/InputStreamInStream.java
@@ -27,8 +27,8 @@ public class InputStreamInStream
     this.is = is;
   }
 
-  public void read(byte[] buf) throws IOException
+  public int read(byte[] buf) throws IOException
   {
-    is.read(buf);
+    return is.read(buf);
   }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKBReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKBReaderTest.java
@@ -212,16 +212,65 @@ public class WKBReaderTest  extends TestCase
   }
 
   /**
+   * Tests WKB that requests a huge number of points.
    * Not yet implemented satisfactorily.
    * 
    * @throws ParseException
    */
-  public void XXtestIllFormedWKB() throws ParseException
+  public void testHugeNumberOfPoints() throws ParseException
   {
-    // WKB is missing LinearRing entry
-    checkWKBGeometry("00000000030000000140590000000000004069000000000000", "POLYGON ((100 200, 100 200, 100 200, 100 200)");
+    /*
+     * 0: 00 - XDR (Big endian)
+     * 1: 00000003 - POLYGON ( 3 ) 
+     * 5: 00000001 - Num Rings = 1
+     * 9: 40590000 - Num Points = 1079574528
+     */
+    checkWKBParseException("00000000030000000140590000000000004069000000000000");
   }
 
+  public void testNumCoordsNegative() throws ParseException
+  {
+    /*
+     * 0: 01 - NDR (Little endian)
+     * 1: 02000000 - LINESTRING ( 2 ) 
+     * 5: 0000FFFF - Num Points = -65536     * 0: 00 - XDR (Big endian)
+     */
+    checkWKBParseException("01020000000000FFFF");
+  }
+  
+  public void testNumElementsNegative() throws ParseException
+  {
+    /*
+     * 0: 00 - XDR (Big endian)
+     * 1: 00000004 - MULTIPOINT ( 4 ) 
+     * 5: FFFFFFFF - Num Elements = -1     * 0: 01 - NDR (Little endian)
+     */
+    checkWKBParseException("0000000004FFFFFFFF000000000140590000000000004059000000000000000000000140690000000000004059000000000000");
+  }
+  
+  public void testNumRingsNegative() throws ParseException
+  {
+    /*
+     * 0: 00 - XDR (Big endian)
+     * 1: 00000004 - MULTIPOINT ( 4 ) 
+     * 5: FFFFFFFF - Num Elements = -1     * 0: 01 - NDR (Little endian)
+     */
+    checkWKBParseException("0000000003FFFFFFFF0000000440590000000000004069000000000000405900000000000040590000000000004069000000000000405900000000000040590000000000004069000000000000");
+  }
+  
+  //======================================
+  
+  private void checkWKBParseException(String wkbHex) 
+  {
+    try {
+      checkWKBGeometry(wkbHex, "");
+    } catch (ParseException e) {
+      // all good
+      return;
+    }
+    // expected ParseException did not occur
+    fail();
+  }
 
   private static CoordinateSequenceComparator comp2 = new CoordinateSequenceComparator(2);
 


### PR DESCRIPTION
This improves the error checking in the `WKBReader` to detect field values which are out of range.  The fields checked are `numElems`, `numRings` and `numCoords`.  They are checked to ensure they are > 0 and less than MAX_INT, and that they are less than the maximum size of the WKB data (if known).  This should prevent `NegativeArraySizeException` and `OutOfMemoryError` errors being caused by malformed or malicious WKB values.
 
Fixes #67.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>