### PR TITLE
Add MaximumInscribedCircle check for invalid tolerance

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircle.java
@@ -101,7 +101,8 @@ public class MaximumInscribedCircle {
    * Creates a new instance of a Maximum Inscribed Circle computation.
    * 
    * @param polygonal an areal geometry
-   * @param tolerance the distance tolerance for computing the centre point
+   * @param tolerance the distance tolerance for computing the centre point (must be positive)
+   * @throws IllegalArgumentException if the tolerance is non-positive, or the input geometry is non-polygonal or empty.
    */
   public MaximumInscribedCircle(Geometry polygonal, double tolerance) {
     if (tolerance <= 0) {

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircle.java
@@ -104,6 +104,9 @@ public class MaximumInscribedCircle {
    * @param tolerance the distance tolerance for computing the centre point
    */
   public MaximumInscribedCircle(Geometry polygonal, double tolerance) {
+    if (tolerance <= 0) {
+      throw new IllegalArgumentException("Tolerance must be positive");
+    }
     if (! (polygonal instanceof Polygon || polygonal instanceof MultiPolygon)) {
       throw new IllegalArgumentException("Input geometry must be a Polygon or MultiPolygon");
     }


### PR DESCRIPTION
Throw an `IllegalArgumentException` if the `MaximumInscribedCircle` tolerance is non-positive.  This prevents infinite loops.
 
Signed-off-by: Martin Davis <mtnclimb@gmail.com>