### PR TITLE
Fix silent dimension addition of WKTReader when allowing old syntax

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
@@ -214,11 +214,11 @@ public class RobustLineIntersector
     if (! Double.isNaN(z)) {
       pCopy.setZ( z );
     }
-    return pCopy;    
+    return pCopy;
   }
   
   private static Coordinate copy(Coordinate p) {
-    return new Coordinate(p);    
+    return p.copy();
   }
   
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
@@ -307,7 +307,50 @@ public class WKTReader
       tokenizer.nextToken();
       opened = true;
     }
-    
+
+    // Read x- and y- ordinates
+    double x = precisionModel.makePrecise(getNextNumber(tokenizer));
+    double y = precisionModel.makePrecise(getNextNumber(tokenizer));
+
+    // Coordinate type
+    EnumSet<Ordinate> readOrdinates = Ordinate.createXY();
+
+    // additionally read other vertices
+    double z = Coordinate.NULL_ORDINATE, m = 0d;
+    if (ordinateFlags.contains(Ordinate.Z))
+    {
+      z = getNextNumber(tokenizer);
+      readOrdinates.add(Ordinate.Z);
+    }
+
+    if (ordinateFlags.contains(Ordinate.M))
+    {
+      m = getNextNumber(tokenizer);
+      readOrdinates.add(Ordinate.M);
+    }
+
+    if (ordinateFlags.size() == 2 && isAllowOldJtsCoordinateSyntax && isNumberNext(tokenizer))
+    {
+      z = getNextNumber(tokenizer);
+      readOrdinates.add(Ordinate.Z);
+    }
+
+    Coordinate coord;
+
+    if(readOrdinates.size() == 2) {
+      coord = new CoordinateXY(x, y);
+    } else if(readOrdinates.size() == 4) {
+      coord = new CoordinateXYZM(x, y, z, m);
+    } else if(readOrdinates.size() == 3){
+      if(readOrdinates.contains(Ordinate.Z))
+        coord = new Coordinate(x, y, z);
+      else
+        coord = new CoordinateXYM(x, y, m);
+    } else{
+      throw new ParseException("Unknown ordinate read: {readOrdinates}");
+    }
+
+    /*
     // create a sequence for one coordinate
     int offsetM = ordinateFlags.contains(Ordinate.Z) ? 1 : 0;
     Coordinate coord = createCoordinate(ordinateFlags);
@@ -323,7 +366,8 @@ public class WKTReader
     if (ordinateFlags.size() == 2 && this.isAllowOldJtsCoordinateSyntax && isNumberNext(tokenizer)) {
       coord.setOrdinate(CoordinateSequence.Z, getNextNumber(tokenizer));
     }
-    
+    */
+
     // read close token if it was opened here
     if (opened) {
       getNextCloser(tokenizer);
@@ -339,7 +383,7 @@ public class WKTReader
       return new CoordinateXYZM();
     if (hasM)
       return new CoordinateXYM();
-    if (hasZ || this.isAllowOldJtsCoordinateSyntax) 
+    if (hasZ)
       return new Coordinate();
     return new CoordinateXY();
   }

