### PR TITLE
Skip deploy of build-tools as it is not needed

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -42,6 +42,13 @@
               <skip>true</skip>
             </configuration>
           </plugin>
+          <plugin>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>3.0.0-M1</version>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+          </plugin>
         </plugins>
      </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,10 @@
                     <version>3.8.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>1.5</version>
                 </plugin>
@@ -221,7 +224,6 @@
                     <version>3.3.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jxr-plugin</artifactId>
                     <version>3.1.1</version>
                 </plugin>


### PR DESCRIPTION
Alternate approach to fixing current build failure, skip deployment of build-tools as they are only needed for quality assurance.