### PR TITLE
Fix IsSimpleOp for repeated endpoints

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/operation/valid/IsSimpleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/valid/IsSimpleTest.java
@@ -98,6 +98,38 @@ public class IsSimpleTest
     checkIsSimple(a, BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE,  true  );
   }
 
+  public void testLineRepeatedStart() {
+    String a = "LINESTRING (100 100, 100 100, 20 20, 200 20, 100 100)";
+
+    // rings are simple under all rules
+    checkIsSimple(a, BoundaryNodeRule.MOD2_BOUNDARY_RULE,      true  );
+    checkIsSimple(a, BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE,  true  );
+  }
+  
+  public void testLineRepeatedEnd() {
+    String a = "LINESTRING (100 100, 20 20, 200 20, 100 100, 100 100)";
+
+    // rings are simple under all rules
+    checkIsSimple(a, BoundaryNodeRule.MOD2_BOUNDARY_RULE,      true  );
+    checkIsSimple(a, BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE,  true  );
+  }
+  
+  public void testLineRepeatedBothEnds() {
+    String a = "LINESTRING (100 100, 100 100, 100 100, 20 20, 200 20, 100 100, 100 100)";
+
+    // rings are simple under all rules
+    checkIsSimple(a, BoundaryNodeRule.MOD2_BOUNDARY_RULE,      true  );
+    checkIsSimple(a, BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE,  true  );
+  }
+  
+  public void testLineRepeatedAll() {
+    String a = "LINESTRING (100 100, 100 100, 100 100)";
+
+    // rings are simple under all rules
+    checkIsSimple(a, BoundaryNodeRule.MOD2_BOUNDARY_RULE,      true  );
+    checkIsSimple(a, BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE,  true  );
+  }
+  
   public void testLinesAll() {
     checkIsSimpleAll("MULTILINESTRING ((10 20, 90 20), (10 30, 90 30), (50 40, 50 10))",
         BoundaryNodeRule.MOD2_BOUNDARY_RULE,

--- a/modules/tests/src/test/resources/testxml/general/TestSimple.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestSimple.xml
@@ -62,6 +62,54 @@
 </case>
 
 <case>
+  <desc>L - simple line - repeated start point</desc>
+  <a>
+    LINESTRING(10 10, 10 10, 20 20)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple line - repeated end point</desc>
+  <a>
+    LINESTRING(10 10, 20 20, 20 20)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple line - repeated points at both ends</desc>
+  <a>
+    LINESTRING(10 10, 10 10, 20 20, 20 20)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
+  <desc>L - simple line - zerolength</desc>
+  <a>
+    LINESTRING(10 10, 10 10, 10 10)
+  </a>
+<test>
+  <op name="isSimple" arg1="A">
+    true
+  </op>
+</test>
+</case>
+
+<case>
   <desc>L - non-simple, proper interior intersection</desc>
   <a>
     LINESTRING (20 60, 160 60, 80 160, 80 20)


### PR DESCRIPTION
Fixes `IsSimpleOp` to correctly handle `LineString`s with repeated endpoints.

Fixes #850.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>