### PR TITLE
Exclude junit compile dependency from json-simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
                 <groupId>com.googlecode.json-simple</groupId>
                 <artifactId>json-simple</artifactId>
                 <version>${json-simple-version}</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                  </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
JUnit should be a test dependency only. Projects using `jts-io-common` also inherits from this (outdated) dependency.
See https://github.com/fangyidong/json-simple/issues/91