### PR TITLE
Remove unsafe System calls from core

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
@@ -274,16 +274,18 @@ public class RobustLineIntersector
     return intPt;
   }
 
+  /*
   private void checkDD(Coordinate p1, Coordinate p2, Coordinate q1,
       Coordinate q2, Coordinate intPt)
   {
     Coordinate intPtDD = CGAlgorithmsDD.intersection(p1, p2, q1, q2);
     boolean isIn = isInSegmentEnvelopes(intPtDD);
-    System.out.println(   "DD in env = " + isIn + "  --------------------- " + intPtDD);
+    Debug.println(   "DD in env = " + isIn + "  --------------------- " + intPtDD);
     if (intPt.distance(intPtDD) > 0.0001) {
-      System.out.println("Distance = " + intPt.distance(intPtDD));
+      Debug.println("Distance = " + intPt.distance(intPtDD));
     }
   }
+  */
   
   /**
    * Computes a segment intersection using homogeneous coordinates.

--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/DirectedEdgeStar.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/DirectedEdgeStar.java
@@ -374,7 +374,7 @@ public class DirectedEdgeStar
 
   public void print(PrintStream out)
   {
-    System.out.println("DirectedEdgeStar: " + getCoordinate());
+    out.println("DirectedEdgeStar: " + getCoordinate());
     for (Iterator it = iterator(); it.hasNext(); ) {
       DirectedEdge de = (DirectedEdge) it.next();
       out.print("out ");

--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeEndStar.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeEndStar.java
@@ -319,7 +319,7 @@ abstract public class EdgeEndStar
 
   public void print(PrintStream out)
   {
-    System.out.println("EdgeEndStar:   " + getCoordinate());
+    out.println("EdgeEndStar:   " + getCoordinate());
     for (Iterator it = iterator(); it.hasNext(); ) {
       EdgeEnd e = (EdgeEnd) it.next();
       e.print(out);

--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/PlanarGraph.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/PlanarGraph.java
@@ -24,6 +24,7 @@ import org.locationtech.jts.algorithm.Orientation;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Location;
 import org.locationtech.jts.geom.Quadrant;
+import org.locationtech.jts.util.Debug;
 
 /**
  * The computation of the <code>IntersectionMatrix</code> relies on the use of a structure
@@ -238,14 +239,6 @@ public class PlanarGraph
       e.print(out);
       e.eiList.print(out);
     }
-  }
-  void debugPrint(Object o)
-  {
-    System.out.print(o);
-  }
-  void debugPrintln(Object o)
-  {
-    System.out.println(o);
   }
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/index/hprtree/HPRtree.java
+++ b/modules/core/src/main/java/org/locationtech/jts/index/hprtree/HPRtree.java
@@ -262,8 +262,7 @@ public class HPRtree
       System.out.println(fact.toGeometry(env));
     }
   }
-*/
-  
+
   private static void dumpItems(List<Item> items) {
     GeometryFactory fact = new GeometryFactory();
     for (Item item : items) {
@@ -271,6 +270,7 @@ public class HPRtree
       System.out.println(fact.toGeometry(env));
     }
   }
+  */
 
   private static double[] createBoundsArray(int size) {
     double[] a = new double[4*size];

--- a/modules/core/src/main/java/org/locationtech/jts/noding/ScaledNoder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/ScaledNoder.java
@@ -111,10 +111,11 @@ public class ScaledNoder
       pts[i].x = pts[i].x / scaleFactor + offsetX;
       pts[i].y = pts[i].y / scaleFactor + offsetY;
     }
-
+    /*
     if (pts.length == 2 && pts[0].equals2D(pts[1])) {
       System.out.println(pts);
     }
+    */
   }
 
   //private double rescale(double val) { return val / scaleFactor; }

--- a/modules/core/src/main/java/org/locationtech/jts/noding/snapround/MCIndexSnapRounder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/snapround/MCIndexSnapRounder.java
@@ -79,6 +79,7 @@ public class MCIndexSnapRounder
     //checkCorrectness(inputSegmentStrings);
   }
 
