### PR TITLE
Fix MultiPoint to check isValid properly

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/MultiPoint.java
@@ -87,10 +87,6 @@ public class MultiPoint
     }
     return new MultiPoint(points, factory);
   }
-  
-  public boolean isValid() {
-    return true;
-  }
 
   public boolean equalsExact(Geometry other, double tolerance) {
     if (!isEquivalentClass(other)) {

--- a/modules/tests/src/test/resources/testxml/general/TestValid.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestValid.xml
@@ -60,12 +60,22 @@
    </case>
 
    <case>
-      <desc>P - repeated points</desc>
+      <desc>mP - repeated points</desc>
       <a>
     MULTIPOINT((10 10), (20 20), (30 30), (10 10))
   </a>
       <test>
          <op name="isValid" arg1="A">    true  </op>
+      </test>
+   </case>
+
+   <case>
+      <desc>mP - invalid point</desc>
+      <a>
+    MULTIPOINT((10 10), (20 20), (30 30), (10 NaN))
+  </a>
+      <test>
+         <op name="isValid" arg1="A">    false  </op>
       </test>
    </case>
 
@@ -138,6 +148,14 @@ LINESTRING (40 180, 120 120, 140 200, 140 200, 200 140, 240 200)
       <a>MULTILINESTRING((1 1, 0 0), EMPTY)</a>
       <test>
          <op name="isValid" arg1="A">      true      </op>
+      </test>
+   </case>
+
+   <case>
+      <desc>mL - MultiLinestring with invalid point</desc>
+      <a>MULTILINESTRING((1 1, 2 NaN, 0 0))</a>
+      <test>
+         <op name="isValid" arg1="A">      false      </op>
       </test>
    </case>
 


### PR DESCRIPTION
Fixes `MultiPoint.isValid` to actually check validity.  

Current the `isValid` test is hard-code to `true`.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>