### PR TITLE
Add OverlayNG support for simple GeometryCollection inputs

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/locate/IndexedPointInAreaLocator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/locate/IndexedPointInAreaLocator.java
@@ -59,15 +59,13 @@ public class IndexedPointInAreaLocator
   
   /**
    * Creates a new locator for a given {@link Geometry}.
-   * {@link Polygonal} and {@link LinearRing} geometries
+   * Geometries containing {@link Polygon}s and {@link LinearRing} geometries
    * are supported.
    * 
    * @param g the Geometry to locate in
    */
   public IndexedPointInAreaLocator(Geometry g)
   {
-    if (! (g instanceof Polygonal  || g instanceof LinearRing))
-      throw new IllegalArgumentException("Argument must be Polygonal or LinearRing");
     geom = g;
   }
     
@@ -144,6 +142,10 @@ public class IndexedPointInAreaLocator
       List lines = LinearComponentExtracter.getLines(geom);
       for (Iterator i = lines.iterator(); i.hasNext(); ) {
         LineString line = (LineString) i.next();
+        //-- only include rings of Polygons or LinearRings
+        if (! line.isClosed())
+          continue;
+        
         Coordinate[] pts = line.getCoordinates();
         addLine(pts);
       }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayMixedPoints.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayMixedPoints.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import org.locationtech.jts.algorithm.locate.IndexedPointInAreaLocator;
 import org.locationtech.jts.algorithm.locate.PointOnGeometryLocator;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateFilter;
 import org.locationtech.jts.geom.CoordinateList;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -217,13 +218,15 @@ class OverlayMixedPoints {
   
   private static Coordinate[] extractCoordinates(Geometry points, PrecisionModel pm) {
     CoordinateList coords = new CoordinateList();
-    int n = points.getNumGeometries();
-    for (int i = 0; i < n; i++) {
-      Point point = (Point) points.getGeometryN(i);
-      if (point.isEmpty()) continue;
-      Coordinate coord = OverlayUtil.round(point, pm);
-      coords.add(coord, true);
-    }
+    points.apply(new CoordinateFilter() {
+
+      @Override
+      public void filter(Coordinate coord) {
+        Coordinate p = OverlayUtil.round(coord, pm);
+        coords.add(p, false);
+      }
+      
+    });
     return coords.toCoordinateArray();
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayNG.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayNG.java
@@ -44,6 +44,9 @@ import org.locationtech.jts.operation.overlay.OverlayOp;
  * </ul>
  * Input geometries may have different dimension.  
  * Input collections must be homogeneous (all elements must have the same dimension).
+ * Inputs may be <b>simple</b> {@link GeometryCollection}s.
+ * A GeometryCollection is simple if it can be flattened into a valid Multi-geometry;
+ * i.e. it is homogeneous and does not contain any overlapping Polygons.  
  * <p>
  * The precision model used for the computation can be supplied 
  * independent of the precision model of the input geometry.

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayUtil.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayUtil.java
@@ -351,9 +351,21 @@ class OverlayUtil {
    */
   public static Coordinate round(Point pt, PrecisionModel pm) {
     if (pt.isEmpty()) return null;
-    Coordinate p = pt.getCoordinate().copy();
+    return round( pt.getCoordinate(), pm );
+  }
+  
+  /**
+   * Rounds a coordinate if precision model is fixed.
+   * Note: return value is only copied if rounding is performed.
+   * 
+   * @param p the coordinate to round
+   * @return the rounded coordinate
+   */
+  public static Coordinate round(Coordinate p, PrecisionModel pm) {
     if (! isFloating(pm)) {
-      pm.makePrecise(p);
+      Coordinate pRound = p.copy();
+      pm.makePrecise(pRound);
+      return pRound;
     }
     return p;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/package-info.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/package-info.java
@@ -44,6 +44,9 @@
  * <li>Input geometries may have different dimension.</li>
  * <li>Collections must be homogeneous
  * (all elements must have the same dimension).</li>
+ * <li>Inputs may be <b>simple</b> {@link GeometryCollection}s.
+ * A GeometryCollection is simple if it can be flattened into a valid Multi-geometry;
+ * i.e. it is homogeneous and does not contain any overlapping Polygons.</li>  
  * <li>In general, inputs must be valid geometries.</li>
  * <li>However, polygonal inputs may contain the following two kinds of "mild" invalid topology:
  * <ul>

--- a/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGGeometryCollectionTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGGeometryCollectionTest.java
@@ -1,0 +1,84 @@
+package org.locationtech.jts.operation.overlayng;
+
+import junit.textui.TestRunner;
+
+/**
+ * Tests supported OverlayNG semantics for GeometryCollection inputs.
+ * 
+ * Note: currently only "simple" GCs are supported.
+ * Simple GCs are ones which can be flattened to a valid Multi-geometry.
+ * 
+ * @author mdavis
+ *
+ */
+public class OverlayNGGeometryCollectionTest extends OverlayNGTestCase {
+  
+  public static void main(String args[]) {
+    TestRunner.run(OverlayNGGeometryCollectionTest.class);
+  }
+
+  public OverlayNGGeometryCollectionTest(String name) { super(name); }
+  
+  public void testSimpleA_mP() {
+    String a = "POLYGON ((0 0, 0 1, 1 1, 0 0))";
+    String b = "GEOMETRYCOLLECTION ( MULTIPOINT ((0 0), (99 99)) )";
+    checkIntersection(a, b, 
+        "POINT (0 0)");
+    checkUnion(a, b, 
+        "GEOMETRYCOLLECTION (POINT (99 99), POLYGON ((0 0, 0 1, 1 1, 0 0)))");
+  }
+  
+  public void testSimpleP_mP() {
+    String a = "POINT(0 0)";
+    String b = "GEOMETRYCOLLECTION ( MULTIPOINT ((0 0), (99 99)) )";
+    checkIntersection(a, b, 
+        "POINT (0 0)");
+    checkUnion(a, b, 
+        "MULTIPOINT ((0 0), (99 99))");
+  }
+  
+  public void testSimpleP_mL() {
+    String a = "POINT(5 5)";
+    String b = "GEOMETRYCOLLECTION ( MULTILINESTRING ((1 9, 9 1), (1 1, 9 9)) )";
+    checkIntersection(a, b, 
+        "POINT (5 5)");
+    checkUnion(a, b, 
+        "MULTILINESTRING ((1 1, 5 5), (1 9, 5 5), (5 5, 9 1), (5 5, 9 9))");
+  }
+  
+  public void testSimpleP_mA() {
+    String a = "POINT(5 5)";
+    String b = "GEOMETRYCOLLECTION ( MULTIPOLYGON (((1 1, 1 5, 5 5, 5 1, 1 1)), ((9 9, 9 5, 5 5, 5 9, 9 9))) )";
+    checkIntersection(a, b, 
+        "POINT (5 5)");
+    checkUnion(a, b, 
+        "MULTIPOLYGON (((1 1, 1 5, 5 5, 5 1, 1 1)), ((9 9, 9 5, 5 5, 5 9, 9 9)))");
+  }
+  
+  public void testSimpleP_AA() {
+    String a = "POINT(5 5)";
+    String b = "GEOMETRYCOLLECTION ( POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1)), POLYGON ((9 9, 9 5, 5 5, 5 9, 9 9)) )";
+    checkIntersection(a, b, 
+        "POINT (5 5)");
+    checkUnion(a, b, 
+        "MULTIPOLYGON (((1 1, 1 5, 5 5, 5 1, 1 1)), ((9 9, 9 5, 5 5, 5 9, 9 9)))");
+  }
+  
+  public void testSimpleL_AA() {
+    String a = "LINESTRING (0 0, 10 10)";
+    String b = "GEOMETRYCOLLECTION ( POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1)), POLYGON ((9 9, 9 5, 5 5, 5 9, 9 9)) )";
+    checkIntersection(a, b, 
+        "MULTILINESTRING ((1 1, 5 5), (5 5, 9 9))");
+    checkUnion(a, b, 
+        "GEOMETRYCOLLECTION (LINESTRING (0 0, 1 1), LINESTRING (9 9, 10 10), POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1)), POLYGON ((5 5, 5 9, 9 9, 9 5, 5 5)))");
+  }
+  
+  public void testSimpleA_AA() {
+    String a = "POLYGON ((2 8, 8 8, 8 2, 2 2, 2 8))";
+    String b = "GEOMETRYCOLLECTION ( POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1)), POLYGON ((9 9, 9 5, 5 5, 5 9, 9 9)) )";
+    checkIntersection(a, b, 
+        "MULTIPOLYGON (((2 2, 2 5, 5 5, 5 2, 2 2)), ((5 5, 5 8, 8 8, 8 5, 5 5)))");
+    checkUnion(a, b, 
+        "POLYGON ((1 1, 1 5, 2 5, 2 8, 5 8, 5 9, 9 9, 9 5, 8 5, 8 2, 5 2, 5 1, 1 1))");
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGTestCase.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGTestCase.java
@@ -1,0 +1,33 @@
+package org.locationtech.jts.operation.overlayng;
+
+import static org.locationtech.jts.operation.overlayng.OverlayNG.INTERSECTION;
+import static org.locationtech.jts.operation.overlayng.OverlayNG.UNION;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.PrecisionModel;
+
+import test.jts.GeometryTestCase;
+
+class OverlayNGTestCase extends GeometryTestCase {
+  
+  protected OverlayNGTestCase(String name) {
+    super(name);
+  }
+
+  protected void checkIntersection(String wktA, String wktB, String wktExpected) {
+    checkOverlay(wktA, wktB, INTERSECTION, wktExpected);
+  }
+  
+  protected void checkUnion(String wktA, String wktB, String wktExpected) {
+    checkOverlay(wktA, wktB, UNION, wktExpected);
+  }
+  
+  protected void checkOverlay(String wktA, String wktB, int overlayOp, String wktExpected) {
+    Geometry a = read(wktA);
+    Geometry b = read(wktB);
+    PrecisionModel pm = new PrecisionModel();
+    Geometry actual = OverlayNG.overlay(a, b, overlayOp, pm);
+    Geometry expected = read(wktExpected);
+    checkEqual(expected, actual);
+  }
+}


### PR DESCRIPTION
Adds support for **simple** `GeometryCollection` inputs to OverlayNG.

A simple GeometryCollection is one which can be flattened to a valid Multi-geometry; i.e. it is homogeneous and has no overlapping Polygon compents.
 
Signed-off-by: Martin Davis <mtnclimb@gmail.com>