### PR TITLE
Fix LineSegment.orientationIndex(LineSegment)

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -159,7 +159,7 @@ public class LineSegment
       return Math.max(orient0, orient1);
     // this handles the case where the points are R or collinear
     if (orient0 <= 0 && orient1 <= 0)
-      return Math.max(orient0, orient1);
+      return Math.min(orient0, orient1);
     // points lie on opposite sides ==> indeterminate orientation
     return 0;
   }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/LineSegmentTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/LineSegmentTest.java
@@ -172,6 +172,8 @@ public class LineSegmentTest extends TestCase {
   	
   	checkOrientationIndex(seg, 200, 200, 210, 210, 0);
   	
+  	checkOrientationIndex(seg, 105, 105, 110, 100, -1);
+  	
   }
   
   void checkOrientationIndex(double x0, double y0, double x1, double y1, double px, double py, 
@@ -197,7 +199,11 @@ public class LineSegmentTest extends TestCase {
   {
   	LineSegment seg2 = new LineSegment(s0x, s0y, s1x, s1y);
   	int orient = seg.orientationIndex(seg2);
-  	assertTrue(orient == expectedOrient);
+  	String msg = "";
+  	if (orient != expectedOrient) {
+  	  msg = "orientationIndex of " + seg + " and " + seg2;
+  	}
+  	assertEquals(msg, expectedOrient, orient);
   }
   
 


### PR DESCRIPTION
Fix `LineSegment.orientationIndex(LineSegment)` to have correct result for the case of a non-collinear segment on the right side of the target segment.

Fixes #893.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>