### PR TITLE
Fixes regression in WKTReader.

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
@@ -337,10 +337,10 @@ public class WKTReader
     boolean hasM = ordinateFlags.contains(Ordinate.M);
     if (hasZ && hasM) 
       return new CoordinateXYZM();
+    if (hasM)
+      return new CoordinateXYM();
     if (hasZ || this.isAllowOldJtsCoordinateSyntax) 
       return new Coordinate();
-    if (hasM) 
-      return new CoordinateXYM();
     return new CoordinateXY();
   }
 

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
@@ -89,13 +89,17 @@ public class WKTReaderTest extends GeometryTestCase {
     Point pt2DE = (Point) readerXY.read("POINT EMPTY");
     Point pt3D = (Point) readerXYZ.read("POINT Z(10 10 10)");
     Point pt2DM = (Point) readerXYM.read("POINT M(10 10 11)");
+    Point pt2DM2 = (Point) new WKTReader().read("POINT M(10 10 11)");
     Point pt3DM = (Point) readerXYZM.read("POINT ZM(10 10 10 11)");
 
     // assert
     assertTrue(isEqual(seqPt2D, pt2D.getCoordinateSequence()));
     assertTrue(isEqual(seqPt2DE, pt2DE.getCoordinateSequence()));
     assertTrue(isEqual(seqPt3D, pt3D.getCoordinateSequence()));
+    assertTrue(pt2DM.getCoordinateSequence().hasM());
     assertTrue(isEqual(seqPt2DM, pt2DM.getCoordinateSequence()));
+    assertTrue(pt2DM2.getCoordinateSequence().hasM());
+    assertTrue(isEqual(seqPt2DM, pt2DM2.getCoordinateSequence()));
     assertTrue(isEqual(seqPt3DM, pt3DM.getCoordinateSequence()));
   }
 


### PR DESCRIPTION
https://github.com/locationtech/jts/commit/96e76995 introduced a small change in how geometries like "POINT M (2 0 20))" were read.

This adds a test and (hopefully) fixes the change.