### PR TITLE
Fix VoronoiDiagramBuilder to respect clip envelope

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/VoronoiDiagramBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/VoronoiDiagramBuilder.java
@@ -109,22 +109,21 @@ public class VoronoiDiagramBuilder
 	{
 		if (subdiv != null) return;
 		
-		Envelope siteEnv = DelaunayTriangulationBuilder.envelope(siteCoords);
 		diagramEnv = clipEnv;
 		if (diagramEnv == null) {
 		  /** 
-		   * If no user-provided clip env, 
-		   * create one which encloses all the sites,
-		   * with a buffer around the edges.
+		   * If no user-provided clip envelope, 
+		   * use one which encloses all the sites,
+		   * with a 50% buffer around the edges.
 		   */
-  		diagramEnv = siteEnv;
-  		// add a buffer around the sites envelope
+  		diagramEnv = DelaunayTriangulationBuilder.envelope(siteCoords);
+  		// add a 50% buffer around the sites envelope
   		double expandBy = diagramEnv.getDiameter();
   		diagramEnv.expandBy(expandBy);
 		}
 
 		List vertices = DelaunayTriangulationBuilder.toVertices(siteCoords);
-		subdiv = new QuadEdgeSubdivision(siteEnv, tolerance);
+		subdiv = new QuadEdgeSubdivision(diagramEnv, tolerance);
 		IncrementalDelaunayTriangulator triangulator = new IncrementalDelaunayTriangulator(subdiv);
 		triangulator.insertSites(vertices);
 	}

--- a/modules/core/src/test/java/org/locationtech/jts/triangulate/VoronoiDiagramBuilderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/triangulate/VoronoiDiagramBuilderTest.java
@@ -19,6 +19,13 @@ public class VoronoiDiagramBuilderTest extends GeometryTestCase {
     assertTrue(voronoi.getEnvelopeInternal().equals(clip.getEnvelopeInternal()));
   }
   
+  public void testClipEnvelopeBig() {
+    Geometry sites = read("MULTIPOINT ((50 100), (50 50), (100 50), (100 100))");
+    Geometry clip = read("POLYGON ((-1000 1000, 1000 1000, 1000 -1000, -1000 -1000, -1000 1000))");
+    Geometry voronoi = voronoiDiagram(sites, clip);
+    assertTrue(voronoi.getEnvelopeInternal().equals(clip.getEnvelopeInternal()));
+  }
+  
   private static final double TRIANGULATION_TOLERANCE = 0.0;
 
   public static Geometry voronoiDiagram(Geometry sitesGeom, Geometry clipGeom)


### PR DESCRIPTION
Fix VoronoiDiagramBuilder to respect user-provided clip envelope.

Replaces #724.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>