### PR TITLE
Fix RectangleIntersects to handle XYZM coordinates

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/predicate/RectangleIntersects.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/predicate/RectangleIntersects.java
@@ -266,8 +266,6 @@ class RectangleIntersectsSegmentVisitor extends ShortCircuitedGeometryVisitor
   private RectangleLineIntersector rectIntersector;
 
   private boolean hasIntersection = false;
-  private Coordinate p0 = new Coordinate();
-  private Coordinate p1 = new Coordinate();
 
   /**
    * Creates a visitor for checking rectangle intersection
@@ -323,6 +321,8 @@ class RectangleIntersectsSegmentVisitor extends ShortCircuitedGeometryVisitor
   private void checkIntersectionWithSegments(LineString testLine)
   {
     CoordinateSequence seq1 = testLine.getCoordinateSequence();
+    Coordinate p0 = seq1.createCoordinate();
+    Coordinate p1 = seq1.createCoordinate();
     for (int j = 1; j < seq1.size(); j++) {
       seq1.getCoordinate(j - 1, p0);
       seq1.getCoordinate(j,     p1);

--- a/modules/core/src/test/java/org/locationtech/jts/operation/predicate/RectangleIntersectsTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/predicate/RectangleIntersectsTest.java
@@ -1,0 +1,28 @@
+package org.locationtech.jts.operation.predicate;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
+
+public class RectangleIntersectsTest extends GeometryTestCase {
+  public static void main(String args[]) {
+    TestRunner.run(RectangleIntersectsTest.class);
+  }
+
+  public RectangleIntersectsTest(String name) { super(name); }
+  
+  public void testXYZM() throws ParseException {
+    GeometryFactory geomFact = new GeometryFactory(PackedCoordinateSequenceFactory.DOUBLE_FACTORY);
+    WKTReader rdr = new WKTReader(geomFact);
+    Polygon rect = (Polygon) rdr.read("POLYGON ZM ((1 9 2 3, 9 9 2 3, 9 1 2 3, 1 1 2 3, 1 9 2 3))");
+    Geometry line = rdr.read("LINESTRING ZM (5 15 5 5, 15 5 5 5)");
+    boolean rectIntersects = RectangleIntersects.intersects(rect, line);
+    assertEquals(false, rectIntersects);
+  }
+}


### PR DESCRIPTION
Fix RectangleIntersects to handle XYZM coordinates, caused by improper use of the `CoordinateSequence.getCoordinate` method.

Fixes #793.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>