### PR TITLE
Fix PolygonEarClipper to handle collapsed corners

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/TriangulatePolyFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/TriangulatePolyFunctions.java
@@ -12,7 +12,9 @@
 package org.locationtech.jtstest.function;
 
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.triangulate.polygon.ConstrainedDelaunayTriangulator;
+import org.locationtech.jts.triangulate.polygon.PolygonHoleJoiner;
 import org.locationtech.jts.triangulate.polygon.PolygonTriangulator;
 
 
@@ -28,5 +30,9 @@ public class TriangulatePolyFunctions
     return ConstrainedDelaunayTriangulator.triangulate(geom);
   }
 
+  public static Geometry joinHoles(Geometry geom)
+  {
+    return PolygonHoleJoiner.joinAsPolygon((Polygon) geom);
+  }
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/polygon/PolygonHoleJoiner.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/polygon/PolygonHoleJoiner.java
@@ -31,13 +31,17 @@ import org.locationtech.jts.noding.SegmentString;
 import org.locationtech.jts.noding.SegmentStringUtil;
 
 /**
- * Transforms a polygon with holes into a single self-touching ring
+ * Transforms a polygon with holes into a single self-touching (invalid) ring
  * by connecting holes to the exterior shell or to another hole. 
  * The holes are added from the lowest upwards. 
  * As the resulting shell develops, a hole might be added to what was
  * originally another hole.
+ * <p>
+ * There is no attempt to optimize the quality of the join lines.
+ * In particular, a hole which already touches at a vertex may be
+ * joined at a different vertex.
  */
-class PolygonHoleJoiner {
+public class PolygonHoleJoiner {
   
   public static Polygon joinAsPolygon(Polygon inputPolygon) {
     return inputPolygon.getFactory().createPolygon(join(inputPolygon));

--- a/modules/core/src/test/java/org/locationtech/jts/triangulate/polygon/PolygonTriangulatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/triangulate/polygon/PolygonTriangulatorTest.java
@@ -65,6 +65,15 @@ public class PolygonTriangulatorTest extends GeometryTestCase {
     checkTri(
   "POLYGON ((110 170, 138 272, 145 286, 152 296, 160 307, 303 307, 314 301, 332 287, 343 278, 352 270, 385 99, 374 89, 359 79, 178 89, 167 91, 153 99, 146 107, 173 157, 182 163, 191 170, 199 176, 208 184, 218 194, 226 203, 198 252, 188 247, 182 239, 175 231, 167 223, 161 213, 156 203, 155 198, 110 170))"
         );
+  }  
+  
+  /**
+   * Ear clipping creates a collapsed corner (A-B-A), which was not detected by flat corner removal
+   */
+  public void testCollapsedCorner() {
+    checkTri(
+  "POLYGON ((186 90, 71 17, 74 10, 65 0, 0 121, 186 90), (73 34, 67 41, 71 17, 73 34))"
+        );
   }
   
   private void checkTri(String wkt, String wktExpected) {


### PR DESCRIPTION
`PolygonEarClipper` now detects collapsed corners (ABA) as well as degenerate corners (AAB or ABB). 

I suspect that these kinds of corners occur when a polygon with a hole touching the shell produces a "bad" hole-joined ring.  It might be good to fix `PolygonHoleJoiner` to do a better job of joining in this situation, but this is relatively rare case, it will take more time and probably doesn't improve the eventual triangulation very much