+  /*
   private void checkCorrectness(Collection inputSegmentStrings)
   {
     Collection resultSegStrings = NodedSegmentString.getNodedSubstrings(inputSegmentStrings);
@@ -89,7 +90,8 @@ public class MCIndexSnapRounder
       ex.printStackTrace();
     }
   }
-
+*/
+  
   private void snapRound(Collection segStrings, LineIntersector li)
   {
     List intersections = findInteriorIntersections(segStrings, li);

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/validate/BufferDistanceValidator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/validate/BufferDistanceValidator.java
@@ -25,6 +25,7 @@ import org.locationtech.jts.geom.util.LinearComponentExtracter;
 import org.locationtech.jts.geom.util.PolygonExtracter;
 import org.locationtech.jts.io.WKTWriter;
 import org.locationtech.jts.operation.distance.DistanceOp;
+import org.locationtech.jts.util.Debug;
 
 /**
  * Validates that a given buffer curve lies an appropriate distance
@@ -90,7 +91,7 @@ public class BufferDistanceValidator
   		checkNegativeValid();
   	}
     if (VERBOSE) {
-      System.out.println("Min Dist= " + minDistanceFound + "  err= " 
+      Debug.println("Min Dist= " + minDistanceFound + "  err= " 
         + (1.0 - minDistanceFound / bufDistance) 
         + "  Max Dist= " + maxDistanceFound + "  err= " 
         + (maxDistanceFound / bufDistance - 1.0)

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/validate/BufferResultValidator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/validate/BufferResultValidator.java
@@ -16,6 +16,7 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.util.Debug;
 
 /**
  * Validates that the result of a buffer operation
@@ -125,7 +126,7 @@ public class BufferResultValidator
   private void report(String checkName)
   {
     if (! VERBOSE) return;
-    System.out.println("Check " + checkName + ": " 
+    Debug.println("Check " + checkName + ": " 
         + (isValid ? "passed" : "FAILED"));
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlay/snap/SnapOverlayOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlay/snap/SnapOverlayOp.java
@@ -128,11 +128,12 @@ public class SnapOverlayOp
     remGeom[1] = cbr.removeCommonBits(geom[1].copy());
     return remGeom;
   }
-  
+  /*
   private void checkValid(Geometry g)
   {
   	if (! g.isValid()) {
   		System.out.println("Snapped geometry is invalid");
   	}
   }
+  */
 }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlay/validate/OverlayResultValidator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlay/validate/OverlayResultValidator.java
@@ -19,6 +19,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Location;
 import org.locationtech.jts.operation.overlay.OverlayOp;
 import org.locationtech.jts.operation.overlay.snap.GeometrySnapper;
