### PR TITLE
fix(sec): upgrade jdom2 to 2.0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit-version>4.13.1</junit-version>
-        <jdom-version>2.0.6</jdom-version>
+        <jdom-version>2.0.6.1</jdom-version>
         <jump.version>1.2</jump.version>
         <json-simple-version>1.1.1</json-simple-version>
         <sde-version>9.1</sde-version>


### PR DESCRIPTION
Upgrade jdom2 from 2.0.6 to 2.0.6.1 for vulnerability fix:
- [CVE-2021-33813](https://www.oscs1024.com/hd/MPS-2021-8350)