--- a/modules/core/src/main/java/org/locationtech/jts/noding/NodedSegmentString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/NodedSegmentString.java
@@ -164,7 +164,7 @@ public class NodedSegmentString
    */
   public void addIntersection(LineIntersector li, int segmentIndex, int geomIndex, int intIndex)
   {
-    Coordinate intPt = new Coordinate(li.getIntersection(intIndex));
+    Coordinate intPt = li.getIntersection(intIndex).copy();
     addIntersection(intPt, segmentIndex);
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNode.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNode.java
@@ -31,7 +31,7 @@ public class SegmentNode
 
   public SegmentNode(NodedSegmentString segString, Coordinate coord, int segmentIndex, int segmentOctant) {
     this.segString = segString;
-    this.coord = new Coordinate(coord);
+    this.coord = coord.copy();
     this.segmentIndex = segmentIndex;
     this.segmentOctant = segmentOctant;
     isInterior = ! coord.equals2D(segString.getCoordinate(segmentIndex));

--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentNodeList.java
@@ -255,11 +255,11 @@ public class SegmentNodeList
 
     Coordinate[] pts = new Coordinate[npts];
     int ipt = 0;
-    pts[ipt++] = new Coordinate(ei0.coord);
+    pts[ipt++] = ei0.coord.copy();
     for (int i = ei0.segmentIndex + 1; i <= ei1.segmentIndex; i++) {
       pts[ipt++] = edge.getCoordinate(i);
     }
-    if (useIntPt1) pts[ipt] = new Coordinate(ei1.coord);
+    if (useIntPt1) pts[ipt] = ei1.coord.copy();
     return pts;
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurveBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurveBuilder.java
@@ -163,7 +163,7 @@ public class OffsetCurveBuilder
   {
     Coordinate[] copy = new Coordinate[pts.length];
     for (int i = 0; i < copy.length; i++) {
-      copy[i] = new Coordinate(pts[i]);
+      copy[i] = pts[i].copy();
     }
     return copy;
   }
@@ -177,7 +177,7 @@ public class OffsetCurveBuilder
    * Computes the distance tolerance to use during input
    * line simplification.
    * 
-   * @param distance the buffer distance
+   * @param bufDistance the buffer distance
    * @return the simplification tolerance
    */
   private double simplifyTolerance(double bufDistance)

--- a/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryFixerTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryFixerTest.java
@@ -12,10 +12,12 @@
 package org.locationtech.jts.geom.util;
 
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateArrays;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 
 import junit.textui.TestRunner;
+import org.locationtech.jts.io.WKTReader;
 import test.jts.GeometryTestCase;
 
 public class GeometryFixerTest extends GeometryTestCase {
@@ -344,7 +346,26 @@ public class GeometryFixerTest extends GeometryTestCase {
     checkFix("POLYGON ((50.69544005538049 4.587126197745181, 50.699035986722194 4.592752502415541, 50.699395579856365 4.592049214331746, 50.699125885005735 4.590501980547397, 50.69867639358802 4.591064611014433, 50.69795720731968 4.591064611014433, 50.69759761418551 4.590501980547397, 50.69759761418551 4.589376719613325, 50.69831680045385 4.588251458679252, 50.69723802105134 4.586563567278144, 50.69579964851466 4.586563567278144, 50.69544005538049 4.587126197745181))");
   }
 
-  
+  //----------------------------------------
+  public void testDimensionConsistence(){
+    // test 2d case
+    WKTReader reader = new WKTReader();
+    reader.setIsOldJtsCoordinateSyntaxAllowed(false);
+    Geometry geom2d = read(reader, "POLYGON((0 0, 1 0.1, 1 1, 0.5 1, 0.5 1.5, 1 1, 1.5 1.5, 1.5 1, 1 1, 1.5 0.5, 1 0.1, 2 0, 2 2,0 2, 0 0))");
+    assertEquals(2, CoordinateArrays.dimension(geom2d.getCoordinates()));
+
+    Geometry fix2d = GeometryFixer.fix(geom2d);
+    assertEquals(2, CoordinateArrays.dimension(fix2d.getCoordinates()));
+
+    // test 3d case
+    reader.setIsOldJtsCoordinateSyntaxAllowed(true);
+    Geometry geom3d = read(reader, "POLYGON((0 0, 1 0.1, 1 1, 0.5 1, 0.5 1.5, 1 1, 1.5 1.5, 1.5 1, 1 1, 1.5 0.5, 1 0.1, 2 0, 2 2,0 2, 0 0))");
+    assertEquals(3, CoordinateArrays.dimension(geom3d.getCoordinates()));
+
+    Geometry fix3d = GeometryFixer.fix(geom3d);
+    assertEquals(3, CoordinateArrays.dimension(fix3d.getCoordinates()));
+  }
+
   //================================================
 
   private void checkFix(String wkt) {

--- a/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryFixerTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryFixerTest.java
@@ -359,7 +359,7 @@ public class GeometryFixerTest extends GeometryTestCase {
 
     // test 3d case
     reader.setIsOldJtsCoordinateSyntaxAllowed(true);
-    Geometry geom3d = read(reader, "POLYGON((0 0, 1 0.1, 1 1, 0.5 1, 0.5 1.5, 1 1, 1.5 1.5, 1.5 1, 1 1, 1.5 0.5, 1 0.1, 2 0, 2 2,0 2, 0 0))");
+    Geometry geom3d = read(reader, "POLYGON Z ((10 90 1, 60 90 6, 60 10 6, 10 10 1, 10 90 1), (20 80 2, 90 80 9, 90 20 9, 20 20 2, 20 80 2))");
     assertEquals(3, CoordinateArrays.dimension(geom3d.getCoordinates()));
 
     Geometry fix3d = GeometryFixer.fix(geom3d);

--- a/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryFixerTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/util/GeometryFixerTest.java
@@ -358,7 +358,6 @@ public class GeometryFixerTest extends GeometryTestCase {
     assertEquals(2, CoordinateArrays.dimension(fix2d.getCoordinates()));
 
     // test 3d case
-    reader.setIsOldJtsCoordinateSyntaxAllowed(true);
     Geometry geom3d = read(reader, "POLYGON Z ((10 90 1, 60 90 6, 60 10 6, 10 10 1, 10 90 1), (20 80 2, 90 80 9, 90 20 9, 20 20 2, 20 80 2))");
     assertEquals(3, CoordinateArrays.dimension(geom3d.getCoordinates()));
 

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
@@ -464,6 +464,27 @@ public class WKTReaderTest extends GeometryTestCase {
     assertTrue(isEqual(seq, pt3.getCoordinateSequence()));
   }
 
+  public void testDimensionConsistence() throws Exception {
+    //test 2-d point with XY coordinate
+    CoordinateSequence seq1 = createSequence(Ordinate.createXY(), new double[] {10, 10});
+    Point pt1 = (Point)readerXYOld.read("POINT (10 10)");
+    assertTrue(isEqual(seq1, pt1.getCoordinateSequence()));
+
+    //test 2-d point with XYZ coordinate
+    CoordinateSequence seq2 = createSequence(Ordinate.createXYZ(), new double[] { 10, 10 });
+    seq2.setOrdinate(0, 2, Double.NaN);
+    Point pt2 = (Point)this.readerXYOld.read("POINT (10 10 NaN)");
+    assertTrue(isEqual(seq2, pt2.getCoordinateSequence()));
+
+    //test points sequence
+    CoordinateSequence seq3 = createSequence(Ordinate.createXYZ(), new double[] { 10, 10, 20, 20, 30, 30 });
+    seq3.setOrdinate(0, 2, Double.NaN);
+    seq3.setOrdinate(1, 2, 25);
+    seq3.setOrdinate(2, 2, Double.NaN);
+    LineString ls = (LineString)this.readerXYOld.read("LINESTRING (10 10 NaN, 20 20 25, 30 30 NaN)");
+    assertTrue(isEqual(seq3, ls.getCoordinateSequence()));
+  }
+
   public void testLargeNumbers() throws Exception {
     PrecisionModel precisionModel = new PrecisionModel(1E9);
     GeometryFactory geometryFactory = new GeometryFactory(precisionModel, 0);


### PR DESCRIPTION
A quick fix for #939. May need further work for thorough fix.