### PR TITLE
Add OffsetCurve parameters

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/OffsetCurveFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/OffsetCurveFunctions.java
@@ -17,6 +17,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.util.GeometryCombiner;
 import org.locationtech.jts.operation.buffer.OffsetCurve;
+import org.locationtech.jtstest.geomfunction.Metadata;
 
 public class OffsetCurveFunctions {
 
@@ -25,10 +26,40 @@ public class OffsetCurveFunctions {
     return OffsetCurve.getCurve(geom, distance);
   }
 
+  public static Geometry offsetCurveWithParams(Geometry geom,       
+      Double distance,
+      @Metadata(title="Quadrant Segs")
+      Integer quadrantSegments, 
+      @Metadata(title="NOT USED")
+      Integer capStyle, 
+      @Metadata(title="Join style")
+      Integer joinStyle, 
+      @Metadata(title="Mitre limit")
+      Double mitreLimit)
+  {
+    return OffsetCurve.getCurve(geom, distance, quadrantSegments, joinStyle, mitreLimit);
+  }
+
   public static Geometry offsetCurveBoth(Geometry geom, double distance)
   {
     Geometry curve1 = OffsetCurve.getCurve(geom, distance);
     Geometry curve2 = OffsetCurve.getCurve(geom, -distance);
+    return GeometryCombiner.combine(curve1, curve2);
+  }
+
+  public static Geometry offsetCurveBothWithParams(Geometry geom,       
+      Double distance,
+      @Metadata(title="Quadrant Segs")
+      Integer quadrantSegments, 
+      @Metadata(title="NOT USED")
+      Integer capStyle, 
+      @Metadata(title="Join style")
+      Integer joinStyle, 
+      @Metadata(title="Mitre limit")
+      Double mitreLimit)
+  {
+    Geometry curve1 = OffsetCurve.getCurve(geom, distance, quadrantSegments, joinStyle, mitreLimit);
+    Geometry curve2 = OffsetCurve.getCurve(geom, -distance, quadrantSegments, joinStyle, mitreLimit);
     return GeometryCombiner.combine(curve1, curve2);
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/BufferParameters.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/BufferParameters.java
@@ -308,4 +308,13 @@ public class BufferParameters
   {
     this.simplifyFactor = simplifyFactor < 0 ? 0 : simplifyFactor;
   }
+  
+  public BufferParameters copy() {
+    BufferParameters bp = new BufferParameters();
+    bp.quadrantSegments = quadrantSegments;
+    bp.endCapStyle = endCapStyle;
+    bp.joinStyle = joinStyle;
+    bp.mitreLimit = mitreLimit;
+    return bp;
+  }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -165,8 +165,43 @@ public class OffsetCurveTest extends GeometryTestCase {
 
   }
   
+  //---------------------------------------
+  
+  public void testQuadSegs() {
+    checkOffsetCurve(
+        "LINESTRING (20 20, 50 50, 80 20)", 
+        10, 2, -1, -1,
+        "LINESTRING (12.93 27.07, 42.93 57.07, 50 60, 57.07 57.07, 87.07 27.07)"
+    );
+  }
+
+  public void testJoinBevel() {
+    checkOffsetCurve(
+        "LINESTRING (20 20, 50 50, 80 20)", 
+        10, -1, BufferParameters.JOIN_BEVEL, -1,
+        "LINESTRING (12.93 27.07, 42.93 57.07, 57.07 57.07, 87.07 27.07)"
+    );
+  }
+  
+  public void testJoinMitre() {
+    checkOffsetCurve(
+        "LINESTRING (20 20, 50 50, 80 20)", 
+        10, -1, BufferParameters.JOIN_MITRE, -1,
+        "LINESTRING (12.93 27.07, 50 64.14, 87.07 27.07)"
+    );
+  }
+  
+  //=======================================
+  
   private void checkOffsetCurve(String wkt, double distance, String wktExpected) {
     checkOffsetCurve(wkt, distance, wktExpected, 0.05);
+  }
+  
+  private void checkOffsetCurve(String wkt, double distance, 
+      int quadSegs, int joinStyle, double mitreLimit,
+      String wktExpected) 
+  {
+    checkOffsetCurve(wkt, distance, quadSegs, joinStyle, mitreLimit, wktExpected, 0.05);
   }
   
   private void checkOffsetCurve(String wkt, double distance, String wktExpected, double tolerance) {
@@ -180,4 +215,19 @@ public class OffsetCurveTest extends GeometryTestCase {
     Geometry expected = read(wktExpected);
     checkEqual(expected, result, tolerance);
   }
+  
+  private void checkOffsetCurve(String wkt, double distance, 
+      int quadSegs, int joinStyle, double mitreLimit,
+      String wktExpected, double tolerance) {
+    Geometry geom = read(wkt);
+    Geometry result = OffsetCurve.getCurve(geom, distance, quadSegs, joinStyle, mitreLimit);
+    //System.out.println(result);
+    
+    if (wktExpected == null)
+      return;
+    
+    Geometry expected = read(wktExpected);
+    checkEqual(expected, result, tolerance);
+  }
+
 }


### PR DESCRIPTION
Add `OffsetCurve` parameters for quadrant segments, join style and mitre limit.

Quadrant Segments = 2
![image](https://user-images.githubusercontent.com/3529053/145618658-82373df4-ed1c-4d9f-8bf2-50b7bb828ac6.png)

Join Style = BEVEL
![image](https://user-images.githubusercontent.com/3529053/145618723-c8c4b192-0021-4b93-9075-561dfbbef3a4.png)

Join Style = MITRE
![image](https://user-images.githubusercontent.com/3529053/145618782-656aaec8-6f6e-4966-b6a6-4cd0d6aedc2d.png)


Signed-off-by: Martin Davis <mtnclimb@gmail.com>