### PR TITLE
Dedup `Polygonizer` invalid ring lines result

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/polygonize/EdgeRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/polygonize/EdgeRing.java
@@ -104,9 +104,11 @@ class EdgeRing {
   private List<LinearRing> holes;
   private EdgeRing shell;
   private boolean isHole;
+  private boolean isValid = false;
   private boolean isProcessed = false;
   private boolean isIncludedSet = false;
   private boolean isIncluded = false;
+
 
   public EdgeRing(GeometryFactory factory)
   {
@@ -133,6 +135,10 @@ class EdgeRing {
     deList.add((PolygonizeDirectedEdge) de);
   }
 
+  public List<PolygonizeDirectedEdge> getEdges() {
+    return deList;
+  }
+  
   /**
    * Tests whether this ring is a hole.
    * @return <code>true</code> if this ring is a hole
@@ -198,12 +204,22 @@ class EdgeRing {
    * 
    * @return true if the ring is valid
    */
-  public boolean isValid()
-  {
+  public boolean isValid() {
+    return isValid;
+  }
+  
+  /**
+   * Computes the validity of the ring.
+   * Must be called prior to calling {@link #isValid}.
+   */
+  public void computeValid() {
     getCoordinates();
-    if (ringPts.length <= 3) return false;
+    if (ringPts.length <= 3) { 
+      isValid = false;
+      return;
+    }
     getRing();
-    return ring.isValid();
+    isValid = ring.isValid();
   }
 
   public boolean isIncludedSet() {
@@ -461,7 +477,21 @@ class EdgeRing {
     public int compare(EdgeRing r0, EdgeRing r1) {
       return r0.getRing().getEnvelope().compareTo(r1.getRing().getEnvelope());
     }
-    
   }
 
+  /**
+   * Compares EdgeRings based on the area of their envelopes.
+   * Smaller envelopes sort before bigger ones.
+   * This effectively sorts EdgeRings in order of containment.
+   * 
+   * @author mdavis
+   *
+   */
+  static class EnvelopeAreaComparator implements Comparator<EdgeRing> {
+    public int compare(EdgeRing r0, EdgeRing r1) {
+      return Double.compare(
+          r0.getRing().getEnvelope().getArea(),
+          r1.getRing().getEnvelope().getArea() );
+    }
+  }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/operation/polygonize/PolygonizerTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/polygonize/PolygonizerTest.java
@@ -14,6 +14,8 @@ package org.locationtech.jts.operation.polygonize;
 import java.util.Collection;
 import java.util.List;
 
+import org.locationtech.jts.geom.Geometry;
+
 import test.jts.GeometryTestCase;
 
 /**
@@ -160,6 +162,21 @@ public class PolygonizerTest extends GeometryTestCase {
     });
   }
   
+  public void testUniqueInvalidRings() {
+    checkPolygonizeInvalidRings(    
+        "MULTILINESTRING ((0 0, 2 0, 2 2, 0 2, 0 0), (0 0, 1 1), (2 2, 4 4, 2 4, 4 2, 2 2))",
+        "LINESTRING (2 2, 4 2, 2 4, 4 4, 2 2)"
+        );
+  }
+
+  public void testUniqueInvalidRings2() {
+    checkPolygonizeInvalidRings(    
+        "MULTILINESTRING ((3 8, 7 8), (7 8, 7 3), (7 3, 3 3), (3 3, 3 8), (7 3, 9 6, 9 5, 7 8), (3 8, 1 5), (1 5, 1 6), (1 6, 3 3))",
+        "MULTILINESTRING ((3 8, 3 3, 1 6, 1 5, 3 8), (7 3, 7 8, 9 5, 9 6, 7 3))"
+        );
+  }
+
+
 /*
   public void test2() {
     doTest(new String[]{
@@ -182,6 +199,10 @@ public class PolygonizerTest extends GeometryTestCase {
     checkPolygonize(false, inputWKT, expectedWKT);
   }
 
+  private void checkPolygonize(String inputWKT, String[] expectedWKT) {
+    checkPolygonize(false, new String[] { inputWKT }, expectedWKT);
+  }
+
   private void checkPolygonize(boolean extractOnlyPolygonal, String[] inputWKT, String[] expectedWKT) {
     Polygonizer polygonizer = new Polygonizer(extractOnlyPolygonal);
     polygonizer.add(readList(inputWKT));
@@ -200,5 +221,18 @@ public class PolygonizerTest extends GeometryTestCase {
       ex.printStackTrace();
       fail("Polygonizer threw an unexpected error");
     }
+  }
+  
+  private void checkPolygonizeInvalidRings(String inputWKT, String expectedWKT) {
+    Polygonizer polygonizer = new Polygonizer();
+    polygonizer.add(read(inputWKT));
+    Collection actualList = polygonizer.getInvalidRingLines();
+    Geometry expected = read(expectedWKT);
+    Geometry actual = expected.getFactory().buildGeometry(actualList);
+    /**
+     * Use topological equality to handle differences in ring orientation and order
+     */
+    boolean isSameLinework = expected.equalsTopo(actual);
+    assertTrue(isSameLinework);
   }
 }


### PR DESCRIPTION
An improvement to ensure that the result of `Polgyonizer.getInvalidRingLines` does not contain duplicate linework for rings.

Fixes #947 

Signed-off-by: Martin Davis <mtnclimb@gmail.com>