### PR TITLE
Use SegmentString.getCoordinate where appropriate

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/index/SegmentIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/index/SegmentIntersector.java
@@ -141,11 +141,11 @@ public class SegmentIntersector
      )
   {
     if (e0 == e1 && segIndex0 == segIndex1) return;
-numTests++;
-    Coordinate p00 = e0.getCoordinates()[segIndex0];
-    Coordinate p01 = e0.getCoordinates()[segIndex0 + 1];
-    Coordinate p10 = e1.getCoordinates()[segIndex1];
-    Coordinate p11 = e1.getCoordinates()[segIndex1 + 1];
+    numTests++;
+    Coordinate p00 = e0.getCoordinate(segIndex0);
+    Coordinate p01 = e0.getCoordinate(segIndex0 + 1);
+    Coordinate p10 = e1.getCoordinate(segIndex1);
+    Coordinate p11 = e1.getCoordinate(segIndex1 + 1);
 
     li.computeIntersection(p00, p01, p10, p11);
 //if (li.hasIntersection() && li.isProper()) Debug.println(li);

--- a/modules/core/src/main/java/org/locationtech/jts/noding/InteriorIntersectionFinderAdder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/InteriorIntersectionFinderAdder.java
@@ -64,10 +64,10 @@ public class InteriorIntersectionFinderAdder
     // don't bother intersecting a segment with itself
     if (e0 == e1 && segIndex0 == segIndex1) return;
 
-    Coordinate p00 = e0.getCoordinates()[segIndex0];
-    Coordinate p01 = e0.getCoordinates()[segIndex0 + 1];
-    Coordinate p10 = e1.getCoordinates()[segIndex1];
-    Coordinate p11 = e1.getCoordinates()[segIndex1 + 1];
+    Coordinate p00 = e0.getCoordinate(segIndex0);
+    Coordinate p01 = e0.getCoordinate(segIndex0 + 1);
+    Coordinate p10 = e1.getCoordinate(segIndex1);
+    Coordinate p11 = e1.getCoordinate(segIndex1 + 1);
 
     li.computeIntersection(p00, p01, p10, p11);
 //if (li.hasIntersection() && li.isProper()) Debug.println(li);

--- a/modules/core/src/main/java/org/locationtech/jts/noding/IntersectionAdder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/IntersectionAdder.java
@@ -121,11 +121,11 @@ public class IntersectionAdder
      )
   {
     if (e0 == e1 && segIndex0 == segIndex1) return;
-numTests++;
-    Coordinate p00 = e0.getCoordinates()[segIndex0];
-    Coordinate p01 = e0.getCoordinates()[segIndex0 + 1];
-    Coordinate p10 = e1.getCoordinates()[segIndex1];
-    Coordinate p11 = e1.getCoordinates()[segIndex1 + 1];
+    numTests++;
+    Coordinate p00 = e0.getCoordinate(segIndex0);
+    Coordinate p01 = e0.getCoordinate(segIndex0 + 1);
+    Coordinate p10 = e1.getCoordinate(segIndex1);
+    Coordinate p11 = e1.getCoordinate(segIndex1 + 1);
 
     li.computeIntersection(p00, p01, p10, p11);
 //if (li.hasIntersection() && li.isProper()) Debug.println(li);

--- a/modules/core/src/main/java/org/locationtech/jts/noding/IntersectionFinderAdder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/IntersectionFinderAdder.java
@@ -65,10 +65,10 @@ public class IntersectionFinderAdder
     // don't bother intersecting a segment with itself
     if (e0 == e1 && segIndex0 == segIndex1) return;
 
-    Coordinate p00 = e0.getCoordinates()[segIndex0];
-    Coordinate p01 = e0.getCoordinates()[segIndex0 + 1];
-    Coordinate p10 = e1.getCoordinates()[segIndex1];
-    Coordinate p11 = e1.getCoordinates()[segIndex1 + 1];
+    Coordinate p00 = e0.getCoordinate(segIndex0);
+    Coordinate p01 = e0.getCoordinate(segIndex0 + 1);
+    Coordinate p10 = e1.getCoordinate(segIndex1);
+    Coordinate p11 = e1.getCoordinate(segIndex1 + 1);
 
     li.computeIntersection(p00, p01, p10, p11);
 //if (li.hasIntersection() && li.isProper()) Debug.println(li);

--- a/modules/core/src/main/java/org/locationtech/jts/noding/NodingValidator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/NodingValidator.java
@@ -103,10 +103,10 @@ public class NodingValidator {
   {
     if (e0 == e1 && segIndex0 == segIndex1) return;
 //numTests++;
-    Coordinate p00 = e0.getCoordinates()[segIndex0];
-    Coordinate p01 = e0.getCoordinates()[segIndex0 + 1];
-    Coordinate p10 = e1.getCoordinates()[segIndex1];
-    Coordinate p11 = e1.getCoordinates()[segIndex1 + 1];
+    Coordinate p00 = e0.getCoordinate(segIndex0);
+    Coordinate p01 = e0.getCoordinate(segIndex0 + 1);
+    Coordinate p10 = e1.getCoordinate(segIndex1);
+    Coordinate p11 = e1.getCoordinate(segIndex1 + 1);
 
     li.computeIntersection(p00, p01, p10, p11);
     if (li.hasIntersection()) {

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentIntersectionDetector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentIntersectionDetector.java
@@ -145,10 +145,10 @@ public class SegmentIntersectionDetector
     // don't bother intersecting a segment with itself
     if (e0 == e1 && segIndex0 == segIndex1) return;
     
-    Coordinate p00 = e0.getCoordinates()[segIndex0];
-    Coordinate p01 = e0.getCoordinates()[segIndex0 + 1];
-    Coordinate p10 = e1.getCoordinates()[segIndex1];
-    Coordinate p11 = e1.getCoordinates()[segIndex1 + 1];
+    Coordinate p00 = e0.getCoordinate(segIndex0);
+    Coordinate p01 = e0.getCoordinate(segIndex0 + 1);
+    Coordinate p10 = e1.getCoordinate(segIndex1);
+    Coordinate p11 = e1.getCoordinate(segIndex1 + 1);
     
     li.computeIntersection(p00, p01, p10, p11);
 //  if (li.hasIntersection() && li.isProper()) Debug.println(li);

--- a/modules/core/src/main/java/org/locationtech/jts/noding/snap/SnappingIntersectionAdder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/snap/SnappingIntersectionAdder.java
@@ -63,10 +63,10 @@ public class SnappingIntersectionAdder
     // don't bother intersecting a segment with itself
     if (seg0 == seg1 && segIndex0 == segIndex1) return;
 
-    Coordinate p00 = seg0.getCoordinates()[segIndex0];
-    Coordinate p01 = seg0.getCoordinates()[segIndex0 + 1];
-    Coordinate p10 = seg1.getCoordinates()[segIndex1];
-    Coordinate p11 = seg1.getCoordinates()[segIndex1 + 1];
+    Coordinate p00 = seg0.getCoordinate(segIndex0);
+    Coordinate p01 = seg0.getCoordinate(segIndex0 + 1);
+    Coordinate p10 = seg1.getCoordinate(segIndex1);
+    Coordinate p11 = seg1.getCoordinate(segIndex1 + 1);
 
     /**
      * Don't node intersections which are just 

--- a/modules/core/src/main/java/org/locationtech/jts/noding/snapround/SnapRoundingIntersectionAdder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/snapround/SnapRoundingIntersectionAdder.java
@@ -103,10 +103,10 @@ public class SnapRoundingIntersectionAdder
     // don't bother intersecting a segment with itself
     if (e0 == e1 && segIndex0 == segIndex1) return;
 
-    Coordinate p00 = e0.getCoordinates()[segIndex0];
-    Coordinate p01 = e0.getCoordinates()[segIndex0 + 1];
-    Coordinate p10 = e1.getCoordinates()[segIndex1];
-    Coordinate p11 = e1.getCoordinates()[segIndex1 + 1];
+    Coordinate p00 = e0.getCoordinate(segIndex0);
+    Coordinate p01 = e0.getCoordinate(segIndex0 + 1);
+    Coordinate p10 = e1.getCoordinate(segIndex1);
+    Coordinate p11 = e1.getCoordinate(segIndex1 + 1);
 
     li.computeIntersection(p00, p01, p10, p11);
 //if (li.hasIntersection() && li.isProper()) Debug.println(li);


### PR DESCRIPTION
This PR improves code to use `SegmentString.getCoordinate` where it is appropriate.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>