### PR TITLE
Fix envelope of Voronoi Diagram

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/VoronoiDiagramBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/VoronoiDiagramBuilder.java
@@ -117,14 +117,14 @@ public class VoronoiDiagramBuilder
 		   * create one which encloses all the sites,
 		   * with a buffer around the edges.
 		   */
-  		diagramEnv = siteEnv;
-  		// add a buffer around the sites envelope
-  		double expandBy = diagramEnv.getDiameter();
-  		diagramEnv.expandBy(expandBy);
+			diagramEnv = siteEnv;
+			// add a buffer around the sites envelope
+			double expandBy = diagramEnv.getDiameter();
+			diagramEnv.expandBy(expandBy);
 		}
 
 		List vertices = DelaunayTriangulationBuilder.toVertices(siteCoords);
-		subdiv = new QuadEdgeSubdivision(siteEnv, tolerance);
+		subdiv = new QuadEdgeSubdivision(diagramEnv, tolerance);
 		IncrementalDelaunayTriangulator triangulator = new IncrementalDelaunayTriangulator(subdiv);
 		triangulator.insertSites(vertices);
 	}


### PR DESCRIPTION
When an envelope containing the entire envelope automatically generated from the original coordinates is set, it's never used and the (smaller) envelope automatically generated is always used instead when creating the QuadEdgeSubdivision

This is causing that large envelopes are never taken into account and results in Voronoi Diagrams smaller than they are supposed to when setting the envelope via 'setClipEnvelope'