### PR TITLE
Lower LinearRing min vertex limit to 3

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/io/shapefile/PolygonHandler.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/io/shapefile/PolygonHandler.java
@@ -194,7 +194,10 @@ public class PolygonHandler implements ShapeHandler{
                 offset++;
             }
             LinearRing ring = geometryFactory.createLinearRing(points);
-            if(Orientation.isCCW(points)){
+            /**
+             * Allow reading a 3-point ring, and treat it as a shell.
+             */
+            if(points.length >= 4 && Orientation.isCCW(points)){
                 holes.add(ring);
             }
             else{

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LinearRing.java
@@ -18,23 +18,26 @@ package org.locationtech.jts.geom;
  * A <code>LinearRing</code> is a {@link LineString} which is both closed and simple.
  * In other words,
  * the first and last coordinate in the ring must be equal,
- * and the interior of the ring must not self-intersect.
+ * and the ring must not self-intersect.
  * Either orientation of the ring is allowed.
  * <p>
- * A ring must have either 0 or 4 or more points.
+ * A ring must have either 0 or 3 or more points.
  * The first and last points must be equal (in 2D).
  * If these conditions are not met, the constructors throw
- * an {@link IllegalArgumentException}
+ * an {@link IllegalArgumentException}.
+ * A ring with 3 points is invalid, because it is collapsed
+ * and thus has a self-intersection.  It is allowed to be constructed
+ * so that it can be represented, and repaired if needed.
  *
  * @version 1.7
  */
 public class LinearRing extends LineString
 {
   /**
-   * The minimum number of vertices allowed in a valid non-empty ring (= 4).
+   * The minimum number of vertices allowed in a valid non-empty ring.
    * Empty rings with 0 vertices are also valid.
    */
-  public static final int MINIMUM_VALID_SIZE = 4;
+  public static final int MINIMUM_VALID_SIZE = 3;
 
   private static final long serialVersionUID = -4261142084085851829L;
 

--- a/modules/core/src/test/java/org/locationtech/jts/geom/LineStringImplTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/LineStringImplTest.java
@@ -19,6 +19,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
 
 
 /**
@@ -26,7 +27,7 @@ import junit.textui.TestRunner;
  *
  * @version 1.7
  */
-public class LineStringImplTest extends TestCase {
+public class LineStringImplTest extends GeometryTestCase {
 
   PrecisionModel precisionModel = new PrecisionModel(1000);
   GeometryFactory geometryFactory = new GeometryFactory(precisionModel, 0);
@@ -169,17 +170,14 @@ public class LineStringImplTest extends TestCase {
   }
 
   public void testLinearRingConstructor() throws Exception {
-    try {
       LinearRing ring =
         new GeometryFactory().createLinearRing(
           new Coordinate[] {
             new Coordinate(0, 0),
             new Coordinate(10, 10),
             new Coordinate(0, 0)});
-      assertTrue(false);
-    } catch (IllegalArgumentException e) {
-      assertTrue(true);
-    }
+      Geometry ringFromWKT = read("LINEARRING (0 0, 10 10, 0 0)");
+      checkEqual(ring, ringFromWKT);
   }
 
 }


### PR DESCRIPTION
Lowers the constraint on the LinearRing minimum number of vertices to 3 (from 4).  This allows invalid rings to be created, so that they can be found and fixed.

This provides a resolution to #558.  

See also R-sf issue [1589](https://github.com/r-spatial/sf/issues/1589).

Signed-off-by: Martin Davis <mtnclimb@gmail.com>