### PR TITLE
Improve ConvexHull radial sort robustness

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Vivid Solutions.
+ * Copyright (c) 2022 Martin Davis.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +15,8 @@ package org.locationtech.jts.algorithm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
 
@@ -101,7 +104,7 @@ public class ConvexHull
     Coordinate[] sortedPts = preSort(reducedPts);
 
     // Use Graham scan to find convex hull.
-    Stack cHS = grahamScan(sortedPts);
+    Stack<Coordinate> cHS = grahamScan(sortedPts);
 
     // Convert stack to an array.
     Coordinate[] cH = toCoordinateArray(cHS);
@@ -114,7 +117,7 @@ public class ConvexHull
    * An alternative to Stack.toArray, which is not present in earlier versions
    * of Java.
    */
-  protected Coordinate[] toCoordinateArray(Stack stack) {
+  protected Coordinate[] toCoordinateArray(Stack<Coordinate> stack) {
     Coordinate[] coordinates = new Coordinate[stack.size()];
     for (int i = 0; i < stack.size(); i++) {
       Coordinate coordinate = (Coordinate) stack.get(i);
@@ -156,7 +159,7 @@ public class ConvexHull
 //    System.out.println(ring);
 
     // add points defining polygon
-    TreeSet reducedSet = new TreeSet();
+    Set<Coordinate> reducedSet = new TreeSet<Coordinate>();
     for (int i = 0; i < polyPts.length; i++) {
       reducedSet.add(polyPts[i]);
     }
@@ -209,7 +212,6 @@ public class ConvexHull
     // sort the points radially around the focal point.
     Arrays.sort(pts, 1, pts.length, new RadialComparator(pts[0]));
 
-    //radialSort(pts);
     return pts;
   }
 
@@ -219,22 +221,23 @@ public class ConvexHull
    * @param c a list of points, with at least 3 entries
    * @return a Stack containing the ordered points of the convex hull ring
    */
-  private Stack grahamScan(Coordinate[] c) {
+  private Stack<Coordinate> grahamScan(Coordinate[] c) {
     Coordinate p;
-    Stack ps = new Stack();
+    Stack<Coordinate> ps = new Stack<Coordinate>();
     ps.push(c[0]);
     ps.push(c[1]);
     ps.push(c[2]);
     for (int i = 3; i < c.length; i++) {
+      Coordinate cp = c[i];
       p = (Coordinate) ps.pop();
       // check for empty stack to guard against robustness problems
       while (
           ! ps.empty() && 
-          Orientation.index((Coordinate) ps.peek(), p, c[i]) > 0) {
-        p = (Coordinate) ps.pop();
+          Orientation.index((Coordinate) ps.peek(), p, cp) > 0) {
+         p = (Coordinate) ps.pop();
       }
       ps.push(p);
-      ps.push(c[i]);
+      ps.push(cp);
     }
     ps.push(c[0]);
     return ps;
@@ -316,66 +319,6 @@ public class ConvexHull
 
   }
 
-/*
-  // MD - no longer used, but keep for reference purposes
-  private Coordinate[] computeQuad(Coordinate[] inputPts) {
-    BigQuad bigQuad = bigQuad(inputPts);
-
-    // Build a linear ring defining a big poly.
-    ArrayList bigPoly = new ArrayList();
-    bigPoly.add(bigQuad.westmost);
-    if (! bigPoly.contains(bigQuad.northmost)) {
-      bigPoly.add(bigQuad.northmost);
-    }
-    if (! bigPoly.contains(bigQuad.eastmost)) {
-      bigPoly.add(bigQuad.eastmost);
-    }
-    if (! bigPoly.contains(bigQuad.southmost)) {
-      bigPoly.add(bigQuad.southmost);
-    }
-    // points must all lie in a line
-    if (bigPoly.size() < 3) {
-      return null;
-    }
-    // closing point
-    bigPoly.add(bigQuad.westmost);
-
-    Coordinate[] bigPolyArray = CoordinateArrays.toCoordinateArray(bigPoly);
-
-    return bigPolyArray;
-  }
-
-  private BigQuad bigQuad(Coordinate[] pts) {
-    BigQuad bigQuad = new BigQuad();
-    bigQuad.northmost = pts[0];
-    bigQuad.southmost = pts[0];
-    bigQuad.westmost = pts[0];
-    bigQuad.eastmost = pts[0];
-    for (int i = 1; i < pts.length; i++) {
-      if (pts[i].x < bigQuad.westmost.x) {
-        bigQuad.westmost = pts[i];
-      }
-      if (pts[i].x > bigQuad.eastmost.x) {
-        bigQuad.eastmost = pts[i];
-      }
-      if (pts[i].y < bigQuad.southmost.y) {
-        bigQuad.southmost = pts[i];
-      }
-      if (pts[i].y > bigQuad.northmost.y) {
-        bigQuad.northmost = pts[i];
-      }
-    }
-    return bigQuad;
-  }
-
-  private static class BigQuad {
-    public Coordinate northmost;
-    public Coordinate southmost;
-    public Coordinate westmost;
-    public Coordinate eastmost;
-  }
-  */
-
   /**
    *@param  vertices  the vertices of a linear ring, which may or may not be
    *      flattened (i.e. vertices collinear)
@@ -403,7 +346,7 @@ public class ConvexHull
    */
   private Coordinate[] cleanRing(Coordinate[] original) {
     Assert.equals(original[0], original[original.length - 1]);
-    ArrayList cleanedRing = new ArrayList();
+    List<Coordinate> cleanedRing = new ArrayList<Coordinate>();
     Coordinate previousDistinctCoordinate = null;
     for (int i = 0; i <= original.length - 2; i++) {
       Coordinate currentCoordinate = original[i];
@@ -427,24 +370,37 @@ public class ConvexHull
   /**
    * Compares {@link Coordinate}s for their angle and distance
    * relative to an origin.
+   * The origin is assumed to be lower than
+   * all other point inputs.
    *
    * @author Martin Davis
    * @version 1.7
    */
   private static class RadialComparator
-      implements Comparator
+      implements Comparator<Coordinate>
   {
     private Coordinate origin;
 
+    /**
+     * Creates a new comparator using a given origin.
+     * The origin must be less than or equal to all 
+     * compared points,
+     * using {@link Coordinate#compareTo(Coordinate)}.
+     * 
+     * @param origin the origin of the radial comparison
+     */
     public RadialComparator(Coordinate origin)
     {
       this.origin = origin;
     }
-    public int compare(Object o1, Object o2)
+    
+    @Override
+    public int compare(Coordinate o1, Coordinate o2)
     {
       Coordinate p1 = (Coordinate) o1;
       Coordinate p2 = (Coordinate) o2;
-      return polarCompare(origin, p1, p2);
+      int comp = polarCompare(origin, p1, p2);      
+      return comp;
     }
 
     /**
@@ -467,41 +423,39 @@ public class ConvexHull
      */
     private static int polarCompare(Coordinate o, Coordinate p, Coordinate q)
     {
-      double dxp = p.x - o.x;
-      double dyp = p.y - o.y;
-      double dxq = q.x - o.x;
-      double dyq = q.y - o.y;
-
-/*
-      // MD - non-robust
-      int result = 0;
-      double alph = Math.atan2(dxp, dyp);
-      double beta = Math.atan2(dxq, dyq);
-      if (alph < beta) {
-        result = -1;
-      }
-      if (alph > beta) {
-        result = 1;
-      }
-      if (result !=  0) return result;
-      //*/
-
       int orient = Orientation.index(o, p, q);
-
       if (orient == Orientation.COUNTERCLOCKWISE) return 1;
       if (orient == Orientation.CLOCKWISE) return -1;
 
-      // points are collinear - check distance
-      double op = dxp * dxp + dyp * dyp;
-      double oq = dxq * dxq + dyq * dyq;
-      if (op < oq) {
-        return -1;
-      }
-      if (op > oq) {
+      /** 
+       * The points are collinear,
+       * so compare based on distance from the origin.  
+       * The points p and q are >= to the origin,
+       * so they lie in the closed half-plane to the right of the origin.
+       * If they are not in a vertical line, 
+       * the X ordinate can be tested to determine distance.
+       * This is more robust than computing the distance explicitly.
+       */
+      if (p.x > q.x) {
         return 1;
       }
+      if (p.x < q.x) {
+        return -1;
+      }
+      /**
+       * The points lie in a vertical line, which should also contain the origin
+       * (since they are collinear).
+       * Also, they must be above the origin.
+       * Use the Y ordinate to determine distance. 
+       */
+      if (p.y > q.y) {
+        return 1;
+      }
+      if (p.y < q.y) {
+        return -1;
+      }
+      // Assert: p = q
       return 0;
     }
-
   }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016 Vivid Solutions.
- * Copyright (c) 2022 Martin Davis.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/ConvexHullTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/ConvexHullTest.java
@@ -23,9 +23,9 @@ import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.io.WKTReader;
 
 import junit.framework.Test;
-import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
 
 
 
@@ -34,7 +34,7 @@ import junit.textui.TestRunner;
  *
  * @version 1.7
  */
-public class ConvexHullTest extends TestCase {
+public class ConvexHullTest extends GeometryTestCase {
 
   PrecisionModel precisionModel = new PrecisionModel(1000);
   GeometryFactory geometryFactory = new GeometryFactory(precisionModel, 0);
@@ -141,6 +141,26 @@ public class ConvexHullTest extends TestCase {
     assertTrue(convexHull.equalsExact(geometry.convexHull()));
   }
 
+  public void testCollinearPoints() throws Exception {
+    checkConvexHull("MULTIPOINT ((-0.2 -0.1), (0 -0.1), (0.2 -0.1), (0 -0.1), (-0.2 0.1), (0 0.1), (0.2 0.1), (0 0.1))",
+        "POLYGON ((-0.2 -0.1, -0.2 0.1, 0.2 0.1, 0.2 -0.1, -0.2 -0.1))");
+  }
 
+  public void testCollinearPointsTinyX() throws Exception {
+    checkConvexHull("MULTIPOINT (-0.2 -0.1, 1.38777878e-17 -0.1, 0.2 -0.1, -1.38777878e-17 -0.1, -0.2 0.1, 1.38777878e-17 0.1, 0.2 0.1, -1.38777878e-17 0.1)",
+        "POLYGON ((-0.2 -0.1, -0.2 0.1, 0.2 0.1, 0.2 -0.1, -0.2 -0.1))");
+  }
+
+  public void testCollinearPointsTinyXAlt() throws Exception {
+    checkConvexHull("MULTIPOINT (-0.2 -0.1, 1.38777878e-7 -0.1, 0.2 -0.1, -1.38777878e-7 -0.1, -0.2 0.1, 1.38777878e-7 0.1, 0.2 0.1, -1.38777878e-7 0.1)",
+        "POLYGON ((-0.2 -0.1, -0.2 0.1, 0.2 0.1, 0.2 -0.1, -0.2 -0.1))");
+  }
+
+  private void checkConvexHull(String wkt, String wktExpected) {
+    Geometry geom = read(wkt);
+    Geometry actual = geom.convexHull();
+    Geometry expected = read(wktExpected);
+    checkEqual(expected, actual);
+  }
 
 }


### PR DESCRIPTION
Improves the robustness of the radial sorting used by the `ConvexHull` Graham scan algorithm.

This fixes a failure case reported in GEOS: https://github.com/libgeos/geos/issues/722.

The case is 
```
MULTIPOINT (-0.2 -0.1, 1.38777878e-17 -0.1, 0.2 -0.1, -1.38777878e-17 -0.1, -0.2 0.1, 1.38777878e-17 0.1, 0.2 0.1, -1.38777878e-17 0.1)
```
The case contains points which are extremely close (below the precision of double-precision floating point).  This caused the old code to fail, since it was unable to robustly compute a different distance for the close points, and thus sorted the points incorrectly.  This in turn caused an incorrect result from the Graham Scan algorithm:
![image](https://user-images.githubusercontent.com/3529053/199797619-91d3f81a-b601-4cfd-9445-abd428df7623.png)

The fix is to use a more robust way of computing relative distance for the radial sort.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>