### PR TITLE
More robust Delaunay Triangulation frame size heuristic

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
@@ -60,7 +60,8 @@ import org.locationtech.jts.io.WKTWriter;
  * @author Martin Davis
  */
 public class QuadEdgeSubdivision {
-	/**
+
+  /**
 	 * Gets the edges for the triangle to the left of the given {@link QuadEdge}.
 	 * 
 	 * @param startQE
@@ -78,6 +79,8 @@ public class QuadEdgeSubdivision {
 	}
 
 	private final static double EDGE_COINCIDENCE_TOL_FACTOR = 1000;
+	
+  private static final double FRAME_SIZE_FACTOR = 100.0;
 
 	// debugging only - preserve current subdiv statically
 	// private static QuadEdgeSubdivision currentSubdiv;
@@ -114,22 +117,29 @@ public class QuadEdgeSubdivision {
 		locator = new LastFoundQuadEdgeLocator(this);
 	}
 
+	/**
+	 * Creates a triangular frame which contains the vertices to be triangulated.
+	 * <p>
+	 * The frame must be large enough so that its vertices are not in the circumcircle
+	 * of any constructed triangle.  
+	 * This ensures that the vertices of the frame do not prevent the convex hull
+	 * of the input vertices from forming edges of the triangulation.
+	 * This is done by using a heuristic size 
+	 * of the frame.  However, it may be that this is not fully robust, 
+	 * for input points which contain very narry triangles.
+	 * 
+	 * @param env the envelope of the input points
+	 */
 	private void createFrame(Envelope env)
 	{
 		double deltaX = env.getWidth();
 		double deltaY = env.getHeight();
-		double offset = 0.0;
-		if (deltaX > deltaY) {
-			offset = deltaX * 10.0;
-		} else {
-			offset = deltaY * 10.0;
-		}
+		double frameSize = Math.max(deltaX, deltaY) * FRAME_SIZE_FACTOR;
 
-		frameVertex[0] = new Vertex((env.getMaxX() + env.getMinX()) / 2.0, env
-				.getMaxY()
-				+ offset);
-		frameVertex[1] = new Vertex(env.getMinX() - offset, env.getMinY() - offset);
-		frameVertex[2] = new Vertex(env.getMaxX() + offset, env.getMinY() - offset);
+		frameVertex[0] = new Vertex((env.getMaxX() + env.getMinX()) / 2.0, 
+		                              env.getMaxY()	+ frameSize);
+		frameVertex[1] = new Vertex(env.getMinX() - frameSize, env.getMinY() - frameSize);
+		frameVertex[2] = new Vertex(env.getMaxX() + frameSize, env.getMinY() - frameSize);
 
 		frameEnv = new Envelope(frameVertex[0].getCoordinate(), frameVertex[1]
 				.getCoordinate());

--- a/modules/core/src/test/java/org/locationtech/jts/triangulate/DelaunayTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/triangulate/DelaunayTest.java
@@ -80,6 +80,14 @@ public class DelaunayTest extends TestCase {
     runDelaunayEdges(wkt, expected);
   }
   
+  public void testFrameTooSmallBug()
+  throws ParseException
+  {
+    String wkt = "MULTIPOINT ((0 194), (66 151), (203 80), (273 43), (340 0))";
+    String expected = "GEOMETRYCOLLECTION (POLYGON ((0 194, 66 151, 203 80, 0 194)), POLYGON ((0 194, 203 80, 273 43, 0 194)), POLYGON ((273 43, 203 80, 340 0, 273 43)), POLYGON ((340 0, 203 80, 66 151, 340 0)))";
+    runDelaunay(wkt, true, expected);
+  }
+  
 	static final double COMPARISON_TOLERANCE = 1.0e-7;
 	
   void runDelaunayEdges(String sitesWKT, String expectedWKT)

--- a/modules/core/src/test/java/org/locationtech/jts/triangulate/VoronoiTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/triangulate/VoronoiTest.java
@@ -12,10 +12,8 @@
 package org.locationtech.jts.triangulate;
 
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.math.DD;
-import org.locationtech.jts.triangulate.quadedge.QuadEdgeSubdivision;
 
 import junit.textui.TestRunner;
 import test.jts.GeometryTestCase;
@@ -36,7 +34,7 @@ public class VoronoiTest extends GeometryTestCase {
   throws ParseException
   {
     String wkt = "MULTIPOINT ((10 10), (20 70), (60 30), (80 70))";
-    String expected = "GEOMETRYCOLLECTION (POLYGON ((-1162.076359832636 462.66344142259413, 50 419.375, 50 60, 27.857142857142854 37.857142857142854, -867 187, -1162.076359832636 462.66344142259413)), POLYGON ((-867 187, 27.857142857142854 37.857142857142854, 245 -505, 45 -725, -867 187)), POLYGON ((27.857142857142854 37.857142857142854, 50 60, 556.6666666666666 -193.33333333333331, 245 -505, 27.857142857142854 37.857142857142854)), POLYGON ((50 60, 50 419.375, 1289.1616314199396 481.3330815709969, 556.6666666666666 -193.33333333333331, 50 60)))";
+    String expected = "GEOMETRYCOLLECTION (POLYGON ((-82.19544457292888 56.1992407621548, -82.19544457292888 162.19544457292886, 50 162.19544457292886, 50 60, 27.857142857142858 37.857142857142854, -82.19544457292888 56.1992407621548)), POLYGON ((-82.19544457292888 -82.19544457292888, -82.19544457292888 56.1992407621548, 27.857142857142858 37.857142857142854, 75.87817782917156 -82.19544457292888, -82.19544457292888 -82.19544457292888)), POLYGON ((172.19544457292886 -1.0977222864644354, 172.19544457292886 -82.19544457292888, 75.87817782917156 -82.19544457292888, 27.857142857142858 37.857142857142854, 50 60, 172.19544457292886 -1.0977222864644354)), POLYGON ((50 162.19544457292886, 172.19544457292886 162.19544457292886, 172.19544457292886 -1.0977222864644354, 50 60, 50 162.19544457292886)))";
     runVoronoi(wkt, true, expected);
   }
   
@@ -63,19 +61,10 @@ public class VoronoiTest extends GeometryTestCase {
   void runVoronoi(String sitesWKT, boolean computePolys, String expectedWKT)
   {
   	Geometry sites = read(sitesWKT);
-  	DelaunayTriangulationBuilder builder = new DelaunayTriangulationBuilder();
+  	VoronoiDiagramBuilder builder = new VoronoiDiagramBuilder();
   	builder.setSites(sites);
   	
-    QuadEdgeSubdivision subdiv = builder.getSubdivision();
-    
-  	GeometryFactory geomFact = new GeometryFactory();
-  	Geometry result = null;
-  	if (computePolys) {
-  		result = subdiv.getVoronoiDiagram(geomFact);	
-  	}
-  	else {
-  		//result = builder.getEdges(geomFact);
-  	}
+  	Geometry result = builder.getDiagram(sites.getFactory()); 
  	
   	assertTrue("Found invalid geometry(s) in Voronoi result", result.isValid() );
   	


### PR DESCRIPTION
Increases the size of the "frame" used to initialize the Incremental Delaunay Triangulation subdivision.  This improves the robustness of constructing triangulations which contain very narrow triangles along the edge of the subdivision.

Originally reported as a failure in the Concave Hull algorithm in https://github.com/libgeos/geos/issues/719.  The failure was caused by the constructed triangulation failing to contain triangles which covered the convex hull of the input.

Signed-off-by: Martin Davis <mtnclimb@gmail.com>