### PR TITLE
Improve code for finding contained EdgeRings

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Envelope.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Envelope.java
@@ -698,6 +698,20 @@ public class Envelope
   }
 
   /**
+   * Tests if an envelope is properly contained in this one.
+   * The envelope is properly contained if it is contained 
+   * by this one but not equal to it.
+   * 
+   * @param other the envelope to test
+   * @return true if the envelope is properly contained
+   */
+  public boolean containsProperly(Envelope other) {
+    if (equals(other))
+      return false;
+    return covers(other);
+  }
+  
+  /**
    * Tests if the given point lies in or on the envelope.
    *
    *@param  x  the x-coordinate of the point which this <code>Envelope</code> is


### PR DESCRIPTION
This improves the code for finding containing EdgeRings in `Polygonizer` and `OverlayNG`.  The original code was confusing, and inefficient in some cases.

The performance of `Polygonizer` is improved in cases where there are many small islands near a larger polygon, by eliminating a linear scan of the larger polygon vertices.  In the case of polygonizing the merged [`world.wkt`](https://github.com/locationtech/jts/blob/master/modules/core/src/test/resources/testdata/world.wkt) file, performance is improved by almost 50%.

There is not expected to be much performance improvement for OverlayNG, since it is able to avoid testing islands as holes due to more available topology information.

The change is not being made for the old overlay code, since this is obsolete.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>