### PR TITLE
Interpolate Z values in Densifier class

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/densify/Densifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/densify/Densifier.java
@@ -83,7 +83,10 @@ public class Densifier {
 			for (int j = 1; j < densifiedSegCount; j++) {
 				double segFract = (j * densifiedSegLen) / len;
 				Coordinate p = seg.pointAlong(segFract);
-        precModel.makePrecise(p);
+				if(!Double.isNaN(seg.p0.z) && !Double.isNaN(seg.p1.z)) {
+					p.setZ(seg.p0.z + segFract * (seg.p1.z - seg.p0.z));
+				}
+        		precModel.makePrecise(p);
 				coordList.add(p, false);
 			}
 		}

--- a/modules/core/src/test/java/org/locationtech/jts/densify/DensifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/densify/DensifierTest.java
@@ -70,7 +70,7 @@ public class DensifierTest extends GeometryTestCase {
   }
 
   public void testLineDensify3D() {
-    checkDensify("POLYGON Z((10 30 10, 30 30 10, 30 10 15, 10 10 10, 10 30 20))",
+    checkDensifyXYZ("POLYGON Z((10 30 10, 30 30 10, 30 10 15, 10 10 10, 10 30 20))",
             10, "POLYGON Z((10 30 10, 20 30 10, 30 30 10, 30 20 12.5, 30 10 15, 20 10 12.5, 10 10 10, 10 20 15, 10 30 20))");
   }
   
@@ -101,7 +101,13 @@ public class DensifierTest extends GeometryTestCase {
     Geometry actual = Densifier.densify(geom, distanceTolerance);
     checkEqual(expected, actual, TOLERANCE);
   }
-  
+
+  private void checkDensifyXYZ(String wkt, double distanceTolerance, String wktExpected) {
+    Geometry geom = read(wkt);
+    Geometry expected = read(wktExpected);
+    Geometry actual = Densifier.densify(geom, distanceTolerance);
+    checkEqualXYZ(expected, actual);
+  }
   /**
    * Note: it's hard to construct a geometry which would actually be invalid when densified.
    * This test just checks that the code path executes.

--- a/modules/core/src/test/java/org/locationtech/jts/densify/DensifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/densify/DensifierTest.java
@@ -68,6 +68,11 @@ public class DensifierTest extends GeometryTestCase {
     checkDensifyNoValidate("POLYGON ((10 30, 30 30, 30 10, 10 10, 10 30))", 
         10, "POLYGON ((10 10, 10 20, 10 30, 20 30, 30 30, 30 20, 30 10, 20 10, 10 10))");
   }
+
+  public void testLineDensify3D() {
+    checkDensify("POLYGON Z((10 30 10, 30 30 10, 30 10 15, 10 10 10, 10 30 20))",
+            10, "POLYGON Z((10 30 10, 20 30 10, 30 30 10, 30 20 12.5, 30 10 15, 20 10 12.5, 10 10 10, 10 20 15, 10 30 20))");
+  }
   
   public void testDimension2d() {
       GeometryFactory gf = new GeometryFactory();


### PR DESCRIPTION
Manage the interpolation of Z values of Coordinates in the Densifier class

About https://github.com/orbisgis/h2gis/issues/1272

Without this patch the Densifier would output a mix of Z and NaN values

(retry commit and PR eclipse is blocking for email issue I think ?)