### PR TITLE
Fix MinimumDiameter minimumRectangle for flat input

### DIFF
--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -58,6 +58,7 @@ Distributions for older JTS versions can be obtained at the
 * Fix IsValidOp for repeated node points (#845)
 * Fix `IsSimpleOp` for repeated endpoints (#851)
 * Fix `GeometryFixer` via noding check for zero-distance buffers (#867)
+* Fix `MinimumDiameter.minimumRectangle` for flat inputs (#875)
 
 # Version 1.18.2
 

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumRectanglelTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumRectanglelTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 Martin Davis.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import org.locationtech.jts.geom.Geometry;
+
+import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
+
+
+/**
+ * @version 1.7
+ */
+public class MinimumRectanglelTest extends GeometryTestCase {
+
+  private static final double TOL = 1e-10;
+
+  public static void main(String args[]) {
+    TestRunner.run(MinimumRectanglelTest.class);
+  }
+
+  public MinimumRectanglelTest(String name) { super(name); }
+
+  public void testLengthZero() {
+    checkMinRectangle("LINESTRING (1 1, 1 1)", "POINT (1 1)");
+  }
+  
+  public void testHorizontal() {
+    checkMinRectangle("LINESTRING (1 1, 3 1, 5 1, 7 1)", "LINESTRING (1 1, 7 1)");
+  }
+  
+  public void testVertical() {
+    checkMinRectangle("LINESTRING (1 1, 1 4, 1 7, 1 9)", "LINESTRING (1 1, 1 9)");
+  }
+  
+  public void testBentLine() {
+    checkMinRectangle("LINESTRING (1 2, 3 8, 9 6)", "POLYGON ((9 6, 7 10, -1 6, 1 2, 9 6))");
+  }
+  
+  /**
+   * Failure case from https://trac.osgeo.org/postgis/ticket/5163
+   * @throws Exception
+   */
+  public void testFlatDiagonal() throws Exception {
+    checkMinRectangle("LINESTRING(-99.48710639268086 34.79029839231914,-99.48370699999998 34.78689899963806,-99.48152167568102 34.784713675318976)", 
+        "LINESTRING (-99.48710639268086 34.79029839231914, -99.48152167568102 34.784713675318976)");
+  }  
+
+  private void checkMinRectangle(String wkt, String wktExpected) {
+    Geometry geom = read(wkt);
+    Geometry actual = MinimumDiameter.getMinimumRectangle(geom);
+    Geometry expected = read(wktExpected);
+    checkEqual(expected, actual, TOL);
+  }
+  
+
+}


### PR DESCRIPTION
Fixes the issue identified in [PostGIS-5163](https://trac.osgeo.org/postgis/ticket/5163).
Adds unit tests for Minimum Rectangles.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>