### PR TITLE
Fix WKTReader and WKTWriter handling of collections with all empty elems

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -436,14 +436,19 @@ public abstract class Geometry
   /**
    * Tests whether the set of points covered by this <code>Geometry</code> is
    * empty.
+   * <p>
+   * Note this test is for topological emptiness,
+   * not structural emptiness. 
+   * A collection containing only empty elements is reported as empty.
+   * To check structural emptiness use {@link #getNumGeometries()}.
    *
    *@return <code>true</code> if this <code>Geometry</code> does not cover any points
    */
   public abstract boolean isEmpty();
 
   /**
-   *  Returns the minimum distance between this <code>Geometry</code>
-   *  and another <code>Geometry</code>.
+   * Returns the minimum distance between this <code>Geometry</code>
+   * and another <code>Geometry</code>.
    *
    * @param  g the <code>Geometry</code> from which to compute the distance
    * @return the distance between the geometries

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
@@ -903,7 +903,7 @@ S  */
     // MD 2009-02-21 - this is only provided for backwards compatibility for a few versions
     if (isAllowOldJtsMultipointSyntax) {
       String nextWord = lookAheadWord(tokenizer);
-      if (nextWord != L_PAREN) {
+      if (nextWord != L_PAREN && nextWord != WKTConstants.EMPTY) {
         return geometryFactory.createMultiPoint(
             getCoordinateSequenceOldMultiPoint(tokenizer, ordinateFlags));
       }

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTWriter.java
@@ -870,7 +870,7 @@ public class WKTWriter
           int level, Writer writer, OrdinateFormat formatter)
     throws IOException
   {
-    if (multiPoint.isEmpty()) {
+    if (multiPoint.getNumGeometries() == 0) {
       writer.write(WKTConstants.EMPTY);
     }
     else {
@@ -903,7 +903,7 @@ public class WKTWriter
            boolean useFormatting, int level, /*boolean indentFirst, */Writer writer, OrdinateFormat formatter)
     throws IOException
   {
-    if (multiLineString.isEmpty()) {
+    if (multiLineString.getNumGeometries() == 0) {
       writer.write(WKTConstants.EMPTY);
     }
     else {
@@ -938,7 +938,7 @@ public class WKTWriter
           int level, Writer writer, OrdinateFormat formatter)
     throws IOException
   {
-    if (multiPolygon.isEmpty()) {
+    if (multiPolygon.getNumGeometries() == 0) {
       writer.write(WKTConstants.EMPTY);
     }
     else {
@@ -973,7 +973,7 @@ public class WKTWriter
           int level, Writer writer, OrdinateFormat formatter)
     throws IOException
   {
-    if (geometryCollection.isEmpty()) {
+    if (geometryCollection.getNumGeometries() == 0) {
       writer.write(WKTConstants.EMPTY);
     }
     else {

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReadWriteTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReadWriteTest.java
@@ -1,15 +1,12 @@
 package org.locationtech.jts.io;
 
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.textui.TestRunner;
-
-import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 
-import java.util.EnumSet;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import junit.textui.TestRunner;
 
 public class WKTReadWriteTest extends TestCase {
 
@@ -70,16 +67,19 @@ public class WKTReadWriteTest extends TestCase {
   public void testReadMultiPoint() throws Exception {
     assertEquals("MULTIPOINT ((10 10), (20 20))", writer.write(reader.read("MULTIPOINT ((10 10), (20 20))")));
     assertEquals("MULTIPOINT EMPTY", writer.write(reader.read("MULTIPOINT EMPTY")));
+    assertEquals("MULTIPOINT (EMPTY, EMPTY)", writer.write(reader.read("MULTIPOINT (EMPTY, EMPTY)")));
   }
 
   public void testReadMultiLineString() throws Exception {
     assertEquals("MULTILINESTRING ((10 10, 20 20), (15 15, 30 15))", writer.write(reader.read("MULTILINESTRING ((10 10, 20 20), (15 15, 30 15))")));
     assertEquals("MULTILINESTRING EMPTY", writer.write(reader.read("MULTILINESTRING EMPTY")));
+    assertEquals("MULTILINESTRING (EMPTY, EMPTY)", writer.write(reader.read("MULTILINESTRING (EMPTY, EMPTY)")));
   }
 
   public void testReadMultiPolygon() throws Exception {
     assertEquals("MULTIPOLYGON (((10 10, 10 20, 20 20, 20 15, 10 10)), ((60 60, 70 70, 80 60, 60 60)))", writer.write(reader.read("MULTIPOLYGON (((10 10, 10 20, 20 20, 20 15, 10 10)), ((60 60, 70 70, 80 60, 60 60)))")));
     assertEquals("MULTIPOLYGON EMPTY", writer.write(reader.read("MULTIPOLYGON EMPTY")));
+    assertEquals("MULTIPOLYGON (EMPTY, EMPTY)", writer.write(reader.read("MULTIPOLYGON (EMPTY, EMPTY)")));
   }
 
   public void testReadGeometryCollection() throws Exception {
@@ -87,5 +87,10 @@ public class WKTReadWriteTest extends TestCase {
     assertEquals("GEOMETRYCOLLECTION (POINT (10 10), LINEARRING EMPTY, LINESTRING (15 15, 20 20))", writer.write(reader.read("GEOMETRYCOLLECTION (POINT (10 10), LINEARRING EMPTY, LINESTRING (15 15, 20 20))")));
     assertEquals("GEOMETRYCOLLECTION (POINT (10 10), LINEARRING (10 10, 20 20, 30 40, 10 10), LINESTRING (15 15, 20 20))", writer.write(reader.read("GEOMETRYCOLLECTION (POINT (10 10), LINEARRING (10 10, 20 20, 30 40, 10 10), LINESTRING (15 15, 20 20))")));
     assertEquals("GEOMETRYCOLLECTION EMPTY", writer.write(reader.read("GEOMETRYCOLLECTION EMPTY")));
+  }
+  
+  public void testReadGeometryCollectionEmptyWithElements() throws Exception {
+    assertEquals("GEOMETRYCOLLECTION (POINT EMPTY)", writer.write(reader.read("GEOMETRYCOLLECTION ( POINT EMPTY )")));
+    assertEquals("GEOMETRYCOLLECTION (POINT EMPTY, LINESTRING EMPTY)", writer.write(reader.read("GEOMETRYCOLLECTION ( POINT EMPTY, LINESTRING EMPTY )")));
   }
 }


### PR DESCRIPTION
This fixes a bug in `WKTWriter` causing collections with all empty elements to be output as completely empty collections.
E.g. `MULTIPOINT( EMPTY, EMPTY)` was written as `MULTIPOINT EMPTY`.

While collections containing empty elements are of dubious value, `WKTWriter` should not be masking this structure.

Also fixes a `WKTReader` bug preventing `MULTIPOINT( EMPTY, EMPTY)` from being parsed.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>