### PR TITLE
Improve PolygonHull to avoid exceeding target parameter

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/PolygonHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/PolygonHull.java
@@ -51,7 +51,11 @@ import org.locationtech.jts.math.MathUtil;
  * Value 0 produces the original geometry.
  * Larger values produce less concave results.
  * </li>
- * </ol>  
+ * </ol> 
+ * The algorithm ensures that the result does not cause the target parameter 
+ * to be exceeded.  This allows computing outer or inner hulls
+ * with a small area delta ratio to be an effective way of removing 
+ * narrow gores and spikes.   
  * 
  * @author Martin Davis
  *

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/RingHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/RingHull.java
@@ -138,12 +138,13 @@ class RingHull {
   
   public void compute(RingHullIndex hullIndex) {        
     while (! cornerQueue.isEmpty() 
-        && ! isAtTarget()
         && vertexRing.size() > 3) {
       Corner corner = cornerQueue.poll();
       //-- a corner may no longer be valid due to removal of adjacent corners
       if (corner.isRemoved(vertexRing))
         continue;
+      if (isAtTarget(corner))
+        return;
       //System.out.println(corner.toLineString(vertexList));
       /**
        * Corner is concave or flat - remove it if possible.
@@ -154,12 +155,14 @@ class RingHull {
     }
   }
 
-  private boolean isAtTarget() {
+  private boolean isAtTarget(Corner corner) {
     if (targetVertexNum >= 0) {
       return vertexRing.size() < targetVertexNum;
     }
     if (targetAreaDelta >= 0) {
-      return areaDelta > targetAreaDelta;
+      //-- include candidate corder to avoid overshooting target
+      // (important for very small target area deltas)
+      return areaDelta + corner.getArea() > targetAreaDelta;
     }
     //-- no target set
     return true;

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/hull/PolygonHullTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/hull/PolygonHullTest.java
@@ -79,6 +79,10 @@ public class PolygonHullTest extends GeometryTestCase {
     checkHullByAreaDelta(wkt, 1, "POLYGON ((30 90, 80 80, 90 30, 70 10, 40 10, 10 40, 30 90))");
   }
 
+  public void testGoreRemoval() {
+    checkHullByAreaDelta("POLYGON ((30 120, 60 240, 200 220, 60.02 240.08, 80 320, 320 280, 230 160, 250 60, 30 120))",
+        0.01, "POLYGON ((30 120, 80 320, 320 280, 230 160, 250 60, 30 120))");
+  }
   
   //=================================================
   

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/hull/PolygonHullTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/hull/PolygonHullTest.java
@@ -73,8 +73,9 @@ public class PolygonHullTest extends GeometryTestCase {
   public void testByAreaOuterSimple() {
     String wkt = "POLYGON ((30 90, 10 40, 40 10, 70 10, 90 30, 80 80, 70 40, 30 40, 50 50, 60 70, 30 90))";
     checkHullByAreaDelta(wkt, 0, "POLYGON ((10 40, 30 90, 60 70, 50 50, 30 40, 70 40, 80 80, 90 30, 70 10, 40 10, 10 40))");
-    checkHullByAreaDelta(wkt, 0.1, "POLYGON ((30 90, 60 70, 70 40, 80 80, 90 30, 70 10, 40 10, 10 40, 30 90))");
-    checkHullByAreaDelta(wkt, 0.2, "POLYGON ((30 90, 60 70, 80 80, 90 30, 70 10, 40 10, 10 40, 30 90))");
+    checkHullByAreaDelta(wkt, 0.01, "POLYGON ((10 40, 30 90, 60 70, 50 50, 30 40, 70 40, 80 80, 90 30, 70 10, 40 10, 10 40))");
+    checkHullByAreaDelta(wkt, 0.1, "POLYGON ((10 40, 30 90, 60 70, 50 50, 70 40, 80 80, 90 30, 70 10, 40 10, 10 40))");
+    checkHullByAreaDelta(wkt, 0.2, "POLYGON ((30 90, 60 70, 70 40, 80 80, 90 30, 70 10, 40 10, 10 40, 30 90))");
     checkHullByAreaDelta(wkt, 1, "POLYGON ((30 90, 80 80, 90 30, 70 10, 40 10, 10 40, 30 90))");
   }
 


### PR DESCRIPTION
This improves the `PolygonHull` algorithm to avoid exceeding the specified target parameter. To do this the corner removal candidate is taken into account when checking the parameter value.

This allows `PolygonHull` to be used to remove narrow spikes and gores, by computing innner and outer hulls with a small Area Delta Ratio target.

**Example: Polygon with narrow gore**
```
POLYGON ((41 115, 64.01883066182887 235.99641758140817, 200 220, 64.2 236.5, 80 320, 320 280, 230 160, 252 65, 41 115))
```
Outer Hull using Target Area Delta Ratio of 0.01:
```
POLYGON ((41 115, 80 320, 320 280, 230 160, 252 65, 41 115))
```
![image](https://user-images.githubusercontent.com/3529053/168144805-43f46051-e26e-493c-b07b-a54e0f2c303a.png)


Signed-off-by: Martin Davis <mtnclimb@gmail.com>