+import org.locationtech.jts.util.Debug;
 
 /**
  * Validates that the result of an overlay operation is
@@ -154,7 +155,7 @@ public class OverlayResultValidator
 
   private void reportResult(int overlayOp, int[] location, boolean expectedInterior)
   {
-  	System.out.println(
+  	Debug.println(
   			"Overlay result invalid - A:" + Location.toLocationSymbol(location[0])
   			+ " B:" + Location.toLocationSymbol(location[1])
   			+ " expected:" + (expectedInterior ? 'i' : 'e')

--- a/modules/core/src/main/java/org/locationtech/jts/operation/polygonize/EdgeRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/polygonize/EdgeRing.java
@@ -303,19 +303,18 @@ class EdgeRing {
 
   /**
    * Returns this ring as a {@link LinearRing}, or null if an Exception occurs while
-   * creating it (such as a topology problem). Details of problems are written to
-   * standard output.
+   * creating it (such as a topology problem). 
    */
   public LinearRing getRing()
   {
     if (ring != null) return ring;
     getCoordinates();
-    if (ringPts.length < 3) System.out.println(ringPts);
+    //if (ringPts.length < 3) System.out.println(ringPts);
     try {
       ring = factory.createLinearRing(ringPts);
     }
     catch (Exception ex) {
-      System.out.println(ringPts);
+      //System.out.println(ringPts);
     }
     return ring;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/union/UnionInteracting.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/union/UnionInteracting.java
@@ -66,11 +66,12 @@ public class UnionInteracting
 		
 //		System.out.println(int0);
 //		System.out.println(int1);
-
+/*
 		if (int0.isEmpty() || int1.isEmpty()) {
 			System.out.println("found empty!");
 //			computeInteracting();
 		}
+		*/
 //		if (! int0.isValid()) {
 			//System.out.println(int0);
 			//throw new RuntimeException("invalid geom!");

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
@@ -935,7 +935,7 @@ public class QuadEdgeSubdivision {
     coordList.closeRing();
     
     if (coordList.size() < 4) {
-      System.out.println(coordList);
+      //System.out.println(coordList);
       coordList.add(coordList.get(coordList.size()-1), true);
     }
     

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/TrianglePredicate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/TrianglePredicate.java
@@ -279,36 +279,38 @@ public class TrianglePredicate
    * @param c a vertex of the triangle
    * @param p the point to test
    */
-private static void checkRobustInCircle(Coordinate a, Coordinate b, Coordinate c,
-    Coordinate p) 
-{
-  boolean nonRobustInCircle = isInCircleNonRobust(a, b, c, p);
-  boolean isInCircleDD = TrianglePredicate.isInCircleDDSlow(a, b, c, p);
-  boolean isInCircleCC = TrianglePredicate.isInCircleCC(a, b, c, p);
-
-  Coordinate circumCentre = Triangle.circumcentre(a, b, c);
-  System.out.println("p radius diff a = "
-      + Math.abs(p.distance(circumCentre) - a.distance(circumCentre))
-      / a.distance(circumCentre));
-
-  if (nonRobustInCircle != isInCircleDD || nonRobustInCircle != isInCircleCC) {
-    System.out.println("inCircle robustness failure (double result = "
-        + nonRobustInCircle 
-        + ", DD result = " + isInCircleDD
-        + ", CC result = " + isInCircleCC + ")");
-    System.out.println(WKTWriter.toLineString(new CoordinateArraySequence(
-        new Coordinate[] { a, b, c, p })));
-    System.out.println("Circumcentre = " + WKTWriter.toPoint(circumCentre)
-        + " radius = " + a.distance(circumCentre));
+  /*
+  private static void checkRobustInCircle(Coordinate a, Coordinate b, Coordinate c,
+      Coordinate p) 
+  {
+    boolean nonRobustInCircle = isInCircleNonRobust(a, b, c, p);
+    boolean isInCircleDD = TrianglePredicate.isInCircleDDSlow(a, b, c, p);
+    boolean isInCircleCC = TrianglePredicate.isInCircleCC(a, b, c, p);
+  
+    Coordinate circumCentre = Triangle.circumcentre(a, b, c);
     System.out.println("p radius diff a = "
-        + Math.abs(p.distance(circumCentre)/a.distance(circumCentre) - 1));
-    System.out.println("p radius diff b = "
-        + Math.abs(p.distance(circumCentre)/b.distance(circumCentre) - 1));
-    System.out.println("p radius diff c = "
-        + Math.abs(p.distance(circumCentre)/c.distance(circumCentre) - 1));
-    System.out.println();
+        + Math.abs(p.distance(circumCentre) - a.distance(circumCentre))
+        / a.distance(circumCentre));
+  
+    if (nonRobustInCircle != isInCircleDD || nonRobustInCircle != isInCircleCC) {
+      System.out.println("inCircle robustness failure (double result = "
+          + nonRobustInCircle 
+          + ", DD result = " + isInCircleDD
+          + ", CC result = " + isInCircleCC + ")");
+      System.out.println(WKTWriter.toLineString(new CoordinateArraySequence(
+          new Coordinate[] { a, b, c, p })));
+      System.out.println("Circumcentre = " + WKTWriter.toPoint(circumCentre)
+          + " radius = " + a.distance(circumCentre));
+      System.out.println("p radius diff a = "
+          + Math.abs(p.distance(circumCentre)/a.distance(circumCentre) - 1));
+      System.out.println("p radius diff b = "
+          + Math.abs(p.distance(circumCentre)/b.distance(circumCentre) - 1));
+      System.out.println("p radius diff c = "
+          + Math.abs(p.distance(circumCentre)/c.distance(circumCentre) - 1));
+      System.out.println();
+    }
   }
-}
+*/
 
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/Vertex.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/Vertex.java
@@ -300,8 +300,8 @@ public class Vertex
         try {
             cc = new Vertex(hcc.getX(), hcc.getY());
         } catch (NotRepresentableException nre) {
-            System.err.println("a: " + a + "  b: " + b + "  c: " + c);
-            System.err.println(nre);
+            //Debug.println("a: " + a + "  b: " + b + "  c: " + c);
+            //Debug.println(nre);
         }
         return cc;
     }


### PR DESCRIPTION
Removes *almost* all of the following from JTS-core `main`:

* References to `System.out` and `System.err`
* Calls to `Exception.printStackTrace`

The remaining instances of the above are localized and under control of external configuration (e.g. in the `Debug` class).

Motivated by [this dev-list message](https://www.eclipse.org/lists/jts-dev/msg00325.html).