### PR TITLE
Fixed TriangleEdgesListVisitor

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java
@@ -737,7 +737,7 @@ public class QuadEdgeSubdivision {
 		private List triList = new ArrayList();
 
 		public void visit(QuadEdge[] triEdges) {
-			triList.add(triEdges);
+			triList.add(new QuadEdge[]{triEdges[0], triEdges[1], triEdges[2]});
 		}
 
 		public List getTriangleEdges() {


### PR DESCRIPTION
Currently the TriangleEdgesListVisitor, simply adds the provided `QuadEdge[] triEdges` array too the list, however this array is always the same instance, as fetchTriangleToVisit just updates the same array each time, see below.

https://github.com/locationtech/jts/blob/1c0902d47f96f383be3723cfc2c5c24f60cbe0dc/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/QuadEdgeSubdivision.java#L693

So currently a call to `getTriangleEdges` will provide a list of identical arrays, this change fixes that by creating a new instance of the array passed too the TriangleEdgesListVisitor so the  `getTriangleEdges` method now performs as expected.