### PR TITLE
Add WKTReader fixStructure ability

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineString.java
@@ -36,6 +36,13 @@ public class LineString
 	implements Lineal
 {
   private static final long serialVersionUID = 3110669828065365560L;
+  
+  /**
+   * The minimum number of vertices allowed in a valid non-empty linestring.
+   * Empty linestrings with 0 vertices are also valid.
+   */
+  public static final int MINIMUM_VALID_SIZE = 2;
+  
   /**
    *  The points of this <code>LineString</code>.
    */
@@ -77,12 +84,13 @@ public class LineString
     if (points == null) {
       points = getFactory().getCoordinateSequenceFactory().create(new Coordinate[]{});
     }
-    if (points.size() == 1) {
+    if (points.size() > 0 && points.size() < MINIMUM_VALID_SIZE) {
       throw new IllegalArgumentException("Invalid number of points in LineString (found "
-      		+ points.size() + " - must be 0 or >= 2)");
+      		+ points.size() + " - must be 0 or >= " + MINIMUM_VALID_SIZE + ")");
     }
     this.points = points;
   }
+  
   public Coordinate[] getCoordinates() {
     return points.toCoordinateArray();
   }

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
@@ -18,12 +18,15 @@ import java.io.StreamTokenizer;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Locale;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFactory;
-
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.CoordinateXYM;
+import org.locationtech.jts.geom.CoordinateXYZM;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -64,6 +67,11 @@ import org.locationtech.jts.util.AssertionFailedException;
  * create XYZ geometry (this is backwards compatible with older JTS versions).  
  * This can be altered to create XY geometry by
  * calling {@link #setIsOldJtsCoordinateSyntaxAllowed(boolean)}.
+ * <p>
+ * A reader can be set to ensure the input is structurally valid
+ * by calling {@link #setFixStructure(boolean)}.
+ * This ensures that geometry can be constructed without errors due to missing coordinates.
+ * The created geometry may still be topologically invalid.
  * 
  * <h3>Notes:</h3>
  * <ul>
@@ -159,6 +167,9 @@ public class WKTReader
    */
   private static final boolean ALLOW_OLD_JTS_MULTIPOINT_SYNTAX = true;
   private boolean isAllowOldJtsMultipointSyntax = ALLOW_OLD_JTS_MULTIPOINT_SYNTAX;
+  
+  
+  private boolean isFixStructure = false;
 
   /**
    * Creates a reader that creates objects using the default {@link GeometryFactory}.
@@ -198,6 +209,19 @@ public class WKTReader
     isAllowOldJtsMultipointSyntax = value;
   }
 
+  /**
+   * Sets a flag indicating that the structure of input geometry should be fixed
+   * so that the geometry can be constructed without error.
+   * This involves adding coordinates if the input coordinate sequence is shorter than required.
+   * 
+   * @param isFixStructure true if the input structure should be fixed
+   * 
+   * @see LinearRing#MINIMUM_VALID_SIZE
+   */
+  public void setFixStructure(boolean isFixStructure) {
+    this.isFixStructure = isFixStructure;
+  }
+  
   /**
    * Reads a Well-Known Text representation of a {@link Geometry}
    * from a {@link String}.
@@ -264,49 +288,60 @@ public class WKTReader
   /**
    * Reads a <code>Coordinate</Code> from a stream using the given {@link StreamTokenizer}.
    * <p>
-   *   All ordinate values are read, but -depending on the {@link CoordinateSequenceFactory} of the
-   *   underlying {@link GeometryFactory}- not necessarily all can be handled. Those are silently dropped.
+   * All ordinate values are read, but -depending on the {@link CoordinateSequenceFactory} of the
+   * underlying {@link GeometryFactory}- not necessarily all can be handled. Those are silently dropped.
    * </p>
    * @param tokenizer the tokenizer to use
    * @param ordinateFlags a bit-mask defining the ordinates to read.
    * @param tryParen a value indicating if a starting {@link #L_PAREN} should be probed.
-   * @return a {@link CoordinateSequence} of length 1 containing the read ordinate values
+   * @return a {@link Coordinate} of appropriate dimension containing the read ordinate values
    *
    *@throws  IOException     if an I/O error occurs
    *@throws  ParseException  if an unexpected token was encountered
    */
-  private CoordinateSequence getCoordinate(StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags, boolean tryParen)
-          throws IOException, ParseException
+  private Coordinate getCoordinate(StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags, boolean tryParen)
+      throws IOException, ParseException
   {
-
     boolean opened = false;
     if (tryParen && isOpenerNext(tokenizer) ) {
       tokenizer.nextToken();
       opened = true;
     }
-
+    
     // create a sequence for one coordinate
     int offsetM = ordinateFlags.contains(Ordinate.Z) ? 1 : 0;
-    CoordinateSequence sequence = csFactory.create(1, toDimension(ordinateFlags), ordinateFlags.contains(Ordinate.M) ? 1 : 0);
-    sequence.setOrdinate(0, CoordinateSequence.X, precisionModel.makePrecise(getNextNumber(tokenizer)));
-    sequence.setOrdinate(0, CoordinateSequence.Y, precisionModel.makePrecise(getNextNumber(tokenizer)));
-
+    Coordinate coord = createCoordinate(ordinateFlags);
+    coord.setOrdinate(CoordinateSequence.X, precisionModel.makePrecise(getNextNumber(tokenizer)));
+    coord.setOrdinate(CoordinateSequence.Y, precisionModel.makePrecise(getNextNumber(tokenizer)));
+    
     // additionally read other vertices
     if (ordinateFlags.contains(Ordinate.Z))
-      sequence.setOrdinate(0, CoordinateSequence.Z, getNextNumber(tokenizer));
+      coord.setOrdinate(CoordinateSequence.Z, getNextNumber(tokenizer));
     if (ordinateFlags.contains(Ordinate.M))
-      sequence.setOrdinate(0, CoordinateSequence.Z + offsetM, getNextNumber(tokenizer));
-
+      coord.setOrdinate(CoordinateSequence.Z + offsetM, getNextNumber(tokenizer));
+    
     if (ordinateFlags.size() == 2 && this.isAllowOldJtsCoordinateSyntax && isNumberNext(tokenizer)) {
-      sequence.setOrdinate(0, CoordinateSequence.Z, getNextNumber(tokenizer));
+      coord.setOrdinate(CoordinateSequence.Z, getNextNumber(tokenizer));
     }
-
+    
     // read close token if it was opened here
     if (opened) {
       getNextCloser(tokenizer);
     }
-
-    return sequence;
+    
+    return coord;
+  }
+  
+  private Coordinate createCoordinate(EnumSet<Ordinate> ordinateFlags) {
+    boolean hasZ = ordinateFlags.contains(Ordinate.Z);
+    boolean hasM = ordinateFlags.contains(Ordinate.M);
+    if (hasZ && hasM) 
+      return new CoordinateXYZM();
+    if (hasZ || this.isAllowOldJtsCoordinateSyntax) 
+      return new Coordinate();
+    if (hasM) 
+      return new CoordinateXYM();
+    return new CoordinateXY();
   }
 
   /**
@@ -325,17 +360,41 @@ public class WKTReader
    *@throws  IOException     if an I/O error occurs
    *@throws  ParseException  if an unexpected token was encountered
    */
-  private CoordinateSequence getCoordinateSequence(StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
+  private CoordinateSequence getCoordinateSequence(StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags, int minSize, boolean isRing)
           throws IOException, ParseException {
     if (getNextEmptyOrOpener(tokenizer).equals(WKTConstants.EMPTY))
       return createCoordinateSequenceEmpty(ordinateFlags);
     
-    ArrayList coordinates = new ArrayList();
+    List<Coordinate> coordinates = new ArrayList<Coordinate>();
     do {
       coordinates.add(getCoordinate(tokenizer, ordinateFlags, false));
     } while (getNextCloserOrComma(tokenizer).equals(COMMA));
 
-    return mergeSequences(coordinates, ordinateFlags);  
+    if (isFixStructure) {
+      fixStructure(coordinates, minSize, isRing);
+    }
+    Coordinate[] coordArray = coordinates.toArray(new Coordinate[0]);
+    return csFactory.create(coordArray);
+  }
+
+  private static void fixStructure(List<Coordinate> coords, int minSize, boolean isRing) {
+    if (coords.size() == 0)
+      return;
+    if (isRing && ! isClosed(coords)) {
+        coords.add(coords.get(0).copy());
+      }
+    while (coords.size() < minSize) {
+      coords.add(coords.get(coords.size() - 1).copy());
+    }
+  }
+
+  private static boolean isClosed(List<Coordinate> coords) {
+    if (coords.size() == 0) return true;
+    if (coords.size() == 1 
+        || ! coords.get(0).equals2D(coords.get(coords.size() - 1))) {
+      return false;
+    } 
+    return true;
   }
 
   private CoordinateSequence createCoordinateSequenceEmpty(EnumSet<Ordinate> ordinateFlags)
@@ -865,7 +924,7 @@ S  */
    *@throws  ParseException  if an unexpected token was encountered
    */
   private Point readPointText(StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags) throws IOException, ParseException {
-    Point point = geometryFactory.createPoint(getCoordinateSequence(tokenizer, ordinateFlags));
+    Point point = geometryFactory.createPoint(getCoordinateSequence(tokenizer, ordinateFlags, 1, false));
     return point;
   }
 
@@ -880,7 +939,7 @@ S  */
    *@throws  ParseException  if an unexpected token was encountered
    */
   private LineString readLineStringText(StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags) throws IOException, ParseException {
-    return geometryFactory.createLineString(getCoordinateSequence(tokenizer, ordinateFlags));
+    return geometryFactory.createLineString(getCoordinateSequence(tokenizer, ordinateFlags, LineString.MINIMUM_VALID_SIZE, false));
   }
 
   /**
@@ -898,7 +957,7 @@ S  */
   private LinearRing readLinearRingText(StreamTokenizer tokenizer, EnumSet<Ordinate> ordinateFlags)
     throws IOException, ParseException
   {
-    return geometryFactory.createLinearRing(getCoordinateSequence(tokenizer, ordinateFlags));
+    return geometryFactory.createLinearRing(getCoordinateSequence(tokenizer, ordinateFlags, LinearRing.MINIMUM_VALID_SIZE, true));
   }
 
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderFixStructureTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderFixStructureTest.java
@@ -1,0 +1,70 @@
+package org.locationtech.jts.io;
+
+import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
+
+public class WKTReaderFixStructureTest extends GeometryTestCase {
+  
+  public static void main(String args[]) {
+    TestRunner.run(WKTReaderFixStructureTest.class);
+  }
+
+  private WKTReader readerFix;
+  private WKTReader reader;
+
+  public WKTReaderFixStructureTest(String name) {
+    super(name);
+    
+    reader = new WKTReader();
+    readerFix = new WKTReader();
+    readerFix.setFixStructure(true);
+  }
+  
+  public void testLineaStringShort() throws ParseException {
+    checkFixStructure("LINESTRING (0 0)");
+  }
+  
+  public void testLinearRingUnclosed() throws ParseException {
+    checkFixStructure("LINEARRING (0 0, 0 1, 1 0)");
+  }
+  
+  public void testLinearRingShort() throws ParseException {
+    checkFixStructure("LINEARRING (0 0, 0 1)");
+  }
+  
+  public void testPolygonShort() throws ParseException {
+    checkFixStructure("POLYGON ((0 0))");
+  }
+  
+  public void testPolygonUnclosed() throws ParseException {
+    checkFixStructure("POLYGON ((0 0, 0 1, 1 0))");
+  }
+  
+  public void testPolygonUnclosedHole() throws ParseException {
+    checkFixStructure("POLYGON ((0 0, 0 10, 10 0, 0 0), (0 0, 1 0, 0 1))");
+  }
+  
+  public void testCollection() throws ParseException {
+    checkFixStructure("GEOMETRYCOLLECTION (LINESTRING (0 0), LINEARRING (0 0, 0 1), POLYGON ((0 0, 0 10, 10 0, 0 0), (0 0, 1 0, 0 1)) )");
+  }
+  
+  private void checkFixStructure(String wkt) throws ParseException {
+    checkHasBadStructure(wkt);
+    checkFixed(wkt);
+  }
+  
+  private void checkFixed(String wkt) throws ParseException {
+    // if not fixed will fail with IllegalArgumentException 
+    readerFix.read(wkt);
+  }
+  
+  private void checkHasBadStructure(String wkt) throws ParseException {
+    try {
+      reader.read(wkt);
+      fail("Input does not have non-closed rings");
+    } catch (IllegalArgumentException e) {
+      // ok, do nothing
+    }
+  }
+  
+}

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderParseErrorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderParseErrorTest.java
@@ -102,11 +102,6 @@ public class WKTReaderParseErrorTest
     readWithParseException("LINESTRINGABCZM ( 0 0 0 0, 1 1 1 1 )");
   }
 
-  public void testUnclosedPolygon() throws IOException
-  {
-    readWithParseException("POLYGON ((0 0, 1 0, 0 1))");
-  }
-
   private void readWithParseException(String wkt)
       throws IOException
   {

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderParseErrorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderParseErrorTest.java
@@ -102,6 +102,11 @@ public class WKTReaderParseErrorTest
     readWithParseException("LINESTRINGABCZM ( 0 0 0 0, 1 1 1 1 )");
   }
 
+  public void testUnclosedPolygon() throws IOException
+  {
+    readWithParseException("POLYGON ((0 0, 1 0, 0 1))");
+  }
+
   private void readWithParseException(String wkt)
       throws IOException
   {

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
@@ -48,6 +48,7 @@ public class WKTReaderTest extends GeometryTestCase {
   private final WKTReader readerXYZ;
   private final WKTReader readerXYM;
   private final WKTReader readerXYZM;
+  private WKTReader readerXYZCloseRings;
 
   public static void main(String args[]) {
     TestRunner.run(suite());
@@ -66,6 +67,9 @@ public class WKTReaderTest extends GeometryTestCase {
     readerXYZ = getWKTReader(Ordinate.createXYZ(), 1d);
     readerXYM = getWKTReader(Ordinate.createXYM(), 1d);
     readerXYZM = getWKTReader(Ordinate.createXYZM(), 1d);
+    
+    readerXYZCloseRings = getWKTReader(Ordinate.createXYZM(), 1d);
+    readerXYZCloseRings.setFixStructure(true);
   }
 
   public static Test suite() { return new TestSuite(WKTReaderTest.class); }
@@ -478,6 +482,7 @@ public class WKTReaderTest extends GeometryTestCase {
       }
   }
   
+
 
   private void checkCS(CoordinateSequence cs, Geometry geom) {
     assertTrue( isEqual( cs, extractCS(geom)));


### PR DESCRIPTION
Adds a method `WKTReader.setFixStructure` to indicate that input should be fixed to be structurally (but not necessarily topologically) valid.

Also improves the efficiency of reading coordinate sequences. 

Signed-off-by: Martin Davis <mtnclimb@gmail.com>