### PR TITLE
Fix InteriorPoint to handle partially empty collections

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -780,10 +780,10 @@ public abstract class Geometry
    *    <li><code>[0********]</code> (for L/L situations)
    *   </ul>
    * </ul>
-   * For any other combination of dimensions this predicate returns <code>false</code>.
+   * For the A/A and P/P situations this predicate returns <code>false</code>.
    * <p>
    * The SFS defined this predicate only for P/L, P/A, L/L, and L/A situations.
-   * In order to make the relation symmetric,
+   * To make the relation symmetric
    * JTS extends the definition to apply to L/P, A/P and A/L situations as well.
    *
    *@param  g  the <code>Geometry</code> with which to compare this <code>Geometry</code>
@@ -1857,6 +1857,9 @@ public abstract class Geometry
 
   private Point createPointFromInternalCoord(Coordinate coord, Geometry exemplar)
   {
+    // create empty point for null input
+    if (coord == null) 
+      return exemplar.getFactory().createPoint();
     exemplar.getPrecisionModel().makePrecise(coord);
     return exemplar.getFactory().createPoint(coord);
   }

--- a/modules/tests/src/test/resources/testxml/general/TestCentroid.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestCentroid.xml
@@ -92,6 +92,13 @@
 </case>
 
 <case>
+  <desc>A - empty</desc>
+  <a>    POLYGON EMPTY
+  </a>
+<test><op name="getCentroid" arg1="A" >    POINT EMPTY   </op></test>
+</case>
+
+<case>
   <desc>A - box</desc>
   <a>    POLYGON ((40 160, 160 160, 160 40, 40 40, 40 160))  </a>
 <test><op name="getCentroid" arg1="A" >    POINT (100 100)   </op></test>
@@ -219,6 +226,33 @@
 </case>
 
 <case>
+  <desc>GC - collection with empty polygon, line, and point</desc>
+  <a>    GEOMETRYCOLLECTION (POLYGON EMPTY, 
+  LINESTRING (20 20, 30 30, 40 40),
+  MULTIPOINT ((20 10), (10 20)) )
+  </a>
+<test><op name="getCentroid" arg1="A" >    POINT (30 30)   </op></test>
+</case>
+
+<case>
+  <desc>GC - collection with empty polygon, empty line, and point</desc>
+  <a>    GEOMETRYCOLLECTION (POLYGON EMPTY, 
+  LINESTRING EMPTY,
+  POINT (10 10) )
+  </a>
+<test><op name="getCentroid" arg1="A" >    POINT (10 10)   </op></test>
+</case>
+
+<case>
+  <desc>GC - collection with empty polygon, empty line, and empty point</desc>
+  <a>    GEOMETRYCOLLECTION (POLYGON EMPTY, 
+  LINESTRING EMPTY,
+  POINT EMPTY )
+  </a>
+<test><op name="getCentroid" arg1="A" >    POINT EMPTY  </op></test>
+</case>
+
+<case>
   <desc>GC - overlapping polygons </desc>
   <a>    GEOMETRYCOLLECTION (POLYGON ((20 100, 20 -20, 60 -20, 60 100, 20 100)), 
   POLYGON ((-20 60, 100 60, 100 20, -20 20, -20 60)))
@@ -236,13 +270,6 @@
   <desc>A - degenerate triangle</desc>
   <a>    POLYGON ((10 10, 100 100, 100 100, 10 10))  </a>
 <test><op name="getCentroid" arg1="A" >    POINT (55 55)   </op></test>
-</case>
-
-<case>
-  <desc>A - empty</desc>
-  <a>    POLYGON EMPTY
-	</a>
-<test><op name="getCentroid" arg1="A" >    POINT EMPTY   </op></test>
 </case>
 
 <case>

--- a/modules/tests/src/test/resources/testxml/general/TestInteriorPoint.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestInteriorPoint.xml
@@ -21,9 +21,16 @@
 </case>
 
 <case>
+  <desc>L - empty</desc>
+  <a>    LINESTRING EMPTY
+  </a>
+<test><op name="getInteriorPoint" arg1="A" >   POINT EMPTY   </op></test>
+</case>
+
+<case>
   <desc>L - linestring with single segment</desc>
   <a>    LINESTRING (0 0, 7 14)
-	</a>
+  </a>
 <test><op name="getInteriorPoint" arg1="A" >   POINT (7 14)   </op></test>
 </case>
 
@@ -119,8 +126,35 @@
   <a>    GEOMETRYCOLLECTION (POLYGON ((10 10, 10 10, 10 10, 10 10)), 
   LINESTRING (20 20, 20 20),
   MULTIPOINT ((20 10), (10 20)) )
-	</a>
+  </a>
 <test><op name="getInteriorPoint" arg1="A" >    POINT (10 10)   </op></test>
+</case>
+
+<case>
+  <desc>GC - collection with empty polygon, line, and point</desc>
+  <a>    GEOMETRYCOLLECTION (POLYGON EMPTY, 
+  LINESTRING (20 20, 30 30, 40 40),
+  MULTIPOINT ((20 10), (10 20)) )
+  </a>
+<test><op name="getInteriorPoint" arg1="A" >    POINT (30 30)   </op></test>
+</case>
+
+<case>
+  <desc>GC - collection with empty polygon, empty line, and point</desc>
+  <a>    GEOMETRYCOLLECTION (POLYGON EMPTY, 
+  LINESTRING EMPTY,
+  POINT (10 10) )
+  </a>
+<test><op name="getInteriorPoint" arg1="A" >    POINT (10 10)   </op></test>
+</case>
+
+<case>
+  <desc>GC - collection with empty polygon, empty line, and empty point</desc>
+  <a>    GEOMETRYCOLLECTION (POLYGON EMPTY, 
+  LINESTRING EMPTY,
+  POINT EMPTY )
+  </a>
+<test><op name="getInteriorPoint" arg1="A" >    POINT EMPTY  </op></test>
 </case>
 
 


### PR DESCRIPTION
Fix is to ignore empty elements in collections.

Previously empty elements of higher dimension would cause a `POINT EMPTY` result, even if there were if there non-empty elements of lower dimension.

Also fixes a bug in `Geometry.createPointFromInternalCoord`.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>