### PR TITLE
Fix element number estimation when parsing WKB of GEOMETRYCOLLECTION containing empty geometries

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKBReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKBReader.java
@@ -115,9 +115,9 @@ public class WKBReader
 
   private static final String FIELD_NUMCOORDS = "numCoords";
 
-  private static final String FIELD_NUMRINGS = null;
+  private static final String FIELD_NUMRINGS = "numRings";
 
-  private static final String FIELD_NUMELEMS = null;
+  private static final String FIELD_NUMELEMS = "numElems";
 
   private GeometryFactory factory;
   private CoordinateSequenceFactory csFactory;
@@ -156,7 +156,7 @@ public class WKBReader
     // possibly reuse the ByteArrayInStream?
     // don't throw IOExceptions, since we are not doing any I/O
     try {
-      return read(new ByteArrayInStream(bytes), bytes.length / 16);
+      return read(new ByteArrayInStream(bytes), bytes.length / 8);
     }
     catch (IOException ex) {
       throw new RuntimeException("Unexpected IOException caught: " + ex.getMessage());

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKBTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKBTest.java
@@ -109,6 +109,11 @@ public class WKBTest
   {
     runWKBTest("LINESTRING EMPTY");
   }
+  public void testGeometryCollectionContainingEmptyGeometries()
+      throws IOException, ParseException
+  {
+    runWKBTest("GEOMETRYCOLLECTION (LINESTRING EMPTY, MULTIPOINT EMPTY)");
+  }
 
   public void testBigPolygon()
       throws IOException, ParseException


### PR DESCRIPTION
WKBReader will raise `ParseException` when parsing WKB of GeometryCollection containing multiple empty geometries, such as `GEOMETRYCOLLECTION(LINESTRING EMPTY, MULTIPOINT EMPTY)`. The following code reproduces this problem:

```
WKTReader wktReader = new WKTReader();
WKBWriter wkbWriter = new WKBWriter();
WKBReader wkbReader = new WKBReader();
Geometry geom = wktReader.read("GEOMETRYCOLLECTION(LINESTRING EMPTY, MULTIPOINT EMPTY)");
byte[] wkb = wkbWriter.write(geom);
wkbReader.read(wkb);
```

Which yields:

```
Exception in thread "main" org.locationtech.jts.io.ParseException: null value is too large
	at org.locationtech.jts.io.WKBReader.readNumField(WKBReader.java:198)
	at org.locationtech.jts.io.WKBReader.readGeometryCollection(WKBReader.java:385)
	at org.locationtech.jts.io.WKBReader.readGeometry(WKBReader.java:279)
	at org.locationtech.jts.io.WKBReader.read(WKBReader.java:191)
	at org.locationtech.jts.io.WKBReader.read(WKBReader.java:159)
```

This PR fixes this problem by estimating the number of geometries in GeometryCollection in a more conservative manner: the minimal length of a WKB geometry is 9 (1 byte order + 4 WKT type + 4 length), we estimate the number of geometries by dividing the length of WKB buffer by 8 instead of 16.