### PR TITLE
Opt in interpolation for RobustLineIntersector

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
@@ -27,6 +27,22 @@ public class RobustLineIntersector
     extends LineIntersector
 {
 
+  public static String INTERPOLATE_PROPERTY_NAME = "jts.interpolate";
+  public static String INTERPOLATE_PROPERTY_VALUE_TRUE = "true";
+  public static String INTERPOLATE_PROPERTY_VALUE_FALSE = "false";
+  public static boolean INTERPOLATE_DEFAULT = false;
+  private static boolean isInterpolate = INTERPOLATE_DEFAULT;
+  static {
+    setInterpolate(System.getProperty(INTERPOLATE_PROPERTY_NAME));
+  }
+  static void setInterpolate(String interpolateCode) {
+    if (interpolateCode == null) 
+      return;
+    isInterpolate = INTERPOLATE_DEFAULT;
+    if (INTERPOLATE_PROPERTY_VALUE_TRUE.equalsIgnoreCase(interpolateCode) )
+      isInterpolate = true;
+  }
+
   public RobustLineIntersector() {
   }
 
@@ -413,6 +429,8 @@ public class RobustLineIntersector
    * @return the interpolated Z value (may be NaN)
    */
   private static double zInterpolate(Coordinate p, Coordinate p1, Coordinate p2) {
+    if (!isInterpolate)
+      return Double.NaN;
     double p1z = p1.getZ();
     double p2z = p2.getZ();
     if (Double.isNaN(p1z)) {


### PR DESCRIPTION
ref https://github.com/locationtech/jts/issues/714

Wanted to see what effect it would have to turn interpolation off by default and it causes a number of expected test failures (OverlayNGZTest, RobustLineIntersectorZTest and GeometryFixerTest).

If we agree that https://github.com/locationtech/jts/issues/714 is indeed a regression then I would have no better current idea than doing something like this, unfortunately.