### PR TITLE
Skip redundant calculation in the DistanceOp point-linesegment

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -505,9 +505,23 @@ public class LineSegment
    */
   public Coordinate closestPoint(Coordinate p)
   {
+    return closestPoint(p, false);
+  }
+  
+  /**
+   * Computes the closest point on this line segment to another point.
+   * @param p the point to find the closest point to
+   * @param skip0 If true, do not check p0. Client will have determined this is redundant.
+   * @return a Coordinate which is the closest point on the line segment to the point p
+   */
+  public Coordinate closestPoint(Coordinate p, boolean skip0)
+  {
     double factor = projectionFactor(p);
     if (factor > 0 && factor < 1) {
       return project(p, factor);
+    }
+    if (skip0) {
+    	return p1;
     }
     double dist0 = p0.distance(p);
     double dist1 = p1.distance(p);
@@ -515,6 +529,7 @@ public class LineSegment
       return p0;
     return p1;
   }
+  
   /**
    * Computes the closest points on two line segments.
    * 

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance/DistanceOp.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance/DistanceOp.java
@@ -428,7 +428,7 @@ public class DistanceOp
         if (dist < minDistance) {
           minDistance = dist;
           LineSegment seg = new LineSegment(coord0[i], coord0[i + 1]);
-          Coordinate segClosestPoint = seg.closestPoint(coord);
+          Coordinate segClosestPoint = seg.closestPoint(coord, i > 0);
           locGeom[0] = new GeometryLocation(line, i, segClosestPoint);
           locGeom[1] = new GeometryLocation(pt, 0, coord);
         }


### PR DESCRIPTION
In the distance calculation for a point and a series of linesegments, if each successive linesegment is closer to the point, the intermediate Coordinate distance calculation is potentially repeated.

A-B-C-D vs pt repeats the B-pt and C-pt distance calculation.

Added a boolean to tell the LineSegment.closestPoint method to skip the redundancy.