### PR TITLE
Fix PolygonHoleJoiner

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/triangulate/polygon/ConstrainedDelaunayTriangulatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/triangulate/polygon/ConstrainedDelaunayTriangulatorTest.java
@@ -12,7 +12,6 @@
 package org.locationtech.jts.triangulate.polygon;
 
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.triangulate.polygon.ConstrainedDelaunayTriangulator;
 
 import junit.textui.TestRunner;
 import test.jts.GeometryTestCase;
@@ -40,6 +39,11 @@ public class ConstrainedDelaunayTriangulatorTest extends GeometryTestCase {
   public void testHoleCW() {
     checkTri("POLYGON ((10 90, 90 90, 90 20, 10 10, 10 90), (30 70, 80 70, 50 30, 30 70))"
         ,"GEOMETRYCOLLECTION (POLYGON ((10 10, 10 90, 30 70, 10 10)), POLYGON ((10 10, 30 70, 50 30, 10 10)), POLYGON ((80 70, 30 70, 90 90, 80 70)), POLYGON ((10 90, 30 70, 90 90, 10 90)), POLYGON ((80 70, 90 90, 90 20, 80 70)), POLYGON ((90 20, 10 10, 50 30, 90 20)), POLYGON ((90 20, 50 30, 80 70, 90 20)))");
+  }
+  
+  public void testTouchingHoles() {
+    checkTri("POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (20 80, 50 70, 30 30, 20 80), (70 20, 50 70, 80 80, 70 20))"
+        ,"GEOMETRYCOLLECTION (POLYGON ((10 10, 10 90, 20 80, 10 10)), POLYGON ((30 30, 50 70, 70 20, 30 30)), POLYGON ((80 80, 50 70, 20 80, 80 80)), POLYGON ((20 80, 10 90, 90 90, 20 80)), POLYGON ((10 10, 20 80, 30 30, 10 10)), POLYGON ((80 80, 20 80, 90 90, 80 80)), POLYGON ((70 20, 10 10, 30 30, 70 20)), POLYGON ((90 10, 80 80, 90 90, 90 10)), POLYGON ((10 10, 70 20, 90 10, 10 10)), POLYGON ((80 80, 90 10, 70 20, 80 80)))");
   }
   
   public void testMultiPolygon() {

--- a/modules/core/src/test/java/org/locationtech/jts/triangulate/polygon/PolygonTriangulatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/triangulate/polygon/PolygonTriangulatorTest.java
@@ -43,7 +43,7 @@ public class PolygonTriangulatorTest extends GeometryTestCase {
   
   public void testTouchingHoles() {
     checkTri("POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (20 80, 50 70, 30 30, 20 80), (70 20, 50 70, 80 80, 70 20))"
-        ,"GEOMETRYCOLLECTION (POLYGON ((10 10, 10 90, 20 80, 10 10)), POLYGON ((50 70, 20 80, 10 90, 50 70)), POLYGON ((10 10, 20 80, 30 30, 10 10)), POLYGON ((30 30, 50 70, 70 20, 30 30)), POLYGON ((80 80, 50 70, 10 90, 80 80)), POLYGON ((90 10, 10 10, 30 30, 90 10)), POLYGON ((80 80, 10 90, 90 90, 80 80)), POLYGON ((90 10, 30 30, 70 20, 90 10)), POLYGON ((70 20, 80 80, 90 90, 70 20)), POLYGON ((90 90, 90 10, 70 20, 90 90)))");
+        ,"GEOMETRYCOLLECTION (POLYGON ((10 10, 10 90, 20 80, 10 10)), POLYGON ((30 30, 50 70, 70 20, 30 30)), POLYGON ((80 80, 50 70, 20 80, 80 80)), POLYGON ((20 80, 10 90, 90 90, 20 80)), POLYGON ((10 10, 20 80, 30 30, 10 10)), POLYGON ((80 80, 20 80, 90 90, 80 80)), POLYGON ((90 10, 10 10, 30 30, 90 10)), POLYGON ((70 20, 80 80, 90 90, 70 20)), POLYGON ((90 10, 30 30, 70 20, 90 10)), POLYGON ((70 20, 90 90, 90 10, 70 20)))");
   }
   
   public void testRepeatedPoints() {
@@ -73,6 +73,16 @@ public class PolygonTriangulatorTest extends GeometryTestCase {
   public void testCollapsedCorner() {
     checkTri(
   "POLYGON ((186 90, 71 17, 74 10, 65 0, 0 121, 186 90), (73 34, 67 41, 71 17, 73 34))"
+        );
+  }
+  
+  /**
+   * A failing case revealing that joining holes by a zero-length cut
+   * was introducing duplicate vertices.
+   */
+  public void testBadHoleJoinZeroLenCutDuplicateVertices() {
+    checkTri(
+  "POLYGON ((71 12, 0 0, 7 47, 16 94, 71 52, 71 12), (7 38, 25 48, 7 47, 7 38), (13 59, 13 54, 26 53, 13 59))"
         );
   }
   


### PR DESCRIPTION
Fixes an issue in `PolygonHoleJoiner` where inserted holes that touch the shell caused vertex duplication, which caused potential self-intersecting results.

Also has various code cleanups.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>