### PR TITLE
Fix IsValidOp for LinearRings

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/IsValidOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/IsValidOp.java
@@ -407,11 +407,15 @@ public class IsValidOp
   private void checkNoSelfIntersectingRing(EdgeIntersectionList eiList)
   {
     Set nodeSet = new TreeSet();
-    boolean isFirst = true;
     for (Iterator i = eiList.iterator(); i.hasNext(); ) {
       EdgeIntersection ei = (EdgeIntersection) i.next();
-      if (isFirst) {
-        isFirst = false;
+      /**
+       * Do not count start point, so start/end node is not counted as a self-intersection.
+       * Another segment with a node in same location will still trigger an invalid error.
+       * (Note that the edgeIntersectionList may not contain the start/end node, 
+       * due to noding short-circuiting.)
+       */
+      if (isStartNode(ei)) {
         continue;
       }
       if (nodeSet.contains(ei.coord)) {
@@ -424,6 +428,10 @@ public class IsValidOp
         nodeSet.add(ei.coord);
       }
     }
+  }
+
+  private static boolean isStartNode(EdgeIntersection ei) {
+    return ei.getSegmentIndex() == 0 && ei.getDistance() == 0.0;
   }
 
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/operation/valid/IsValidTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/valid/IsValidTest.java
@@ -65,5 +65,23 @@ public class IsValidTest extends TestCase {
     g.isValid();
     assertTrue(true); //No exception thrown [Jon Aquino]
   }
+  
+  public void testLinearRingTriangle() throws Exception {
+    Geometry g = reader.read(
+          "LINEARRING (100 100, 150 200, 200 100, 100 100)");
+    assertTrue(g.isValid());
+  }
+
+  public void testLinearRingSelfCrossing() throws Exception {
+    Geometry g = reader.read(
+          "LINEARRING (150 100, 300 300, 100 300, 350 100, 150 100)");
+    assertTrue(! g.isValid());
+  }
+
+  public void testLinearRingSelfCrossing2() throws Exception {
+    Geometry g = reader.read(
+          "LINEARRING (0 0, 100 100, 100 0, 0 100, 0 0)");
+    assertTrue(! g.isValid());
+  }
 
 }


### PR DESCRIPTION
Fixes an issue where certain kinds of LinearRings with self-intersections did not report as invalid.

Fixes #736. 

Signed-off-by: Martin Davis <mtnclimb@gmail.com>