### PR TITLE
Fix STRtree queries on empty trees

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/index/strtree/STRtree.java
+++ b/modules/core/src/main/java/org/locationtech/jts/index/strtree/STRtree.java
@@ -321,6 +321,8 @@ implements SpatialIndex, Serializable
    */
   public Object nearestNeighbour(Envelope env, Object item, ItemDistance itemDist)
   {
+    if (isEmpty()) return null;
+
     Boundable bnd = new ItemBoundable(env, item);
     BoundablePair bp = new BoundablePair(this.getRoot(), bnd, itemDist);
     return nearestNeighbour(bp)[0];
@@ -497,7 +499,7 @@ implements SpatialIndex, Serializable
   }
  
   /**
-   * Finds k items in this tree which are the top k nearest neighbors to the given {@code item}, 
+   * Finds up to k items in this tree which are the nearest neighbors to the given {@code item}, 
    * using {@code itemDist} as the distance metric.
    * A Branch-and-Bound tree traversal algorithm is used
    * to provide an efficient search.
@@ -510,15 +512,20 @@ implements SpatialIndex, Serializable
    * contained in the tree, but it does 
    * have to be compatible with the {@code itemDist} 
    * distance metric. 
+   * <p>
+   * If the tree size is smaller than k fewer items will be returned.
+   * If the tree is empty an array of size 0 is returned.
    * 
    * @param env the envelope of the query item
-   * @param item the item to find the nearest neighbour of
+   * @param item the item to find the nearest neighbours of
    * @param itemDist a distance metric applicable to the items in this tree and the query item
-   * @param k the K nearest items in kNearestNeighbour
-   * @return the K nearest items in this tree
+   * @param k the maximum number of nearest items to search for
+   * @return an array of the nearest items found (with length between 0 and K)
    */
   public Object[] nearestNeighbour(Envelope env, Object item, ItemDistance itemDist,int k)
   {
+    if (isEmpty()) return new Object[0];
+
     Boundable bnd = new ItemBoundable(env, item);
     BoundablePair bp = new BoundablePair(this.getRoot(), bnd, itemDist);
     return nearestNeighbourK(bp,k);

--- a/modules/core/src/test/java/org/locationtech/jts/index/strtree/STRtreeNearestNeighbourTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/index/strtree/STRtreeNearestNeighbourTest.java
@@ -44,7 +44,23 @@ public class STRtreeNearestNeighbourTest extends GeometryTestCase {
 
   public void testNearestNeighboursEmpty() {
     STRtree tree = new STRtree();
+    
     Object[] nn = tree.nearestNeighbour(new GeometryItemDistance());
+    assertTrue(nn == null);
+  }
+  
+  public void testNearestNeighboursTreesEmpty() {
+    STRtree tree = new STRtree();
+    STRtree tree2 = new STRtree();
+    
+    Object[] nn = tree.nearestNeighbour(tree2, new GeometryItemDistance());
+    assertTrue(nn == null);
+  }
+  
+  public void testNearestNeighbourEmpty() {
+    STRtree tree = new STRtree();    
+    Geometry geom = read("POINT (1 1)");
+    Object nn = tree.nearestNeighbour(geom.getEnvelopeInternal(), geom, new GeometryItemDistance());
     assertTrue(nn == null);
   }
   
@@ -68,6 +84,13 @@ public class STRtreeNearestNeighbourTest extends GeometryTestCase {
   public void testWithinDistance() {
     checkWithinDistance( POINTS_A, POINTS_B, 2, true );
     checkWithinDistance( POINTS_A, POINTS_B, 1, false );
+  }
+  
+  public void testKNearestNeighborsEmpty() {
+    STRtree tree = new STRtree();    
+    Geometry geom = read("POINT (1 1)");
+    Object[] nn = tree.nearestNeighbour(geom.getEnvelopeInternal(), geom, new GeometryItemDistance(), 5);
+    assertTrue(nn.length == 0);
   }
   
   private void checkNN(String wktItems, String wktExpected) {
@@ -134,6 +157,8 @@ public class STRtreeNearestNeighbourTest extends GeometryTestCase {
     return tree;
   }
 
+
+  
   public void testKNearestNeighbors() {
     int topK = 1000;
     int totalRecords = 10000;
@@ -194,4 +219,4 @@ public class STRtreeNearestNeighbourTest extends GeometryTestCase {
   }
 
 }
-;
+


### PR DESCRIPTION
Fixes the following `STRtree` queries on empty trees:

* `Object nearestNeighbour(Envelope env, Object item, ItemDistance itemDist)` - returns `null` for empty tree
* `Object[] nearestNeighbour(Envelope env, Object item, ItemDistance itemDist,int k)` - returns `Object[0]` for empty tree

Fixes #881.
Fixes #884.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>