### PR TITLE
Fix GeoJSONWriter to emit empty coordinates array for empty point and linestring

### DIFF
--- a/modules/io/common/src/main/java/org/locationtech/jts/io/geojson/GeoJsonWriter.java
+++ b/modules/io/common/src/main/java/org/locationtech/jts/io/geojson/GeoJsonWriter.java
@@ -119,7 +119,9 @@ public class GeoJsonWriter {
     if (geometry instanceof Point) {
       Point point = (Point) geometry;
 
-      final String jsonString = getJsonString(point.getCoordinateSequence());
+      CoordinateSequence coordinateSequence = point.getCoordinateSequence();
+      final String jsonString = coordinateSequence.size() == 0
+          ? "[]" : getJsonString(coordinateSequence);
 
       result.put(GeoJsonConstants.NAME_COORDINATES, new JSONAware() {
 
@@ -131,8 +133,9 @@ public class GeoJsonWriter {
     } else if (geometry instanceof LineString) {
       LineString lineString = (LineString) geometry;
 
-      final String jsonString = getJsonString(lineString
-          .getCoordinateSequence());
+      CoordinateSequence coordinateSequence = lineString.getCoordinateSequence();
+      final String jsonString = coordinateSequence.size() == 0
+          ? "[]" : getJsonString(coordinateSequence);
 
       result.put(GeoJsonConstants.NAME_COORDINATES, new JSONAware() {
 

--- a/modules/io/common/src/test/java/org/locationtech/jts/io/geojson/GeoJsonWriterTest.java
+++ b/modules/io/common/src/test/java/org/locationtech/jts/io/geojson/GeoJsonWriterTest.java
@@ -14,8 +14,6 @@ package org.locationtech.jts.io.geojson;
 
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
-import org.locationtech.jts.io.geojson.GeoJsonWriter;
-
 
 import test.jts.GeometryTestCase;
 
@@ -45,14 +43,32 @@ public class GeoJsonWriterTest extends GeometryTestCase {
         );
   }
 
+  public void testPointEmpty() throws ParseException {
+    runTest("POINT EMPTY",
+        "{'type':'Point','coordinates':[]}"
+    );
+  }
+
   public void testLineString() throws ParseException {
     runTest("LINESTRING (1 2, 10 20, 100 200)",
         "{'type':'LineString','coordinates':[[1,2],[10,20],[100,200]]}");
   }
 
+  public void testLineStringEmpty() throws ParseException {
+    runTest("LINESTRING EMPTY",
+        "{'type':'LineString','coordinates':[]}"
+    );
+  }
+
   public void testPolygon() throws ParseException {
     runTest("POLYGON ((0 0, 100 0, 100 100, 0 100, 0 0))",
         "{'type':'Polygon','coordinates':[[[0.0,0.0],[100,0.0],[100,100],[0.0,100],[0.0,0.0]]]}");
+  }
+
+  public void testPolygonEmpty() throws ParseException {
+    runTest("POLYGON EMPTY",
+        "{'type':'Polygon','coordinates':[]}"
+    );
   }
 
   public void testPolygonWithHole() throws ParseException {


### PR DESCRIPTION
Fix for https://github.com/locationtech/jts/issues/411.

See also #687.