### PR TITLE
Add Alpha-shapes to ConcaveHull

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/HullFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/HullFunctions.java
@@ -43,6 +43,18 @@ public class HullFunctions {
     return ConcaveHull.concaveHullByLengthRatio(geom, maxLenRatio, true);
   }
   
+  public static Geometry alphaShape(Geometry geom, 
+      @Metadata(title="Alpha (Radius)")
+      double alpha) {
+    return ConcaveHull.alphaShape(geom, alpha, false);
+  }
+  
+  public static Geometry alphaShapeWithHoles(Geometry geom, 
+      @Metadata(title="Alpha (Radius)")
+      double alpha) {
+    return ConcaveHull.alphaShape(geom, alpha, true);
+  }
+  
   public static double concaveHullLenGuess(Geometry geom) {
     return ConcaveHull.uniformGridEdgeLength(geom);
   }

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/TriangleFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/TriangleFunctions.java
@@ -46,6 +46,12 @@ public class TriangleFunctions {
       }});
   }
   
+  public static double circumradius(Geometry g)
+  {
+      Coordinate[] pts = trianglePts(g);
+      return Triangle.circumradius(pts[0], pts[1], pts[2]);
+  }
+  
   public static Geometry circumcentreDD(Geometry g)
   {
     return GeometryMapper.map(g, 

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/ConcaveHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/ConcaveHull.java
@@ -28,23 +28,27 @@ import org.locationtech.jts.geom.Polygon;
  * A given set of points has a sequence of hulls of increasing concaveness,
  * determined by a numeric target parameter.
  * <p>
- * The concave hull is constructed by removing the longest outer edges 
+ * The hull is constructed by removing border triangles 
  * of the Delaunay Triangulation of the points,
- * until the target criterion parameter is reached.
+ * as long as their "size" is larger than the target criterion.
  * <p>
  * The target criteria are:
  * <ul>
  * <li><b>Maximum Edge Length</b> - the length of the longest edge of the hull is no larger
  * than this value.
- * <li><b>Maximum Edge Length Ratio</b> - determine the Maximum Edge Length 
- * as a fraction of the difference between the longest and shortest edge lengths 
+ * <li><b>Maximum Edge Length Ratio</b> - determines the Maximum Edge Length 
+ * by a fraction of the difference between the longest and shortest edge lengths 
  * in the Delaunay Triangulation.  
  * This normalizes the <b>Maximum Edge Length</b> to be scale-free.
  * A value of 1 produces the convex hull; a value of 0 produces maximum concaveness.
+ * <li><b>Alpha</b> - produces Alpha-shapes, 
+ * by removing border triangles with a circumradius greater than alpha. 
+ * Large values produce the convex hull; a value of 0 produces maximum concaveness. 
  * </ul>
  * The preferred criterion is the <b>Maximum Edge Length Ratio</b>, since it is 
  * scale-free and local (so that no assumption needs to be made about the 
  * total amount of concaveness present).
+ * <p>
  * Other length criteria can be used by setting the Maximum Edge Length directly.
  * For example, use a length relative  to the longest edge length
  * in the Minimum Spanning Tree of the point set.
@@ -54,9 +58,7 @@ import org.locationtech.jts.geom.Polygon;
  * (unless it is degenerate, in which case it will be a {@link Point} or a {@link LineString}).
  * This constraint may cause the concave hull to fail to meet the target criterion.
  * <p>
- * Optionally the concave hull can be allowed to contain holes.
- * Note that when using the area-based criterion 
- * this may result in substantially slower computation.
+ * Optionally the concave hull can be allowed to contain holes by calling {@link #setHolesAllowed(boolean)}.
  * 
  * @author Martin Davis
  *
@@ -145,10 +147,32 @@ public class ConcaveHull
     return hull.getHull();
   }
   
+  /**
+   * Computes the alpha shape of a geometry as a polygon.
+   * The alpha parameter is the radius of the eroding disc.
+   * 
+   * @param geom the input geometry
+   * @param alpha the radius of the eroding disc
+   * @param isHolesAllowed whether holes are allowed in the result
+   * @return the alpha shape polygon
+   */
+  public static Geometry alphaShape(Geometry geom, double alpha, boolean isHolesAllowed) {
+    ConcaveHull hull = new ConcaveHull(geom);
+    hull.setAlpha(alpha);
+    hull.setHolesAllowed(isHolesAllowed);
+    return hull.getHull();
+  }
+  
+  private static int PARAM_EDGE_LENGTH = 1;
+  private static int PARAM_ALPHA = 2;
+  
   private Geometry inputGeometry;
-  private double maxEdgeLength = 0.0;
   private double maxEdgeLengthRatio = -1;
+  private double alpha = -1;
   private boolean isHolesAllowed = false;
+  
+  private int criteriaType = PARAM_EDGE_LENGTH;
+  private double maxSizeInHull = 0.0;
   private GeometryFactory geomFactory;
 
 
@@ -182,8 +206,9 @@ public class ConcaveHull
   public void setMaximumEdgeLength(double edgeLength) {
     if (edgeLength < 0)
       throw new IllegalArgumentException("Edge length must be non-negative");
-    this.maxEdgeLength = edgeLength;
+    this.maxSizeInHull = edgeLength;
     maxEdgeLengthRatio = -1;
+    criteriaType = PARAM_EDGE_LENGTH;
   }
   
   /**
@@ -204,6 +229,20 @@ public class ConcaveHull
     if (edgeLengthRatio < 0 || edgeLengthRatio > 1)
       throw new IllegalArgumentException("Edge length ratio must be in range [0,1]");
     this.maxEdgeLengthRatio = edgeLengthRatio;
+    criteriaType = PARAM_EDGE_LENGTH;
+  }
+  
+  /**
+   * Sets the alpha parameter to compute an alpha shape of the input.
+   * Alpha is the radius of the eroding disc.
+   * Border triangles with circumradius greater than alpha are removed.
+   * 
+   * @param alpha the alpha radius
+   */
+  public void setAlpha(double alpha) {
+    this.alpha = alpha;
+    maxSizeInHull = alpha;
+    criteriaType = PARAM_ALPHA;
   }
   
   /**
@@ -225,8 +264,10 @@ public class ConcaveHull
       return geomFactory.createPolygon();
     }
     List<HullTri> triList = HullTriangulation.createDelaunayTriangulation(inputGeometry);
+    setSize(triList);
+    
     if (maxEdgeLengthRatio >= 0) {
-      maxEdgeLength = computeTargetEdgeLength(triList, maxEdgeLengthRatio);
+      maxSizeInHull = computeTargetEdgeLength(triList, maxEdgeLengthRatio);
     }
     if (triList.isEmpty())
       return inputGeometry.convexHull();
@@ -235,6 +276,17 @@ public class ConcaveHull
 
     Geometry hull = toGeometry(triList, geomFactory);
     return hull;
+  }
+
+  private void setSize(List<HullTri> triList) {
+    for (HullTri tri : triList) {
+      if (criteriaType == PARAM_EDGE_LENGTH) {
+        tri.setSizeToLongestEdge();
+      }
+      else {
+        tri.setSizeToCircumradius();
+      }
+    }
   }
 
   private static double computeTargetEdgeLength(List<HullTri> triList, 
@@ -277,11 +329,11 @@ public class ConcaveHull
   
   private void computeHullBorder(List<HullTri> triList) {
     PriorityQueue<HullTri> queue = createBorderQueue(triList);
-    // remove tris in order of decreasing size (edge length)
+    // process tris in order of decreasing size (edge length or circumradius)
     while (! queue.isEmpty()) {
       HullTri tri = queue.poll();
       
-      if (isBelowLengthThreshold(tri)) 
+      if (isInHull(tri)) 
         break;
       
       if (isRemovableBorder(tri)) {
@@ -303,12 +355,7 @@ public class ConcaveHull
   private PriorityQueue<HullTri> createBorderQueue(List<HullTri> triList) {
     PriorityQueue<HullTri> queue = new PriorityQueue<HullTri>();
     for (HullTri tri : triList) {
-      //-- add only border triangles which could be eroded
-      // (if tri has only 1 adjacent it can't be removed because that would isolate a vertex)
-      if (tri.numAdjacent() != 2)
-        continue;
-      tri.setSizeToBoundary();
-      queue.add(tri);
+      addBorderTri(tri, queue);
     }
     return queue;
   }
@@ -316,8 +363,9 @@ public class ConcaveHull
   /**
    * Adds a Tri to the queue.
    * Only add tris with a single border edge,
-   * sice otherwise that would risk isolating a vertex.
-   * Sets the ordering size to the length of the border edge.
+   * since otherwise that would risk isolating a vertex if
+   * the tri ends up being eroded from the hull.
+   * Sets the tri size according to the threshold parameter being used.
    * 
    * @param tri the Tri to add
    * @param queue the priority queue to add to
@@ -325,16 +373,30 @@ public class ConcaveHull
   private void addBorderTri(HullTri tri, PriorityQueue<HullTri> queue) {
     if (tri == null) return;
     if (tri.numAdjacent() != 2) return;
-    tri.setSizeToBoundary();
+    setSize(tri);
     queue.add(tri);
   }
 
-  private boolean isBelowLengthThreshold(HullTri tri) {
-    return tri.lengthOfBoundary() < maxEdgeLength;
+  private void setSize(HullTri tri) {
+    if (criteriaType == PARAM_EDGE_LENGTH)
+      tri.setSizeToBoundary();
+    else 
+      tri.setSizeToCircumradius();
+  }
+  
+  /**
+   * Tests if a tri is included in the hull.
+   * Tris with size less than the maximum are included in the hull.
+   * 
+   * @param tri the tri to test
+   * @return true if the tri is included in the hull
+   */
+  private boolean isInHull(HullTri tri) {
+    return tri.getSize() < maxSizeInHull;
   }
   
   private void computeHullHoles(List<HullTri> triList) {
-    List<HullTri> candidateHoles = findCandidateHoles(triList, maxEdgeLength);
+    List<HullTri> candidateHoles = findCandidateHoles(triList, maxSizeInHull);
     // remove tris in order of decreasing size (edge length)
     for (HullTri tri : candidateHoles) {
       if (tri.isRemoved() 
@@ -350,22 +412,24 @@ public class ConcaveHull
    * Only tris which have a long enough edge and which do not touch the current hull
    * boundary are included.
    * This avoids the risk of disconnecting the result polygon.
-   * The list is sorted in decreasing order of edge length.
+   * The list is sorted in decreasing order of size.
    * 
    * @param triList
-   * @param minEdgeLen minimum length of edges to consider
+   * @param maxSizeInHull maximum tri size which is not in a hole
    * @return
    */
-  private static List<HullTri> findCandidateHoles(List<HullTri> triList, double minEdgeLen) {
+  private static List<HullTri> findCandidateHoles(List<HullTri> triList, double maxSizeInHull) {
     List<HullTri> candidates = new ArrayList<HullTri>();
     for (HullTri tri : triList) {
-      if (tri.getSize() < minEdgeLen) continue;
+      //-- tris below the size threshold are in the hull, so NOT in a hole
+      if (tri.getSize() < maxSizeInHull) continue;
+      
       boolean isTouchingBoundary = tri.isBorder() || tri.hasBoundaryTouch();
       if (! isTouchingBoundary) {
         candidates.add(tri);
       }
     }
-    // sort by HullTri comparator - longest edge length first
+    // sort by HullTri comparator - larger sizes first
     candidates.sort(null);
     return candidates;
   }
@@ -383,7 +447,7 @@ public class ConcaveHull
     while (! queue.isEmpty()) {
       HullTri tri = queue.poll();
       
-      if (tri != triHole && isBelowLengthThreshold(tri)) 
+      if (tri != triHole && isInHull(tri)) 
         break;
       
       if (tri == triHole || isRemovableHole(tri)) {

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/HullTri.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/hull/HullTri.java
@@ -55,6 +55,14 @@ class HullTri extends Tri
     size = lengthOfBoundary();
   }
   
+  public void setSizeToLongestEdge() {
+    size = lengthOfLongestEdge();
+  }
+  
+  public void setSizeToCircumradius() {
+    size = Triangle.circumradius(p2, p1, p0);
+  }
+  
   public boolean isMarked() {
     return isMarked;
   }
@@ -168,14 +176,15 @@ class HullTri extends Tri
   }
 
   /**
-   * PriorityQueues sort in ascending order.
-   * To sort with the largest at the head,
+   * Sorts tris in decreasing order.
+   * Since PriorityQueues sort in <i>ascending</i> order,
+   * to sort with the largest at the head,
    * smaller sizes must compare as greater than larger sizes.
    * (i.e. the normal numeric comparison is reversed).
    * If the sizes are identical (which should be an infrequent case),
    * the areas are compared, with larger areas sorting before smaller.
    * (The rationale is that larger areas indicate an area of lower point density,
-   * which is more likely to be in the exterior of the computed shape.)
+   * which is more likely to be in the exterior of the computed hull.)
    * This improves the determinism of the queue ordering. 
    */
   @Override
@@ -268,4 +277,6 @@ class HullTri extends Tri
     removedTri.setMarked(true);
     return isAllMarked(triList);
   }
+
+
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Triangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Triangle.java
@@ -103,6 +103,26 @@ public class Triangle
   }
 
   /**
+   * Computes the radius of the circumcircle of a triangle.
+   * <p>
+   * Formula is as per https://math.stackexchange.com/a/3610959
+   * 
+   * @param a a vertex of the triangle
+   * @param b a vertex of the triangle
+   * @param c a vertex of the triangle
+   * @return the circumradius of the triangle
+   */
+  public static double circumradius(Coordinate a, Coordinate b, Coordinate c) {
+    double A = a.distance(b);
+    double B = b.distance(c);
+    double C = c.distance(a);
+    double area = area(a, b, c);
+    if (area == 0.0)
+      return Double.POSITIVE_INFINITY;
+    return (A * B * C) / (4 * area);
+  }
+  
+  /**
    * Computes the circumcentre of a triangle. The circumcentre is the centre of
    * the circumcircle, the smallest circle which encloses the triangle. It is
    * also the common intersection point of the perpendicular bisectors of the
@@ -543,8 +563,8 @@ public class Triangle
   
   /**
    * Computes the circumcentre of this triangle. The circumcentre is the centre
-   * of the circumcircle, the smallest circle which encloses the triangle. It is
-   * also the common intersection point of the perpendicular bisectors of the
+   * of the circumcircle, the smallest circle which passes through all the triangle vertices. 
+   * It is also the common intersection point of the perpendicular bisectors of the
    * sides of the triangle, and is the only point which has equal distance to
    * all three vertices of the triangle.
    * <p>
@@ -561,6 +581,16 @@ public class Triangle
     return circumcentre(p0, p1, p2);
   }
 
+  /**
+   * Computes the radius of the circumcircle of a triangle.
+   * 
+   * @return the triangle circumradius
+   */
+  public double circumradius()
+  {
+    return circumradius(p0, p1, p2);
+  }
+  
   /**
    * Computes the centroid (centre of mass) of this triangle. This is also the
    * point at which the triangle's three medians intersect (a triangle median is

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/hull/ConcaveHullTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/hull/ConcaveHullTest.java
@@ -94,13 +94,38 @@ public class ConcaveHullTest extends GeometryTestCase {
   //------------------------------------------------
   
   public void testLengthHolesCircle() {
-    checkHullWithHolesByLength("MULTIPOINT ((90 20), (80 10), (45 5), (10 20), (20 10), (21 30), (40 20), (11 60), (20 70), (20 90), (40 80), (70 80), (80 60), (90 70), (80 90), (56 95), (95 45), (80 40), (70 20), (15 45), (5 40), (40 96), (60 15))", 
-       40, "POLYGON ((20 90, 40 96, 56 95, 80 90, 90 70, 95 45, 90 20, 80 10, 45 5, 20 10, 10 20, 5 40, 11 60, 20 90), (20 70, 15 45, 40 20, 70 20, 80 40, 80 60, 70 80, 40 80, 20 70))" );
+    checkHullWithHolesByLength(WKT_CIRCLE, 40, 
+        "POLYGON ((20 90, 40 96, 56 95, 80 90, 90 70, 95 45, 90 20, 80 10, 45 5, 20 10, 10 20, 5 40, 11 60, 20 90), (20 70, 15 45, 40 20, 70 20, 80 40, 80 60, 70 80, 40 80, 20 70))" );
   }
 
   public void testLengthHolesCircle0() {
-    checkHullWithHolesByLength("MULTIPOINT ((90 20), (80 10), (45 5), (10 20), (20 10), (21 30), (40 20), (11 60), (20 70), (20 90), (40 80), (70 80), (80 60), (90 70), (80 90), (56 95), (95 45), (80 40), (70 20), (15 45), (5 40), (40 96), (60 15))", 
-       0, "POLYGON ((20 90, 40 96, 56 95, 70 80, 80 90, 90 70, 80 60, 95 45, 80 40, 70 20, 90 20, 80 10, 60 15, 45 5, 40 20, 40 80, 15 45, 21 30, 20 10, 10 20, 5 40, 11 60, 20 70, 20 90))" );
+    checkHullWithHolesByLength(WKT_CIRCLE, 0,
+        "POLYGON ((20 90, 40 96, 56 95, 70 80, 80 90, 90 70, 80 60, 95 45, 80 40, 70 20, 90 20, 80 10, 60 15, 45 5, 40 20, 40 80, 15 45, 21 30, 20 10, 10 20, 5 40, 11 60, 20 70, 20 90))" );
+  }
+  
+  //------------------------------------------------
+  
+  private static String WKT_SIMPLE = "MULTIPOINT ((14 18), (18 14), (15 6), (15 2), (5 5), (3 13), (8 14), (8 10), (16 8))";
+  private static String WKT_CIRCLE = "MULTIPOINT ((90 20), (80 10), (45 5), (10 20), (20 10), (21 30), (40 20), (11 60), (20 70), (20 90), (40 80), (70 80), (80 60), (90 70), (80 90), (56 95), (95 45), (80 40), (70 20), (15 45), (5 40), (40 96), (60 15))";
+  
+  public void testLengthSimple() {
+    checkHullByLength(WKT_SIMPLE, 8,
+        "POLYGON ((8 10, 5 5, 3 13, 8 14, 14 18, 18 14, 16 8, 15 2, 15 6, 8 10))" );
+  }
+
+  public void testAlphaSimple() {
+    checkAlphaShape(WKT_SIMPLE, 4,
+        "POLYGON ((5 5, 3 13, 8 14, 14 18, 18 14, 16 8, 8 10, 15 6, 15 2, 5 5))" );
+  }
+
+  public void testAlphaCircle() {
+    checkAlphaShape(WKT_CIRCLE, 20,
+        "POLYGON ((20 70, 20 90, 40 96, 56 95, 80 90, 90 70, 95 45, 90 20, 80 10, 60 15, 45 5, 20 10, 10 20, 5 40, 11 60, 20 70))" );
+  }
+
+  public void testAlphaWithHolesCircle() {
+    checkAlphaShape(WKT_CIRCLE, 20, true,
+        "POLYGON ((20 90, 40 96, 56 95, 80 90, 90 70, 95 45, 90 20, 80 10, 60 15, 45 5, 20 10, 10 20, 5 40, 11 60, 20 70, 20 90), (40 80, 15 45, 21 30, 40 20, 70 20, 80 40, 80 60, 70 80, 40 80))" );
   }
 
   //==========================================================================
@@ -132,5 +157,17 @@ public class ConcaveHullTest extends GeometryTestCase {
     Geometry expected = read(wktExpected);
     checkEqual(expected, actual);
   }
+
+  private void checkAlphaShape(String wkt, double alpha, String wktExpected) {
+    checkAlphaShape(wkt, alpha, false, wktExpected);
+  }
+  
+  private void checkAlphaShape(String wkt, double alpha, boolean isHolesAllowed, String wktExpected) {
+    Geometry geom = read(wkt);
+    Geometry actual = ConcaveHull.alphaShape(geom, alpha, isHolesAllowed);
+    Geometry expected = read(wktExpected);
+    checkEqual(expected, actual);
+  }
+  
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/TriangleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/TriangleTest.java
@@ -144,6 +144,16 @@ public class TriangleTest extends GeometryTestCase
         15.0, 13.75));
   }
 
+  public void testCircumradius() throws Exception
+  {
+    // right triangle
+    checkCircumradius("POLYGON((10 10, 20 20, 20 10, 10 10))");
+    // CCW right tri
+    checkCircumradius("POLYGON((10 10, 20 10, 20 20, 10 10))");
+    // acute
+    checkCircumradius("POLYGON((10 10, 20 10, 15 20, 10 10))");
+  }
+
   public void testCentroid() throws Exception
   {
     // right triangle
@@ -193,6 +203,23 @@ public class TriangleTest extends GeometryTestCase
     assertEquals(expectedValue.toString(), circumcentre.toString());
   }
 
+  public void checkCircumradius(String wkt)
+      throws Exception
+  {
+    Geometry g = reader.read(wkt);
+    Coordinate[] pt = g.getCoordinates();
+
+    Coordinate circumcentre = Triangle.circumcentre(pt[0], pt[1], pt[2]);
+    double circumradius = Triangle.circumradius(pt[0], pt[1], pt[2]);
+    //System.out.println("(Static) circumcentre = " + circumcentre);
+    double rad0 = pt[0].distance(circumcentre);
+    double rad1 = pt[1].distance(circumcentre);
+    double rad2 = pt[2].distance(circumcentre);
+    assertEquals(rad0, circumradius, 0.00001);
+    assertEquals(rad1, circumradius, 0.00001);
+    assertEquals(rad2, circumradius, 0.00001);
+  }
+  
   public void testLongestSideLength() throws Exception
   {
     // right triangle


### PR DESCRIPTION
Adds the ability to compute [Alpha-shapes](https://en.wikipedia.org/wiki/Alpha_shape) to the `ConcaveHull` class.

![image](https://user-images.githubusercontent.com/3529053/214938248-7dfa1ee2-3203-4846-8dd7-ef5a4d05a5cf.png)

Signed-off-by: Martin Davis <mtnclimb@gmail.com>