### PR TITLE
Fix GeometryFixer to use isKeepCollapsed flag for GCs

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryFixer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/GeometryFixer.java
@@ -39,6 +39,7 @@ import org.locationtech.jts.operation.overlayng.OverlayNGRobust;
  * <p>
  * Input geometries are always processed, so even valid inputs may 
  * have some minor alterations.  The output is always a new geometry object.
+ * 
  * <h2>Semantic Rules</h2>
  * <ol>
  * <li>Vertices with non-finite X or Y ordinates are removed 
@@ -62,7 +63,8 @@ import org.locationtech.jts.operation.overlayng.OverlayNGRobust;
  * <li>Collapsed lines and polygons are handled as follows,
  * depending on the <code>keepCollapsed</code> setting:
  * <ul>
- *   <li><code>false</code>: (default) collapses are converted to empty geometries</li>
+ *   <li><code>false</code>: (default) collapses are converted to empty geometries
+ *   (and removed if they are elements of collections)</li>
  *   <li><code>true</code>: collapses are converted to a valid geometry of lower dimension</li>
  * </ul>
  * </li>
@@ -375,8 +377,14 @@ public class GeometryFixer {
   private Geometry fixCollection(GeometryCollection geom) {
     Geometry[] geomRep = new Geometry[geom.getNumGeometries()];
     for (int i = 0; i < geom.getNumGeometries(); i++) {
-      geomRep[i] = fix(geom.getGeometryN(i));
+      geomRep[i] = fix(geom.getGeometryN(i), isKeepCollapsed);
     }
     return factory.createGeometryCollection(geomRep);
+  }
+  
+  private static Geometry fix(Geometry geom, boolean isKeepCollapsed) {
+    GeometryFixer fix = new GeometryFixer(geom);
+    fix.setKeepCollapsed(isKeepCollapsed);
+    return fix.getResult();
   }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryFixerTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryFixerTest.java
@@ -297,16 +297,21 @@ public class GeometryFixerTest extends GeometryTestCase {
         "GEOMETRYCOLLECTION (POINT EMPTY, LINESTRING EMPTY, POLYGON EMPTY)");
   }
 
+  public void testGCKeepCollapse() {
+    checkFixKeepCollapse("GEOMETRYCOLLECTION (LINESTRING ( 0 0, 0 0), POINT (1 1))",
+        "GEOMETRYCOLLECTION (POINT (0 0), POINT (1 1))");
+  }
+
   //----------------------------------------
 
   public void testPolygonZBowtie() {
     checkFixZ("POLYGON Z ((10 90 1, 90 10 9, 90 90 9, 10 10 1, 10 90 1))",
-        "MULTIPOLYGON Z(((10 10 1, 10 90 1, 50 50 5, 10 10 1)), ((50 50 5, 90 90 9, 90 10 9, 50 50 5)))");
+        "MULTIPOLYGON Z (((10 10 1, 10 90 1, 50 50 5, 10 10 1)), ((50 50 5, 90 90 9, 90 10 9, 50 50 5)))");
   }
 
   public void testPolygonZHoleOverlap() {
     checkFixZ("POLYGON Z ((10 90 1, 60 90 6, 60 10 6, 10 10 1, 10 90 1), (20 80 2, 90 80 9, 90 20 9, 20 20 2, 20 80 2))",
-        "POLYGON Z((10 10 1, 10 90 1, 60 90 6, 60 80 6, 20 80 2, 20 20 2, 60 20 6, 60 10 6, 10 10 1))");
+        "POLYGON Z ((10 10 1, 10 90 1, 60 90 6, 60 80 6, 20 80 2, 20 20 2, 60 20 6, 60 10 6, 10 10 1))");
   }
 
   public void testMultiLineStringZKeepCollapse() {


### PR DESCRIPTION
Fixes `GeometryFixer` to propagate `isKeepCollapsed` flag for GeometryCollection elements.

Fixes #789.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>