### PR TITLE
Fix Polygon.compareTo to test holes

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Polygon.java
@@ -367,9 +367,26 @@ public class Polygon
   }
 
   protected int compareToSameClass(Object o) {
+    Polygon poly = (Polygon) o;
+
     LinearRing thisShell = shell;
-    LinearRing otherShell = ((Polygon) o).shell;
-    return thisShell.compareToSameClass(otherShell);
+    LinearRing otherShell = poly.shell;
+    int shellComp = thisShell.compareToSameClass(otherShell);
+    if (shellComp != 0) return shellComp;
+
+    int nHole1 = getNumInteriorRing();
+    int nHole2 = ((Polygon) o).getNumInteriorRing();
+    int i = 0;
+    while (i < nHole1 && i < nHole2) {
+      LinearRing thisHole = (LinearRing) getInteriorRingN(i);
+      LinearRing otherHole = (LinearRing) poly.getInteriorRingN(i);
+      int holeComp = thisHole.compareToSameClass(otherHole);
+      if (holeComp != 0) return holeComp;
+      i++;
+    }
+    if (i < nHole1) return 1;
+    if (i < nHole2) return -1;
+    return 0;
   }
 
   protected int compareToSameClass(Object o, CoordinateSequenceComparator comp) {

--- a/modules/core/src/test/java/org/locationtech/jts/geom/GeometryCompareToTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/GeometryCompareToTest.java
@@ -1,0 +1,52 @@
+package org.locationtech.jts.geom;
+
+import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
+import test.jts.GeometryTestData;
+
+public class GeometryCompareToTest extends GeometryTestCase{
+  public static void main(String args[]) {
+    TestRunner.run(GeometryCompareToTest.class);
+  }
+
+  public GeometryCompareToTest(String name) { super(name); }
+  
+  public void testPoints() {
+    checkCompareTo(-1, "POINT (0 0)", "POINT (1 0)");
+    checkCompareTo(-1, "POINT (0 0)", "POINT (0 1)");
+    checkCompareTo(1, "POINT (1 0)", "POINT (0 1)");
+  }
+
+  public void testLines() {
+    checkCompareTo(-1, 
+        "LINESTRING ( 0 0, 1 1, 0 1)",
+        "LINESTRING ( 0 0, 1 1, 0 2)");
+  }
+
+  public void testPolygonToPolygonWithHole() {
+    checkCompareTo(-1, GeometryTestData.WKT_POLY, GeometryTestData.WKT_POLY_HOLE);
+  }
+
+  public void testEqual() {
+    checkCompareTo(0, GeometryTestData.WKT_POINT,GeometryTestData.WKT_POINT);
+    checkCompareTo(0, GeometryTestData.WKT_LINESTRING,GeometryTestData.WKT_LINESTRING);
+    checkCompareTo(0, GeometryTestData.WKT_POLY,GeometryTestData.WKT_POLY);
+    checkCompareTo(0, GeometryTestData.WKT_POLY_HOLE,GeometryTestData.WKT_POLY_HOLE);
+  }
+
+  public void testOrdering() {
+    checkCompareTo(-1, GeometryTestData.WKT_POINT,GeometryTestData.WKT_MULTIPOINT);
+    checkCompareTo(-1, GeometryTestData.WKT_MULTIPOINT,GeometryTestData.WKT_LINESTRING);
+    checkCompareTo(-1, GeometryTestData.WKT_LINESTRING,GeometryTestData.WKT_LINEARRING);
+    checkCompareTo(-1, GeometryTestData.WKT_LINEARRING,GeometryTestData.WKT_MULTILINESTRING);
+    checkCompareTo(-1, GeometryTestData.WKT_MULTILINESTRING,GeometryTestData.WKT_POLY);
+    checkCompareTo(-1, GeometryTestData.WKT_POLY,GeometryTestData.WKT_MULTIPOLYGON);    
+    checkCompareTo(-1, GeometryTestData.WKT_MULTIPOLYGON,GeometryTestData.WKT_GC);    
+  }
+  private void checkCompareTo(int compExpected, String wkt1, String wkt2 ) {
+    Geometry g1 = read(wkt1);
+    Geometry g2 = read(wkt2);
+    int comp = g1.compareTo(g2);
+    assertEquals(compExpected, comp);
+  }
+}


### PR DESCRIPTION
Fixes `Polygon.compareTo(Object)` to test holes.

Reported in [GEOS 397](https://github.com/libgeos/geos/pull/397).

Signed-off-by: Martin Davis <mtnclimb@gmail.com>