### PR TITLE
Fix IsValidOp for repeated points

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedHoleTester.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedHoleTester.java
@@ -88,11 +88,7 @@ class IndexedNestedHoleTester
         if (! testHole.getEnvelopeInternal().covers( hole.getEnvelopeInternal()) )
           continue;
 
-        /**
-         * Checks nesting via a point-in-polygon test, 
-         * or via the topology of the incident edges.
-         */
-        if (PolygonTopologyAnalyzer.isInside(hole, testHole)) {
+        if (PolygonTopologyAnalyzer.isRingNested(hole, testHole)) {
           //TODO: find a hole point known to be inside
           nestedPt = hole.getCoordinateN(0);
           return true;  

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedHoleTester.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedHoleTester.java
@@ -90,13 +90,11 @@ class IndexedNestedHoleTester
 
         /**
          * Checks nesting via a point-in-polygon test, 
-         * or if the point lies on the boundary via 
-         * the topology of the incident edges.
+         * or via the topology of the incident edges.
          */
-        Coordinate holePt0 = hole.getCoordinateN(0);
-        Coordinate holePt1 = hole.getCoordinateN(1);
-        if (PolygonTopologyAnalyzer.isSegmentInRing(holePt0, holePt1, testHole)) {
-          nestedPt = holePt0;
+        if (PolygonTopologyAnalyzer.isInside(hole, testHole)) {
+          //TODO: find a hole point known to be inside
+          nestedPt = hole.getCoordinateN(0);
           return true;  
         }
       }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedPolygonTester.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedPolygonTester.java
@@ -136,7 +136,7 @@ class IndexedNestedPolygonTester
 
   /**
    * Finds a point of a shell segment which lies inside a polygon, if any.
-   * The shell is assume to touch the polyon only at shell vertices, 
+   * The shell is assumed to touch the polygon only at shell vertices, 
    * and does not cross the polygon.
    * 
    * @param shell the shell to test
@@ -148,10 +148,7 @@ class IndexedNestedPolygonTester
     LinearRing polyShell = poly.getExteriorRing();
     if (polyShell.isEmpty()) return null;
     
-    Coordinate shell0 = shell.getCoordinateN(0);
-    Coordinate shell1 = shell.getCoordinateN(1);
-    
-    if (! PolygonTopologyAnalyzer.isSegmentInRing(shell0, shell1, polyShell))
+    if (! PolygonTopologyAnalyzer.isInside(shell, polyShell))
       return null;
 
     /**
@@ -161,7 +158,7 @@ class IndexedNestedPolygonTester
     for (int i = 0; i < poly.getNumInteriorRing(); i++) {
       LinearRing hole = poly.getInteriorRingN(i);
       if (hole.getEnvelopeInternal().covers(shell.getEnvelopeInternal())
-          && PolygonTopologyAnalyzer.isSegmentInRing(shell0, shell1, hole)) {
+          && PolygonTopologyAnalyzer.isInside(shell, hole)) {
         return null;
       }
     }
@@ -170,6 +167,6 @@ class IndexedNestedPolygonTester
      * The shell is contained in the polygon, but is not contained in a hole.
      * This is invalid.
      */
-    return shell0;
+    return shell.getCoordinateN(0);
   } 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedPolygonTester.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedPolygonTester.java
@@ -148,7 +148,7 @@ class IndexedNestedPolygonTester
     LinearRing polyShell = poly.getExteriorRing();
     if (polyShell.isEmpty()) return null;
     
-    if (! PolygonTopologyAnalyzer.isInside(shell, polyShell))
+    if (! PolygonTopologyAnalyzer.isRingNested(shell, polyShell))
       return null;
 
     /**
@@ -158,7 +158,7 @@ class IndexedNestedPolygonTester
     for (int i = 0; i < poly.getNumInteriorRing(); i++) {
       LinearRing hole = poly.getInteriorRingN(i);
       if (hole.getEnvelopeInternal().covers(shell.getEnvelopeInternal())
-          && PolygonTopologyAnalyzer.isInside(shell, hole)) {
+          && PolygonTopologyAnalyzer.isRingNested(shell, hole)) {
         return null;
       }
     }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedPolygonTester.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/IndexedNestedPolygonTester.java
@@ -25,11 +25,12 @@ import org.locationtech.jts.index.strtree.STRtree;
 
 /**
  * Tests whether a MultiPolygon has any element polygon
- * nested inside another polygon, using a spatial
+ * improperly nested inside another polygon, using a spatial
  * index to speed up the comparisons.
  * <p>
- * The logic assumes that the polygons do not overlap and have no collinear segments
- * (so they are properly nested, and there are no duplicate rings).
+ * The logic assumes that the polygons do not overlap and have no collinear segments.
+ * So the polygon rings may touch at discrete points,
+ * but they are properly nested, and there are no duplicate rings.
  */
 class IndexedNestedPolygonTester
 {
@@ -75,7 +76,7 @@ class IndexedNestedPolygonTester
   public Coordinate getNestedPoint() { return nestedPt; }
 
   /**
-   * Tests if any polygon is nested (contained) within another polygon.
+   * Tests if any polygon is improperly nested (contained) within another polygon.
    * This is invalid.
    * The nested point will be set to reflect this.
    * @return true if some polygon is nested
@@ -106,6 +107,14 @@ class IndexedNestedPolygonTester
     return false;
   }
   
+  /**
+   * Finds an improperly nested point, if one exists.
+   * 
+   * @param shell the test polygon shell
+   * @param possibleOuterPoly a polygon which may contain it
+   * @param locator the locator for the outer polygon
+   * @return a nested point, if one exists, or null
+   */
   private Coordinate findNestedPoint(LinearRing shell, 
       Polygon possibleOuterPoly, IndexedPointInAreaLocator locator) 
   {    
@@ -119,7 +128,7 @@ class IndexedNestedPolygonTester
       return shellPt0;           
     }
     
-    Coordinate shellPt1 = shell.getCoordinateN(0);
+    Coordinate shellPt1 = shell.getCoordinateN(1);
     int loc1 = locator.locate(shellPt1);
     if (loc1 == Location.EXTERIOR) return null;
     if (loc1 == Location.INTERIOR) {
@@ -131,7 +140,7 @@ class IndexedNestedPolygonTester
      * the polygon.
      * Nesting can be checked via the topology of the incident edges.
      */
-    return findSegmentInPolygon(shell, possibleOuterPoly);
+    return findIncidentSegmentNestedPoint(shell, possibleOuterPoly);
   }
 
   /**
@@ -143,7 +152,7 @@ class IndexedNestedPolygonTester
    * @param poly the polygon to test against
    * @return an interior segment point, or null if the shell is nested correctly
    */
-  private static Coordinate findSegmentInPolygon(LinearRing shell, Polygon poly)
+  private static Coordinate findIncidentSegmentNestedPoint(LinearRing shell, Polygon poly)
   {
     LinearRing polyShell = poly.getExteriorRing();
     if (polyShell.isEmpty()) return null;

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/IsValidOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/IsValidOp.java
@@ -471,15 +471,16 @@ public class IsValidOp
    */
   private Coordinate findHoleOutsideShellPoint(LinearRing hole, LinearRing shell) {
     Coordinate holePt0 = hole.getCoordinateN(0);
-    Coordinate holePt1 = hole.getCoordinateN(1);
     /**
      * If hole envelope is not covered by shell, it must be outside
      */
     if (! shell.getEnvelopeInternal().covers( hole.getEnvelopeInternal() ))
-        return holePt0;
+      //TODO: find hole pt outside shell env
+      return holePt0;
     
-    if (PolygonTopologyAnalyzer.isSegmentInRing(holePt0, holePt1, shell))
-      return null;    
+    if (PolygonTopologyAnalyzer.isInside(hole, shell))
+      return null;  
+    //TODO: find hole point outside shell
     return holePt0;
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/IsValidOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/IsValidOp.java
@@ -478,7 +478,7 @@ public class IsValidOp
       //TODO: find hole pt outside shell env
       return holePt0;
     
-    if (PolygonTopologyAnalyzer.isInside(hole, shell))
+    if (PolygonTopologyAnalyzer.isRingNested(hole, shell))
       return null;  
     //TODO: find hole point outside shell
     return holePt0;

--- a/modules/core/src/main/java/org/locationtech/jts/operation/valid/PolygonTopologyAnalyzer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/valid/PolygonTopologyAnalyzer.java
@@ -43,29 +43,16 @@ import org.locationtech.jts.noding.SegmentString;
 class PolygonTopologyAnalyzer {
   
   /**
-   * Finds a self-intersection (if any) in a {@link LinearRing}.
-   * 
-   * @param ring the ring to analyze
-   * @return a self-intersection point if one exists, or null
-   */
-  public static Coordinate findSelfIntersection(LinearRing ring) {
-    PolygonTopologyAnalyzer ata = new PolygonTopologyAnalyzer(ring, false);
-    if (ata.hasInvalidIntersection())
-      return ata.getInvalidLocation();
-    return null;
-  }
-  
-  /**
-   * Tests whether a ring is inside another ring.
+   * Tests whether a ring is nested inside another ring.
    * <p>
    * Preconditions:
    * <ul>
    * <li>The rings do not cross (i.e. the test is wholly inside or outside the target)
-   * <li>The rings may touch (at a point or in a line)
+   * <li>The rings may touch at discrete points only
    * <li>The target ring does not self-cross, but it may self-touch
    * </ul>  
-   * If the start point is properly inside or outside, the provides the result.
-   * Otherwise, the start point is on the target ring, 
+   * If the test ring start point is properly inside or outside, that provides the result.
+   * Otherwise the start point is on the target ring, 
    * and the incident start segment (accounting for repeated points) is
    * tested for its topology relative to the target ring.
    *  
@@ -73,7 +60,7 @@ class PolygonTopologyAnalyzer {
    * @param target the ring to test against
    * @return true if the test ring lies inside the target ring
    */
-  public static boolean isInside(LinearRing test, LinearRing target) {
+  public static boolean isRingNested(LinearRing test, LinearRing target) {
     Coordinate p0 = test.getCoordinateN(0);
     Coordinate[] targetPts = target.getCoordinates();
     int loc = PointLocation.locateInRing(p0, targetPts);
@@ -209,6 +196,19 @@ class PolygonTopologyAnalyzer {
       }
     }
     return -1;
+  }
+  
+  /**
+   * Finds a self-intersection (if any) in a {@link LinearRing}.
+   * 
+   * @param ring the ring to analyze
+   * @return a self-intersection point if one exists, or null
+   */
+  public static Coordinate findSelfIntersection(LinearRing ring) {
+    PolygonTopologyAnalyzer ata = new PolygonTopologyAnalyzer(ring, false);
+    if (ata.hasInvalidIntersection())
+      return ata.getInvalidLocation();
+    return null;
   }
   
   private boolean isInvertedRingValid;

--- a/modules/core/src/test/java/org/locationtech/jts/operation/valid/IsValidTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/valid/IsValidTest.java
@@ -156,6 +156,27 @@ public class IsValidTest extends GeometryTestCase {
           "LINEARRING (0 0, 100 100, 100 0, 0 100, 0 0)");
   }
 
+  /**
+   * Tests that repeated points at nodes are handled correctly.
+   * 
+   * See https://github.com/locationtech/jts/issues/843
+   */
+  public void testPolygonHoleWithRepeatedShellPointTouch() {
+    checkValid( "POLYGON ((90 10, 10 10, 50 90, 50 90, 90 10), (50 90, 60 30, 40 30, 50 90))");
+  }
+  
+  public void testPolygonHoleWithRepeatedShellPointTouchMultiple() {
+    checkValid( "POLYGON ((90 10, 10 10, 50 90, 50 90, 50 90, 50 90, 90 10), (50 90, 60 30, 40 30, 50 90))");
+  }
+  
+  public void testPolygonHoleWithRepeatedTouchEndPoint() {
+    checkValid( "POLYGON ((90 10, 10 10, 50 90, 90 10, 90 10), (90 10, 40 30, 60 50, 90 10))");
+  }
+  
+  public void testPolygonHoleWithRepeatedHolePointTouch() {
+    checkValid( "POLYGON ((50 90, 10 10, 90 10, 50 90), (50 90, 50 90, 60 40, 60 40, 40 40, 50 90))");
+  }
+  
   //=============================================
   
   private void checkValid(String wkt) {

--- a/modules/tests/src/test/resources/testxml/general/TestValid.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestValid.xml
@@ -172,6 +172,54 @@ POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (40 80, 60 80, 50 50, 40 80), (20 
    </case>
    
    <case>
+      <desc>A - hole touches shell at repeated shell point (valid) </desc>
+      <a>
+POLYGON ((90 10, 10 10, 50 90, 50 90, 90 10), (50 90, 60 30, 40 30, 50 90))
+    </a>
+      <test> <op name="isValid" arg1="A"> true </op>  </test>
+   </case>
+   
+   <case>
+      <desc>A - hole touches shell at repeated shell end point (valid) </desc>
+      <a>
+POLYGON ((90 10, 10 10, 50 90, 90 10, 90 10), (90 10, 40 30, 60 50, 90 10))
+    </a>
+      <test> <op name="isValid" arg1="A"> true </op>  </test>
+   </case>
+   
+   <case>
+      <desc>A - hole touches shell at repeated hole point (valid) </desc>
+      <a>
+POLYGON ((50 90, 10 10, 90 10, 50 90), (60 40, 40 40, 50 90, 50 90, 60 40))
+    </a>
+      <test> <op name="isValid" arg1="A"> true </op>  </test>
+   </case>
+   
+   <case>
+      <desc>A - hole touches shell at repeated hole end point (valid) </desc>
+      <a>
+POLYGON ((50 90, 10 10, 90 10, 50 90), (50 90, 50 90, 60 40, 60 40, 40 40, 50 90))
+    </a>
+      <test> <op name="isValid" arg1="A"> true </op>  </test>
+   </case>
+   
+   <case>
+      <desc>A - hole touches hole at repeated point on hole (valid) </desc>
+      <a>
+POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (70 80, 20 50, 80 20, 40 50, 40 50, 70 80), (40 50, 40 50, 70 40, 70 60, 40 50))
+    </a>
+      <test> <op name="isValid" arg1="A"> true </op>  </test>
+   </case>
+   
+   <case>
+      <desc>mA - shell touches shell at repeated point (valid) </desc>
+      <a>
+MULTIPOLYGON (((70 80, 20 50, 80 20, 40 50, 40 50, 70 80)), ((40 50, 40 50, 70 40, 70 60, 40 50)))
+    </a>
+      <test> <op name="isValid" arg1="A"> true </op>  </test>
+   </case>
+   
+   <case>
       <desc>mA - shell inside hole, no touch (valid) </desc>
       <a>
 MULTIPOLYGON (((60 320, 60 80, 300 80, 60 320), 


### PR DESCRIPTION
Fix `IsValidOp` to correctly validate polygons with repeated points at the location of nodes (intersections between holes and shells).

Fixes #843 

Signed-off-by: Martin Davis <mtnclimb@gmail.com>