### PR TITLE
Fix MaximumInscribedCircle to avoid infinite loop on flat inputs

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircle.java
@@ -256,6 +256,11 @@ public class MaximumInscribedCircle {
     double width = env.getWidth();
     double height = env.getHeight();
     double cellSize = Math.min(width, height);
+    
+    // Check for flat collapsed input and if so short-circuit
+    // Result will just be centroid
+    if (cellSize == 0) return;
+    
     double hSide = cellSize / 2.0;
 
     // compute initial grid of cells to cover area

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscibedCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscibedCircleTest.java
@@ -56,6 +56,15 @@ public class MaximumInscibedCircleTest extends GeometryTestCase {
   }
 
   /**
+   * Invalid polygon collapsed to a flat line
+   * (originally caused infinite loop)
+   */
+  public void testCollapsedLineFlat() {
+    checkCircle("POLYGON((1 2, 1 2, 1 2, 1 2, 3 2, 1 2))",
+        0.01, 2, 2, 0 );
+  }
+
+  /**
    * Invalid polygon collapsed to a point
    */
   public void testCollapsedPoint() {


### PR DESCRIPTION
Fixes `MaximumInscribedCircle` to avoid infinite-looping on flat collapsed inputs.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>