### PR TITLE
Fix PreparedGeometry handling of EMPTY elements

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/ComponentCoordinateExtracter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/ComponentCoordinateExtracter.java
@@ -60,6 +60,8 @@ public class ComponentCoordinateExtracter
 
   public void filter(Geometry geom)
   {
+    if (geom.isEmpty())
+      return;
     // add coordinates from connected components
     if (geom instanceof LineString
         || geom instanceof Point) 

--- a/modules/core/src/main/java/org/locationtech/jts/noding/MCIndexSegmentSetMutualIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/MCIndexSegmentSetMutualIntersector.java
@@ -109,6 +109,8 @@ public class MCIndexSegmentSetMutualIntersector implements SegmentSetMutualInter
 
   private void addToMonoChains(SegmentString segStr, List monoChains)
   {
+    if (segStr.size() == 0)
+      return;
     List segChains = MonotoneChainBuilder.getChains(segStr.getCoordinates(), segStr);
     for (Iterator i = segChains.iterator(); i.hasNext(); ) {
       MonotoneChain mc = (MonotoneChain) i.next();

--- a/modules/core/src/main/java/org/locationtech/jts/noding/MCIndexSegmentSetMutualIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/MCIndexSegmentSetMutualIntersector.java
@@ -68,10 +68,12 @@ public class MCIndexSegmentSetMutualIntersector implements SegmentSetMutualInter
    */
   public SpatialIndex getIndex() { return index; }
 
-  private void initBaseSegments(Collection segStrings)
+  private void initBaseSegments(Collection<SegmentString> segStrings)
   {
-    for (Iterator i = segStrings.iterator(); i.hasNext(); ) {
-      addToIndex((SegmentString) i.next());
+    for (SegmentString ss : segStrings) {
+      if (ss.size() == 0)
+        continue;
+      addToIndex(ss);
     }
     // build index to ensure thread-safety
     index.build();

--- a/modules/core/src/test/java/org/locationtech/jts/geom/prep/PreparedGeometryTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/prep/PreparedGeometryTest.java
@@ -16,8 +16,10 @@ public class PreparedGeometryTest extends GeometryTestCase {
   
   public void testEmptyElement() {
     Geometry geomA = read("MULTIPOLYGON (((9 9, 9 1, 1 1, 2 4, 7 7, 9 9)), EMPTY)");
-    Geometry geomB = read("MULTIPOLYGON (((7 6, 7 3, 4 3, 7 6)))");
+    Geometry geomB = read("MULTIPOLYGON (((7 6, 7 3, 4 3, 7 6)), EMPTY)");
     PreparedGeometry prepA = PreparedGeometryFactory.prepare(geomA);
-    boolean result = prepA.covers(geomB);
+    assertTrue( prepA.covers(geomB));
+    assertTrue( prepA.contains(geomB));
+    assertTrue( prepA.intersects(geomB));
   }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/prep/PreparedGeometryTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/prep/PreparedGeometryTest.java
@@ -1,0 +1,23 @@
+package org.locationtech.jts.geom.prep;
+
+import org.locationtech.jts.geom.Geometry;
+
+import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
+
+public class PreparedGeometryTest extends GeometryTestCase {
+  public static void main(String args[]) {
+    TestRunner.run(PreparedGeometryTest.class);
+  }
+  
+  public PreparedGeometryTest(String name) {
+    super(name);
+  }
+  
+  public void testEmptyElement() {
+    Geometry geomA = read("MULTIPOLYGON (((9 9, 9 1, 1 1, 2 4, 7 7, 9 9)), EMPTY)");
+    Geometry geomB = read("MULTIPOLYGON (((7 6, 7 3, 4 3, 7 6)))");
+    PreparedGeometry prepA = PreparedGeometryFactory.prepare(geomA);
+    boolean result = prepA.covers(geomB);
+  }
+}


### PR DESCRIPTION
Fixes handling of EMPTY elements in `PreparedGeometry` methods, by add empty coordinate sequence guards in several places. 