### PR TITLE
Fix WKTReader to produce correct XY coordinate dimension for POLYGON EMPTY

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
@@ -418,6 +418,27 @@ public class WKTReaderTest extends GeometryTestCase {
     assertTrue(gc3.isEmpty());
   }
 
+  public void testEmptyLineDimOldSyntax() throws ParseException {
+    WKTReader wktReader = new WKTReader();
+    LineString geom = (LineString) wktReader.read("LINESTRING EMPTY");
+    int dim = geom.getCoordinateSequence().getDimension();
+    checkCSDim(geom.getCoordinateSequence(), 3);
+  }
+  
+  public void testEmptyLineDim() throws ParseException {
+    WKTReader wktReader = new WKTReader();
+    wktReader.setIsOldJtsCoordinateSyntaxAllowed(false);
+    LineString geom = (LineString) wktReader.read("LINESTRING EMPTY");
+    checkCSDim(geom.getCoordinateSequence(), 2);
+  }
+  
+  public void testEmptyPolygonDim() throws ParseException {
+    WKTReader wktReader = new WKTReader();
+    wktReader.setIsOldJtsCoordinateSyntaxAllowed(false);
+    Polygon geom = (Polygon) wktReader.read("POLYGON EMPTY");
+    checkCSDim(geom.getExteriorRing().getCoordinateSequence(), 2);
+  }
+  
   public void testNaN() throws Exception {
 
     // arrange
@@ -473,6 +494,11 @@ public class WKTReaderTest extends GeometryTestCase {
     if (geom instanceof GeometryCollection) {
       assertTrue(geom.getNumGeometries() == 0);
     }
+  }
+  
+  private void checkCSDim(CoordinateSequence cs, int expectedCoordDim) {
+    int dim = cs.getDimension();
+    assertEquals(expectedCoordDim, dim);
   }
   
   private static CoordinateSequence[] createSequences(EnumSet<Ordinate> ordinateFlags, double[][] xyarray) {


### PR DESCRIPTION
Fixes `WKTReader` to set the correct coordinate dimension for POLYGON EMPTY when the dimension is XY.

Add Javadoc to clarify coordinate dimension semantics (highlighting the [`WKTReader.setIsOldJtsCoordinateSyntaxAllowed`](https://locationtech.github.io/jts/javadoc/org/locationtech/jts/io/WKTReader.html#setIsOldJtsCoordinateSyntaxAllowed-boolean-) method)

Fixes #827

Signed-off-by: Martin Davis <mtnclimb@gmail.com>