### PR TITLE
Fix OverlayNG handling of flat interior lines

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayUtil.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayUtil.java
@@ -134,6 +134,10 @@ class OverlayUtil {
     if (isFloating(pm)) {
       // if PM is FLOAT then there is no scale factor, so add 10%
       double minSize = Math.min(env.getHeight(), env.getWidth());
+      // heuristic to ensure zero-width envelopes don't cause total clipping
+      if (minSize <= 0.0) {
+        minSize = Math.max(env.getHeight(), env.getWidth());
+      }
       envExpandDist = SAFE_ENV_BUFFER_FACTOR * minSize;
     }
     else {

--- a/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGTest.java
@@ -577,6 +577,22 @@ public class OverlayNGTest extends GeometryTestCase {
     checkEqualExact(expected, actual);    
   }
   
+  public void testPolygonLineVerticalntersection() {
+    Geometry a = read("POLYGON ((-200 -200, 200 -200, 200 200, -200 200, -200 -200))");
+    Geometry b = read("LINESTRING (-100 100, -100 -100)");
+    Geometry expected = read("LINESTRING (-100 100, -100 -100)");
+    Geometry actual = intersection(a, b);
+    checkEqual(expected, actual);    
+  }
+  
+  public void testPolygonLineHorizontalIntersection() {
+    Geometry a = read("POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90))");
+    Geometry b = read("LINESTRING (20 50, 80 50)");
+    Geometry expected = read("LINESTRING (20 50, 80 50)");
+    Geometry actual = intersection(a, b);
+    checkEqual(expected, actual);    
+  }
+  
   //============================================================
   
   

--- a/modules/tests/src/test/resources/testxml/general/TestNGOverlayL.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestNGOverlayL.xml
@@ -205,6 +205,31 @@ MULTILINESTRING ((150 150, 200 200, 300 300, 400 200), (100 100, 150 150), (190 
 </case>
 
 <case>
+  <desc>LA - vertical Line</desc>
+  <a>
+    LINESTRING (50 50, 50 20)
+  </a>
+  <b>
+    POLYGON ((10 60, 90 60, 90 10, 10 10, 10 60))
+  </b>
+<test>  <op name="intersectionNG" arg1="A" arg2="B">
+LINESTRING (50 50, 50 20)
+  </op></test>
+<test>  <op name="unionNG" arg1="A" arg2="B">
+POLYGON ((90 60, 90 10, 10 10, 10 60, 90 60))
+  </op></test>
+<test>  <op name="differenceNG" arg1="A" arg2="B">
+LINESTRING EMPTY
+  </op></test>
+<test>  <op name="differenceNG" arg1="B" arg2="A">
+POLYGON ((90 60, 90 10, 10 10, 10 60, 90 60))
+  </op></test>
+<test>  <op name="symdifferenceNG" arg1="A" arg2="B">
+POLYGON ((90 60, 90 10, 10 10, 10 60, 90 60))
+  </op></test>
+</case>
+
+<case>
   <desc>mLmA - disjoint and overlaps in lines and points</desc>
   <a>
 MULTILINESTRING ((50 150, 150 150), (100 350, 200 350), (320 350, 350 350), (300 150, 400 150), (150 300, 400 300))


### PR DESCRIPTION
This fixes a bug in the OverlayNG ring-clipping optimization, which was causing an invalid result for intersection and difference between polygons and flat (vertical/horizontal) interior lines.

Reported in [GEOS 408](https://github.com/libgeos/geos/issues/408).

Signed-off-by: Martin Davis <mtnclimb@gmail.com>