### PR TITLE
Update LineSegment#toString to be consistent with LineString WKT representation

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -18,6 +18,7 @@ import org.locationtech.jts.algorithm.Intersection;
 import org.locationtech.jts.algorithm.LineIntersector;
 import org.locationtech.jts.algorithm.Orientation;
 import org.locationtech.jts.algorithm.RobustLineIntersector;
+import org.locationtech.jts.io.WKTConstants;
 
 
 /**
@@ -696,7 +697,7 @@ public class LineSegment
 
   public String toString()
   {
-    return "LINESTRING( " +
+    return WKTConstants.LINESTRING + " (" +
         p0.x + " " + p0.y
         + ", " +
         p1.x + " " + p1.y + ")";


### PR DESCRIPTION
This fixes a minor inconsistency:
* `LINESTRING (1 2, 3 4)` was produced by `WKTWriter` when serializing `LineString`
* `LINESTRING( 1 2, 3 4)` was produced by `LineSegment#toString`

After this change `LINESTRING (1 2, 3 4)` is produced consistently