### PR TITLE
Fix ConcaveHullOfPolygons hole erosion

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/ConcaveHullOfPolygons.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/ConcaveHullOfPolygons.java
@@ -360,16 +360,21 @@ public class ConcaveHullOfPolygons {
         /**
          * Frame tris are adjacent to at most one border tri,
          * which is opposite the frame corner vertex.
-         * The opposite tri may be another frame tri. 
-         * This is detected when it is processed,
-         * since it is not in the hullTri set.
+         * Or, the opposite tri may be another frame tri,
+         * which is not added as a border tri.
          */
         int oppIndex = Tri.oppEdge(index);
-        addBorderTri(tri, oppIndex);
+        Tri oppTri = tri.getAdjacent(oppIndex);
+        boolean isBorderTri = oppTri != null && ! isFrameTri(oppTri, frameCorners);
+        if (isBorderTri) {
+          addBorderTri(tri, oppIndex);
+        }
+        //-- remove the frame tri
         tri.remove();
       }
       else {
         hullTris.add(tri);
+        //System.out.println(tri);
       }
     }
     return hullTris;
@@ -402,13 +407,14 @@ public class ConcaveHullOfPolygons {
       if (isRemovable(tri)) {
         addBorderTris(tri);
         removeBorderTri(tri);
+        //System.out.println(tri);
       }
     }
   }
 
   private void removeHoleTris() {
     while (true) {
-      Tri holeTri = findHoleTri(hullTris);
+      Tri holeTri = findHoleSeedTri(hullTris);
       if (holeTri == null)
         return;
       addBorderTris(holeTri);
@@ -417,19 +423,29 @@ public class ConcaveHullOfPolygons {
     }
   }
   
-  private Tri findHoleTri(Set<Tri> tris) {
+  private Tri findHoleSeedTri(Set<Tri> tris) {
     for (Tri tri : tris) {
-      if (isHoleTri(tri))
+      if (isHoleSeedTri(tri))
         return tri;
     }
     return null;
   }
 
-  private boolean isHoleTri(Tri tri) {
+  private boolean isHoleSeedTri(Tri tri) {
+    if (isBorderTri(tri))
+      return false;
     for (int i = 0; i < 3; i++) {
       if (tri.hasAdjacent(i)
           && tri.getLength(i) > maxEdgeLength)
          return true;
+    }
+    return false;
+  }
+
+  private boolean isBorderTri(Tri tri) {
+    for (int i = 0; i < 3; i++) {
+      if (! tri.hasAdjacent(i))
+          return true;
     }
     return false;
   }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/hull/ConcaveHullOfPolygonsTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/hull/ConcaveHullOfPolygonsTest.java
@@ -82,7 +82,9 @@ public class ConcaveHullOfPolygonsTest extends GeometryTestCase {
 
   public void testPoly3WithHole() {
     String wkt = "MULTIPOLYGON (((1 9, 5 9, 5 7, 3 7, 3 5, 1 5, 1 9)), ((1 4, 3 4, 3 2, 5 2, 5 0, 1 0, 1 4)), ((6 9, 8 9, 9 5, 8 0, 6 0, 6 2, 8 5, 6 7, 6 9)))";
-    checkHullWithHoles( wkt, 1, wkt);
+    checkHullWithHoles( wkt, .9, wkt);
+    checkHullWithHoles( wkt, 1, 
+        "POLYGON ((1 0, 1 4, 1 5, 1 9, 5 9, 6 9, 8 9, 9 5, 8 0, 6 0, 5 0, 1 0), (3 2, 5 2, 6 2, 8 5, 6 7, 5 7, 3 7, 3 5, 3 4, 3 2))");
     checkHullWithHoles( wkt, 2.5, 
         "POLYGON ((1 5, 1 9, 5 9, 6 9, 8 9, 9 5, 8 0, 6 0, 5 0, 1 0, 1 4, 1 5), (3 4, 3 2, 5 2, 6 2, 8 5, 6 7, 5 7, 3 7, 3 5, 3 4))");
     checkHullWithHoles( wkt, 4, 


### PR DESCRIPTION
Fixes `ConcaveHullOfPolygons` hole eroding to avoid eroding too much.

### Example

```
MULTIPOLYGON (((1 9, 5 9, 5 7, 3 7, 3 5, 1 5, 1 9)), ((1 4, 3 4, 3 2, 5 2, 5 0, 1 0, 1 4)), ((6 9, 8 9, 9 5, 8 0, 6 0, 6 2, 8 5, 6 7, 6 9)))
```
**ConcaveHullOfPolygons** - length = 1.1, holes = true:

![image](https://user-images.githubusercontent.com/3529053/172469830-aa1bef65-4fa0-4904-ba5e-14355e842b2b.png)


Signed-off-by: Martin Davis <mtnclimb@gmail.com>