### PR TITLE
Fix Densifier for segs with length equal to distance tol

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/densify/Densifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/densify/Densifier.java
@@ -25,9 +25,10 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
 /**
  * Densifies a {@link Geometry} by inserting extra vertices along the line segments
  * contained in the geometry. 
- * All segments in the created densified geometry will be no longer than
- * than the given distance tolerance.
- * Densified polygonal geometries are guaranteed to be topologically correct.
+ * All segments in the created densified geometry will be <b>no longer</b>
+ * than the given distance tolerance
+ * (that is, all segments in the output will have length less than or equal to
+ * the distance tolerance).
  * The coordinates created during densification respect the input geometry's
  * {@link PrecisionModel}.
  * <p>
@@ -56,10 +57,10 @@ public class Densifier {
 	}
 
 	/**
-	 * Densifies a coordinate sequence.
+	 * Densifies a list of coordinates.
 	 * 
-	 * @param pts
-	 * @param distanceTolerance
+	 * @param pts the coordinate list
+	 * @param distanceTolerance the densify tolerance
 	 * @return the densified coordinate sequence
 	 */
 	private static Coordinate[] densifyPoints(Coordinate[] pts,
@@ -71,18 +72,24 @@ public class Densifier {
 			seg.p1 = pts[i + 1];
 			coordList.add(seg.p0, false);
 			double len = seg.getLength();
+			
+			// check if no densification is required
+			if (len <= distanceTolerance)
+			  continue;
+			
+			// densify the segment
 			int densifiedSegCount = (int) (len / distanceTolerance) + 1;
-			if (densifiedSegCount > 1) {
-				double densifiedSegLen = len / densifiedSegCount;
-				for (int j = 1; j < densifiedSegCount; j++) {
-					double segFract = (j * densifiedSegLen) / len;
-					Coordinate p = seg.pointAlong(segFract);
-          precModel.makePrecise(p);
-					coordList.add(p, false);
-				}
+			double densifiedSegLen = len / densifiedSegCount;
+			for (int j = 1; j < densifiedSegCount; j++) {
+				double segFract = (j * densifiedSegLen) / len;
+				Coordinate p = seg.pointAlong(segFract);
+        precModel.makePrecise(p);
+				coordList.add(p, false);
 			}
 		}
-		coordList.add(pts[pts.length - 1], false);
+		// this check handles empty sequences
+		if (pts.length > 0) 
+		  coordList.add(pts[pts.length - 1], false);
 		return coordList.toCoordinateArray();
 	}
 
@@ -107,7 +114,6 @@ public class Densifier {
 	/**
 	 * Sets the distance tolerance for the densification. All line segments
 	 * in the densified geometry will be no longer than the distance tolerance.
-	 * simplified geometry will be within this distance of the original geometry.
 	 * The distance tolerance must be positive.
 	 * 
 	 * @param distanceTolerance

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryTransformer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryTransformer.java
@@ -248,9 +248,13 @@ public class GeometryTransformer
     boolean isAllValidLinearRings = true;
     Geometry shell = transformLinearRing(geom.getExteriorRing(), geom);
 
-    if (shell == null
-        || ! (shell instanceof LinearRing)
-        || shell.isEmpty() )
+    // handle empty inputs, or inputs which are made empty
+    boolean shellIsNullOrEmpty = shell == null || shell.isEmpty();
+    if (geom.isEmpty() && shellIsNullOrEmpty ) {
+      return factory.createPolygon();
+    }
+    
+    if (shellIsNullOrEmpty || ! (shell instanceof LinearRing))
       isAllValidLinearRings = false;
 
     ArrayList holes = new ArrayList();

--- a/modules/core/src/test/java/org/locationtech/jts/densify/DensifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/densify/DensifierTest.java
@@ -34,6 +34,31 @@ public class DensifierTest extends GeometryTestCase {
         10, "LINESTRING (0 0, 5 6.666666666666668, 10 13.333333333333336, 15 20, 20 26.66666666666667, 25 33.33333333333334, 30 40, 35 35)");
   }
 
+  public void testLineOfToleranceLength() {
+    checkDensify("LINESTRING (0 0, 10 0)", 
+        10, "LINESTRING (0 0, 10 0)");
+  }
+
+  public void testLineWithToleranceLengthSeg() {
+    checkDensify("LINESTRING (0 0, 12 0, 22 0, 34 0)", 
+        10, "LINESTRING (0 0, 6 0, 12 0, 22 0, 28 0, 34 0)");
+  }
+
+  public void testLineEmpty() {
+    checkDensify("LINESTRING EMPTY", 
+        10, "LINESTRING EMPTY");
+  }
+
+  public void testPointUnchanged() {
+    checkDensify("POINT (0 0)", 
+        10, "POINT (0 0)");
+  }
+
+  public void testPolygonEmpty() {
+    checkDensify("POLYGON EMPTY", 
+        10, "POLYGON EMPTY");
+  }
+
   public void testBox() {
     checkDensify("POLYGON ((10 30, 30 30, 30 10, 10 10, 10 30))", 
         10, "POLYGON ((10 30, 16.666666666666668 30, 23.333333333333336 30, 30 30, 30 23.333333333333332, 30 16.666666666666664, 30 10, 23.333333333333332 10, 16.666666666666664 10, 10 10, 10 16.666666666666668, 10 23.333333333333336, 10 30))");


### PR DESCRIPTION
Fix Densifier behaviour for segments with length equal to distance tolerance.
Segments with length equal to distance tolerance will now **not** be split, which matches the stated semantics.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>