### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/ui/style/VertexStyle.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/ui/style/VertexStyle.java
@@ -74,7 +74,7 @@ public class VertexStyle  implements Style
   private void init() {
     sizeOver2 = size / 2d;
     shape = new Rectangle(0, 0, size, size);
-    float strokeSize = size / 4;
+    float strokeSize = size / 4F ;
     if (strokeSize < 1) strokeSize = 1;
     stroke = new BasicStroke(strokeSize);
   }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2184: 'Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.