### PR TITLE
Improve OffsetCurve behaviour and add Joined mode

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/OffsetCurveFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/OffsetCurveFunctions.java
@@ -40,6 +40,11 @@ public class OffsetCurveFunctions {
     return OffsetCurve.getCurve(geom, distance, quadrantSegments, joinStyle, mitreLimit);
   }
 
+  public static Geometry offsetCurveJoined(Geometry geom, double distance)
+  {
+    return OffsetCurve.getCurveJoined(geom, distance);
+  }
+
   public static Geometry offsetCurveBoth(Geometry geom, double distance)
   {
     Geometry curve1 = OffsetCurve.getCurve(geom, distance);

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.locationtech.jts.algorithm.Distance;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateArrays;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -227,11 +228,13 @@ public class OffsetCurve {
    */
   public static Coordinate[] rawOffsetCurve(LineString line, double distance, BufferParameters bufParams)
   {
+    Coordinate[] pts = line.getCoordinates();
+    Coordinate[] cleanPts = CoordinateArrays.removeRepeatedOrInvalidPoints(pts);
     OffsetCurveBuilder ocb = new OffsetCurveBuilder(
         line.getFactory().getPrecisionModel(), bufParams
         );
-    Coordinate[] pts = ocb.getOffsetCurve(line.getCoordinates(), distance);
-    return pts;
+    Coordinate[] rawPts = ocb.getOffsetCurve(cleanPts, distance);
+    return rawPts;
   }
   
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
@@ -11,45 +11,56 @@
  */
 package org.locationtech.jts.operation.buffer;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.locationtech.jts.algorithm.Distance;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.CoordinateList;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineSegment;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.util.GeometryMapper;
 import org.locationtech.jts.index.chain.MonotoneChain;
 import org.locationtech.jts.index.chain.MonotoneChainSelectAction;
+import org.locationtech.jts.util.Assert;
 
 /**
  * Computes an offset curve from a geometry.
- * The offset curve is a linear geometry which is offset a specified distance
+ * An offset curve is a linear geometry which is offset a given distance
  * from the input.
  * If the offset distance is positive the curve lies on the left side of the input;
  * if it is negative the curve is on the right side.
+ * The curve(s) have the same direction as the input line(s).
+ * <p>
+ * The offset curve is based on the boundary of the buffer for the geometry
+ * at the offset distance (see {@link BufferOp}.
+ * The normal mode of operation is to return the sections of the buffer boundary
+ * which lie on the raw offset curve
+ * (obtained via {@link #rawOffset(LineString, double)}.  
+ * The offset curve will contain multiple sections 
+ * if the input self-intersects or has close approaches.
+ * The computed sections are ordered along the raw offset curve.
+ * Sections are disjoint.  They never self-intersect, but may be rings.
  * <ul>
- * <li>For a {@link LineString} the offset curve is a line.
- * <li>For a {@link Point} the offset curve is an empty {@link LineString}.
+ * <li>For a {@link LineString} the offset curve is a linear geometry
+ * ({@link LineString} or {@link MultiLineString}).
+ * <li>For a {@link Point} or {@link MultiPoint} the offset curve is an empty {@link LineString}.
  * <li>For a {@link Polygon} the offset curve is the boundary of the polygon buffer (which
  * may be a {@link MultiLineString}.
- * <li>For a collection the output is a {@link MultiLineString} containing the element offset curves.
+ * <li>For a collection the output is a {@link MultiLineString} containing the offset curves of the elements.
  * </ul>
- * The offset curve is computed as a single contiguous section of the geometry buffer boundary.
- * In some geometric situations this definition is ill-defined.
- * This algorithm provides a "best-effort" interpretation.
- * In particular:
- * <ul>
- * <li>For self-intersecting lines, the buffer boundary includes
- * offset lines for both left and right sides of the input line.
- * Only a single contiguous portion on the specified side is returned.</li>
- * <li>If the offset corresponds to buffer holes, only the largest hole is used. 
- * </li>
- * </ul>
+ * In "joined" mode (see {@link #setJoined(boolean)}
+ * the sections computed for each input line are joined into a single offset curve line. 
+ * The joined curve may self-intersect. 
+ * At larger offset distances the curve may contain "flat-line" artifacts 
+ * in places where the input self-intersects.
+ * <p>
  * Offset curves support setting the number of quadrant segments, 
  * the join style, and the mitre limit (if applicable) via 
  * the {@link BufferParameters}.
@@ -60,9 +71,9 @@ import org.locationtech.jts.index.chain.MonotoneChainSelectAction;
 public class OffsetCurve {
   
   /**
-   * The nearness tolerance between the raw offset linework and the buffer curve.
+   * The nearness tolerance for matching the the raw offset linework and the buffer curve.
    */
-  private static final int NEARNESS_FACTOR = 10000;
+  private static final int MATCH_DISTANCE_FACTOR = 10000;
 
   /**
    * Computes the offset curve of a geometry at a given distance.
@@ -78,7 +89,7 @@ public class OffsetCurve {
   
   /**
    * Computes the offset curve of a geometry at a given distance,
-   * and for a specified quadrant segments, join style and mitre limit.
+   * with specified quadrant segments, join style and mitre limit.
    * 
    * @param geom a geometry
    * @param distance the offset distance (positive for left, negative for right)
@@ -96,14 +107,30 @@ public class OffsetCurve {
     return oc.getCurve();
   }
   
+  /**
+   * Computes the offset curve of a geometry at a given distance,
+   * joining curve sections into a single line for each input line.
+   * 
+   * @param geom a geometry
+   * @param distance the offset distance (positive for left, negative for right)
+   * @return the joined offset curve
+   */
+  public static Geometry getCurveJoined(Geometry geom, double distance) {
+    OffsetCurve oc = new OffsetCurve(geom, distance);
+    oc.setJoined(true);
+    return oc.getCurve();
+  }
+  
   private Geometry inputGeom;
   private double distance;
+  private boolean isJoined = false;
+  
   private BufferParameters bufferParams;
   private double matchDistance;
   private GeometryFactory geomFactory;
 
   /**
-   * Creates a new instance for computing an offset curve for a geometryat a given distance.
+   * Creates a new instance for computing an offset curve for a geometry at a given distance.
    * with default quadrant segments ({@link BufferParameters#DEFAULT_QUADRANT_SEGMENTS})
    * and join style ({@link BufferParameters#JOIN_STYLE}).
    * 
@@ -118,7 +145,7 @@ public class OffsetCurve {
   
   /**
    * Creates a new instance for computing an offset curve for a geometry at a given distance.
-   * allowing the quadrant segments and join style and mitre limit to be set
+   * setting the quadrant segments and join style and mitre limit 
    * via {@link BufferParameters}.
    * 
    * @param geom the geometry to offset
@@ -129,7 +156,7 @@ public class OffsetCurve {
     this.inputGeom = geom;
     this.distance = distance;
     
-    matchDistance = Math.abs(distance) / NEARNESS_FACTOR;
+    matchDistance = Math.abs(distance) / MATCH_DISTANCE_FACTOR;
     geomFactory = inputGeom.getFactory();
     
     //-- make new buffer params since the end cap style must be the default
@@ -142,7 +169,18 @@ public class OffsetCurve {
   }
   
   /**
-   * Gets the computed offset curve.
+   * Computes a single curve line for each input linear component,
+   * by joining curve sections in order along the raw offset curve.
+   * The default mode is to compute separate curve sections.
+   * 
+   * @param isJoined true if joined mode should be used.
+   */
+  public void setJoined(boolean isJoined) {
+    this.isJoined = isJoined;
+  }
+  
+  /**
+   * Gets the computed offset curve lines.
    * 
    * @return the offset curve geometry
    */
@@ -187,7 +225,7 @@ public class OffsetCurve {
    * @param bufParams the buffer parameters to use
    * @return the raw offset curve points
    */
-  public static Coordinate[] rawOffset(LineString line, double distance, BufferParameters bufParams)
+  public static Coordinate[] rawOffsetCurve(LineString line, double distance, BufferParameters bufParams)
   {
     OffsetCurveBuilder ocb = new OffsetCurveBuilder(
         line.getFactory().getPrecisionModel(), bufParams
@@ -206,22 +244,39 @@ public class OffsetCurve {
    */
   public static Coordinate[] rawOffset(LineString line, double distance)
   {
-    return rawOffset(line, distance, new BufferParameters());
+    return rawOffsetCurve(line, distance, new BufferParameters());
   }
 
-  private LineString computeCurve(LineString lineGeom, double distance) {
-    //-- first handle special/simple cases
+  private Geometry computeCurve(LineString lineGeom, double distance) {
+    //-- first handle simple cases
+    //-- empty or single-point line
     if (lineGeom.getNumPoints() < 2 || lineGeom.getLength() == 0.0) {
       return geomFactory.createLineString();
     }
+    //-- two-point line
     if (lineGeom.getNumPoints() == 2) {
       return offsetSegment(lineGeom.getCoordinates(), distance);
     }
 
-    Coordinate[] rawOffset = rawOffset(lineGeom, distance, bufferParams);
-    if (rawOffset.length == 0) {
-      return geomFactory.createLineString();
+    List<OffsetCurveSection> sections = computeSections(lineGeom, distance);
+
+    Geometry offsetCurve;
+    if (isJoined) {
+      offsetCurve = OffsetCurveSection.toLine(sections, geomFactory);
     }
+    else {
+      offsetCurve = OffsetCurveSection.toGeometry(sections, geomFactory);
+    }
+    return offsetCurve;
+  }
+
+  private List<OffsetCurveSection> computeSections(LineString lineGeom, double distance) {
+    Coordinate[] rawCurve = rawOffsetCurve(lineGeom, distance, bufferParams);
+    List<OffsetCurveSection> sections = new ArrayList<OffsetCurveSection>();
+    if (rawCurve.length == 0) {
+      return sections;
+    }
+    
     /**
      * Note: If the raw offset curve has no
      * narrow concave angles or self-intersections it could be returned as is.
@@ -232,17 +287,16 @@ public class OffsetCurve {
     
     Polygon bufferPoly = getBufferOriented(lineGeom, distance, bufferParams);
     
-    //-- first try matching shell to raw curve
+    //-- first extract offset curve sections from shell
     Coordinate[] shell = bufferPoly.getExteriorRing().getCoordinates();
-    LineString offsetCurve = computeCurve(shell, rawOffset);
-    if (! offsetCurve.isEmpty() 
-        || bufferPoly.getNumInteriorRing() == 0)
-      return offsetCurve;
+    computeCurveSections(shell, rawCurve, sections);
     
-    //-- if shell didn't work, try matching to largest hole 
-    Coordinate[] holePts = extractLongestHole(bufferPoly).getCoordinates();
-    offsetCurve = computeCurve(holePts, rawOffset);
-    return offsetCurve;
+    //-- extract offset curve sections from holes
+    for (int i = 0; i < bufferPoly.getNumInteriorRing(); i++) {
+      Coordinate[] hole = bufferPoly.getInteriorRingN(i).getCoordinates();
+      computeCurveSections(hole, rawCurve, sections);      
+    }
+    return sections;
   }
 
   private LineString offsetSegment(Coordinate[] pts, double distance) {
@@ -262,7 +316,8 @@ public class OffsetCurve {
 
   /**
    * Extracts the largest polygon by area from a geometry.
-   * Used here to avoid issues with non-robust buffer results which have spurious extra polygons.
+   * Used here to avoid issues with non-robust buffer results 
+   * which have spurious extra polygons.
    * 
    * @param geom a geometry
    * @return the polygon element of largest area
@@ -283,50 +338,61 @@ public class OffsetCurve {
     }
     return maxPoly;
   }
+  
+  private static final double NOT_IN_CURVE = -1;
+  
+  private void computeCurveSections(Coordinate[] bufferRingPts, 
+      Coordinate[] rawCurve, List<OffsetCurveSection> sections) {
+    double[] rawPosition = new double[bufferRingPts.length - 1];
+    for (int i = 0; i < rawPosition.length; i++) {
+      rawPosition[i] = NOT_IN_CURVE;
+    }
+    SegmentMCIndex bufferSegIndex = new SegmentMCIndex(bufferRingPts);
+    int bufferFirstIndex = -1;
+    double minRawPosition = -1;
+    for (int i = 0; i < rawCurve.length - 1; i++) {
+      int minBufferIndexForSeg = matchSegments(
+                      rawCurve[i], rawCurve[i + 1], i, bufferSegIndex, bufferRingPts, rawPosition);
+      if (minBufferIndexForSeg >= 0) {
+        double pos = rawPosition[minBufferIndexForSeg];
+        if (bufferFirstIndex < 0 || pos < minRawPosition) {
+          minRawPosition = pos;
+          bufferFirstIndex = minBufferIndexForSeg;
+        }
+       }
+    }
+    //-- no matching sections found in this buffer ring
+    if (bufferFirstIndex < 0)
+      return;
+    extractSections(bufferRingPts, rawPosition, bufferFirstIndex, sections);
+  }
 
-  private static LinearRing extractLongestHole(Polygon poly) {
-    LinearRing largestHole = null;
-    double maxLen = -1;
-    for (int i = 0; i < poly.getNumInteriorRing(); i++) {
-      LinearRing hole = poly.getInteriorRingN(i);
-      double len = hole.getLength();
-      if (len > maxLen) {
-        largestHole = hole;
-        maxLen = len;
-      }
-    }
-    return largestHole;
-  }
-  
-  private LineString computeCurve(Coordinate[] bufferPts, Coordinate[] rawOffset) {
-    boolean[] isInCurve = new boolean[bufferPts.length - 1];
-    SegmentMCIndex segIndex = new SegmentMCIndex(bufferPts);
-    int curveStart = -1;
-    for (int i = 0; i < rawOffset.length - 1; i++) {
-      int index = markMatchingSegments(
-                      rawOffset[i], rawOffset[i + 1], segIndex, bufferPts, isInCurve);
-      if (curveStart < 0) {
-        curveStart = index;
-      }
-    }
-    Coordinate[] curvePts = extractSection(bufferPts, curveStart, isInCurve);
-    return geomFactory.createLineString(curvePts);
-  }
-  
-  private int markMatchingSegments(Coordinate p0, Coordinate p1, 
-      SegmentMCIndex segIndex, Coordinate[] bufferPts, 
-      boolean[] isInCurve) {
-    Envelope matchEnv = new Envelope(p0, p1);
+  /**
+   * Matches the segments in a buffer ring to the raw offset curve
+   * to obtain their match positions (if any).
+   * 
+   * @param raw0 a raw curve segment start point
+   * @param raw1 a raw curve segment end point
+   * @param rawCurveIndex the index of the raw curve segment
+   * @param bufferSegIndex the spatial index of the buffer ring segments
+   * @param bufferPts the points of the buffer ring
+   * @param rawCurvePos the raw curve positions of the buffer ring segments
+   * @return the index of the minimum matched buffer segment
+   */
+  private int matchSegments(Coordinate raw0, Coordinate raw1, int rawCurveIndex,
+      SegmentMCIndex bufferSegIndex, Coordinate[] bufferPts, 
+      double[] rawCurvePos) {
+    Envelope matchEnv = new Envelope(raw0, raw1);
     matchEnv.expandBy(matchDistance);
-    MatchCurveSegmentAction action = new MatchCurveSegmentAction(p0, p1, bufferPts, matchDistance, isInCurve);
-    segIndex.query(matchEnv, action);
-    return action.getMinCurveIndex();
+    MatchCurveSegmentAction matchAction = new MatchCurveSegmentAction(raw0, raw1, rawCurveIndex, matchDistance, bufferPts, rawCurvePos);
+    bufferSegIndex.query(matchEnv, matchAction);
+    return matchAction.getBufferMinIndex();
   }
   
   /**
    * An action to match a raw offset curve segment 
-   * to segments in the buffer ring 
-   * and mark them as being in the offset curve.
+   * to segments in a buffer ring 
+   * and record the matched segment locations(s) along the raw curve.
    * 
    * @author Martin Davis
    */
@@ -335,20 +401,26 @@ public class OffsetCurve {
   {
     private Coordinate p0;
     private Coordinate p1;
-    private Coordinate[] bufferPts;
+    private int rawCurveIndex;
+    private Coordinate[] bufferRingPts;
     private double matchDistance;
-    private boolean[] isInCurve;
-    
-    private double minFrac = -1;
-    private int minCurveIndex = -1;
+    private double[] rawCurveLoc;
+    private double minRawLocation = -1;
+    private int bufferRingMinIndex = -1;
     
     public MatchCurveSegmentAction(Coordinate p0, Coordinate p1, 
-        Coordinate[] bufferPts, double matchDistance, boolean[] isInCurve) {
+        int rawCurveIndex,
+        double matchDistance, Coordinate[] bufferRingPts, double[] rawCurveLoc) {
       this.p0 = p0;
       this.p1 = p1;
-      this.bufferPts = bufferPts;
+      this.rawCurveIndex = rawCurveIndex;
+      this.bufferRingPts = bufferRingPts;
       this.matchDistance = matchDistance;
-      this.isInCurve = isInCurve;
+      this.rawCurveLoc = rawCurveLoc;
+    }
+    
+    public int getBufferMinIndex() {
+      return bufferRingMinIndex;
     }
     
     public void select(MonotoneChain mc, int segIndex)
@@ -356,113 +428,126 @@ public class OffsetCurve {
       /**
        * A curveRingPt segment may match all or only a portion of a single raw segment.
        * There may be multiple curve ring segs that match along the raw segment.
-       * The one closest to the segment start is recorded as the offset curve start.      
        */
-      double frac = subsegmentMatchFrac(bufferPts[segIndex], bufferPts[segIndex+1], p0, p1, matchDistance);
+      double frac = segmentMatchFrac(bufferRingPts[segIndex], bufferRingPts[segIndex+1], 
+          p0, p1, matchDistance);
       //-- no match
       if (frac < 0) return;
       
-      isInCurve[segIndex] = true;
-      
+      //-- location is used to sort segments along raw curve
+      double location = rawCurveIndex + frac;
+      rawCurveLoc[segIndex] = location;
       //-- record lowest index
-      if (minFrac < 0 || frac < minFrac) {
-        minFrac = frac;
-        minCurveIndex = segIndex;
-      }
-    }
-    
-    public int getMinCurveIndex() {
-      return minCurveIndex;
+      if (minRawLocation < 0 || location < minRawLocation) {
+        minRawLocation = location;
+        bufferRingMinIndex = segIndex;
+      }    
     }
   }
   
-  /*
-  // Slower, non-indexed algorithm.  Left here for future testing.
-  
-  private Coordinate[] OLDcomputeCurve(Coordinate[] curveRingPts, Coordinate[] rawOffset) {
-    boolean[] isInCurve = new boolean[curveRingPts.length - 1];
-    int curveStart = -1;
-    for (int i = 0; i < rawOffset.length - 1; i++) {
-      int index = markMatchingSegments(
-                      rawOffset[i], rawOffset[i + 1], curveRingPts, isInCurve);
-      if (curveStart < 0) {
-        curveStart = index;
-      }
-    }
-    Coordinate[] curvePts = extractSection(curveRingPts, isInCurve, curveStart);
-    return curvePts;
-  }
-
-  private int markMatchingSegments(Coordinate p0, Coordinate p1, Coordinate[] curveRingPts, boolean[] isInCurve) {
-    double minFrac = -1;
-    int minCurveIndex = -1;
-    for (int i = 0; i < curveRingPts.length - 1; i++) {
-       // A curveRingPt seg will only match a portion of a single raw segment.
-       // But there may be multiple curve ring segs that match along that segment.
-       // The one closest to the segment start is recorded.
-      double frac = subsegmentMatchFrac(curveRingPts[i], curveRingPts[i+1], p0, p1, matchDistance);
-      //-- no match
-      if (frac < 0) continue;
-      
-      isInCurve[i] = true;
-      
-      //-- record lowest index
-      if (minFrac < 0 || frac < minFrac) {
-        minFrac = frac;
-        minCurveIndex = i;
-      }
-    }
-    return minCurveIndex;
-  }
-  */
-  
-  private static double subsegmentMatchFrac(Coordinate p0, Coordinate p1, 
+  private static double segmentMatchFrac(Coordinate p0, Coordinate p1, 
       Coordinate seg0, Coordinate seg1, double matchDistance) {
     if (matchDistance < Distance.pointToSegment(p0, seg0, seg1))
       return -1;
     if (matchDistance < Distance.pointToSegment(p1, seg0, seg1))
       return -1;
-    //-- matched - determine position as fraction
+    //-- matched - determine position as fraction along segment
     LineSegment seg = new LineSegment(seg0, seg1);
     return seg.segmentFraction(p0);
   }
 
   /**
-   * Extracts a section of a ring of coordinates, starting at a given index, 
-   * and keeping coordinates which are flagged as being required.
-   * 
-   * @param ring the ring of points
-   * @param startIndex the index of the start coordinate
-   * @param isExtracted flag indicating if coordinate is to be extracted
-   * @return
+   * This is only called when there is at least one ring segment matched
+   * (so rawCurvePos has at least one entry != NOT_IN_CURVE).
+   * The start index of the first section must be provided.
+   * This is intended to be the section with lowest position
+   * along the raw curve.
+   * @param ringPts the points in a buffer ring
+   * @param rawCurveLoc the position of buffer ring segments along the raw curve
+   * @param startIndex the index of the start of a section
+   * @param sections the list of extracted offset curve sections
    */
-  private static Coordinate[] extractSection(Coordinate[] ring, int startIndex, boolean[] isExtracted) {
-    if (startIndex < 0)
-      return new Coordinate[0];
-    
-    CoordinateList coordList = new CoordinateList();
-    int i = startIndex;
+  private void extractSections(Coordinate[] ringPts, double[] rawCurveLoc, 
+      int startIndex, List<OffsetCurveSection> sections) {
+    int sectionStart = startIndex;
+    int sectionCount = 0;
+    int sectionEnd;
     do {
-      coordList.add(ring[i], false);
-      if (! isExtracted[i]) {
-        break;
+      sectionEnd = findSectionEnd(rawCurveLoc, sectionStart, startIndex);
+      double location = rawCurveLoc[sectionStart];
+      int lastIndex = prev(sectionEnd, rawCurveLoc.length);
+      double lastLoc = rawCurveLoc[lastIndex];
+      OffsetCurveSection section = OffsetCurveSection.create(ringPts, sectionStart, sectionEnd, location, lastLoc);
+      sections.add(section);
+      sectionStart = findSectionStart(rawCurveLoc, sectionEnd);
+      
+      //-- check for an abnormal state
+      if (sectionCount++ > ringPts.length) {
+        Assert.shouldNeverReachHere("Too many sections for ring - probable bug");
       }
-      i = next(i, ring.length - 1);
-    } while (i != startIndex);
-    //-- handle case where every segment is extracted
-    if (isExtracted[i]) {
-      coordList.add(ring[i], false);
-    }
-    
-    //-- if only one point found return empty LineString
-    if (coordList.size() == 1)
-      return new Coordinate[0];
-    
-    return coordList.toCoordinateArray();  
+    } while (sectionStart != startIndex && sectionEnd != startIndex);
+  }
+  
+  private int findSectionStart(double[] loc, int end) {
+    int start = end;
+    do {
+      int next = next(start, loc.length);
+      //-- skip ahead if segment is not in raw curve
+      if (loc[start] == NOT_IN_CURVE) {
+        start = next;
+        continue;
+      }
+      int prev = prev(start, loc.length);
+      //-- if prev segment is not in raw curve then have found a start
+      if (loc[prev] == NOT_IN_CURVE) {
+        return start;
+      }
+      if (isJoined) {
+        /**
+         *  Start section at next gap in raw curve.
+         *  Only needed for joined curve, since otherwise
+         *  contiguous buffer segments can be in same curve section.
+         */
+        double locDelta = Math.abs(loc[start] - loc[prev]);
+        if (locDelta > 1)
+          return start;
+        }
+      start = next;
+    } while (start != end);
+    return start;
+  }
+  
+  private int findSectionEnd(double[] loc, int start, int firstStartIndex) {
+    // assert: pos[start] is IN CURVE
+    int end = start;
+    int next;
+    do {
+      next = next(end, loc.length);
+      if (loc[next] == NOT_IN_CURVE)
+        return next;
+      if (isJoined) {
+        /**
+         *  End section at gap in raw curve.
+         *  Only needed for joined curve, since otherwise
+         *  contigous buffer segments can be in same section
+         */
+        double locDelta = Math.abs(loc[next] - loc[end]);
+        if (locDelta > 1)
+          return next;
+      }
+      end = next;
+    } while (end != start && end != firstStartIndex);
+    return end;
   }
   
   private static int next(int i, int size) {
     i += 1;
     return (i < size) ? i : 0; 
   }
+  
+  private static int prev(int i, int size) {
+    i -= 1;
+    return (i < 0) ? size - 1 : i; 
+  }
+
 }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurveBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurveBuilder.java
@@ -14,7 +14,6 @@ package org.locationtech.jts.operation.buffer;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateArrays;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.LineSegment;
 import org.locationtech.jts.geom.Position;
 import org.locationtech.jts.geom.PrecisionModel;
 
@@ -27,6 +26,11 @@ import org.locationtech.jts.geom.PrecisionModel;
  * of all the noded raw curves and tracing outside contours.
  * The points in the raw curve are rounded 
  * to a given {@link PrecisionModel}.
+ * <p>
+ * Note: this may not produce correct results if the input
+ * contains repeated or invalid points.
+ * Repeated points should be removed before calling.
+ * See {@link CoordinateArrays#removeRepeatedOrInvalidPoints(Coordinate[])}.
  *
  * @version 1.7
  */

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurveSection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurveSection.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021 Martin Davis.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.operation.buffer;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateList;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+
+/**
+ * Models a section of a raw offset curve,
+ * starting at a given location along the raw curve.
+ * The location is a decimal number, with the integer part 
+ * containing the segment index and the fractional part
+ * giving the fractional distance along the segment.
+ * The location of the last section segment 
+ * is also kept, to allow optimizing joining sections together.
+ * 
+ * @author mdavis
+ */
+class OffsetCurveSection 
+implements Comparable<OffsetCurveSection> {
+  
+  public static Geometry toGeometry(List<OffsetCurveSection> sections, GeometryFactory geomFactory) {
+    if (sections.size() == 0)
+      return geomFactory.createLineString();
+    if (sections.size() == 1)
+      return geomFactory.createLineString(sections.get(0).getCoordinates());
+    
+    //-- sort sections in order along the offset curve
+    Collections.sort(sections);
+    LineString[] lines = new LineString[sections.size()];
+    
+    for (int i = 0; i < sections.size(); i++) {
+      lines[i] = geomFactory.createLineString(sections.get(i).getCoordinates());
+    }
+    return geomFactory.createMultiLineString(lines);
+  }
+
+  /**
+   * Joins section coordinates into a LineString.
+   * Join vertices which lie in the same raw curve segment
+   * are removed, to simplify the result linework.
+   * 
+   * @param sections the sections to join
+   * @param geomFactory the geometry factory to use
+   * @return the simplified linestring for the joined sections
+   */
+  public static Geometry toLine(List<OffsetCurveSection> sections, GeometryFactory geomFactory) {
+    if (sections.size() == 0)
+      return geomFactory.createLineString();
+    if (sections.size() == 1)
+      return geomFactory.createLineString(sections.get(0).getCoordinates());
+    
+    //-- sort sections in order along the offset curve
+    Collections.sort(sections);
+    CoordinateList pts = new CoordinateList();
+    
+    boolean removeStartPt = false;
+    for (int i = 0; i < sections.size(); i++) {
+      OffsetCurveSection section = sections.get(i);
+      
+      boolean removeEndPt = false;
+      if (i < sections.size() - 1) {
+        double nextStartLoc = sections.get(i+1).location;
+        removeEndPt = section.isEndInSameSegment(nextStartLoc);
+      }
+      Coordinate[] sectionPts = section.getCoordinates();
+      for (int j = 0; j < sectionPts.length; j++) {
+        if ((removeStartPt && j == 0) || (removeEndPt && j == sectionPts.length-1))
+          continue;
+        pts.add(sectionPts[j], false);        
+      }
+      removeStartPt = removeEndPt;
+    }
+    return geomFactory.createLineString(pts.toCoordinateArray());
+  }
+
+  public static OffsetCurveSection create(Coordinate[] srcPts, int start, int end, double loc, double locLast) {
+    int len = end - start + 1;
+    if (end <= start) 
+      len = srcPts.length - start + end;
+      
+    Coordinate[] sectionPts = new Coordinate[len];
+    for (int i = 0; i < len; i++) {
+      int index = (start + i) % (srcPts.length - 1);
+      sectionPts[i] = srcPts[index].copy();
+    }
+    return new OffsetCurveSection(sectionPts, loc, locLast);
+  }
+  
+  private Coordinate[] sectionPts;
+  private double location;
+  private double locLast;
+
+  OffsetCurveSection(Coordinate[] pts, double loc, double locLast) {
+    this.sectionPts = pts;
+    this.location = loc;
+    this.locLast = locLast;
+  }
+  
+  private Coordinate[] getCoordinates() {
+    return sectionPts;
+  }
+
+  private boolean isEndInSameSegment(double nextLoc) {
+    int segIndex = (int) locLast;
+    int nextIndex = (int) nextLoc;
+    return segIndex == nextIndex;
+  }
+  
+  /**
+   * Orders sections by their location along the raw offset curve.
+   */
+  @Override
+  public int compareTo(OffsetCurveSection section) {
+    return Double.compare(location, section.location);
+  }
+
+}

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -89,6 +89,13 @@ public class OffsetCurveTest extends GeometryTestCase {
         );
   }
   
+  public void testRightAngle() {
+    checkOffsetCurve(
+        "LINESTRING (2 8, 8 8, 8 1)", 1,
+        "LINESTRING (2 9, 8 9, 8.2 8.98, 8.38 8.92, 8.56 8.83, 8.71 8.71, 8.83 8.56, 8.92 8.38, 8.98 8.2, 9 8, 9 1)"
+        );
+  }
+
   public void testZigzagOneEndCurved4() {
     checkOffsetCurve(
         "LINESTRING (1 3, 6 3, 4 5, 9 5)", 4,
@@ -113,13 +120,37 @@ public class OffsetCurveTest extends GeometryTestCase {
   public void testSelfCross() {
     checkOffsetCurve(
         "LINESTRING (50 90, 50 10, 90 50, 10 50)", 10,
-        "LINESTRING (60 90, 60 60)" );
+        "MULTILINESTRING ((60 90, 60 60), (60 40, 60 34.14, 65.85 40, 60 40), (40 40, 10 40))" );
   }
 
   public void testSelfCrossNeg() {
     checkOffsetCurve(
         "LINESTRING (50 90, 50 10, 90 50, 10 50)", -10,
-        "LINESTRING (40 90, 40 60, 10 60)" );
+        "MULTILINESTRING ((40 90, 40 60, 10 60), (40 40, 40 10, 40.19 8.05, 40.76 6.17, 41.69 4.44, 42.93 2.93, 44.44 1.69, 46.17 0.76, 48.05 0.19, 50 0, 51.95 0.19, 53.83 0.76, 55.56 1.69, 57.07 2.93, 97.07 42.93, 98.31 44.44, 99.24 46.17, 99.81 48.05, 100 50, 99.81 51.95, 99.24 53.83, 98.31 55.56, 97.07 57.07, 95.56 58.31, 93.83 59.24, 91.95 59.81, 90 60, 60 60))" );
+  }
+
+  public void testSelfCrossCWNeg() {
+    checkOffsetCurve(
+        "LINESTRING (0 70, 100 70, 40 0, 40 100)", -10,
+        "MULTILINESTRING ((0 60, 30 60), (50 60, 50 27.03, 78.25 60, 50 60), (50 80, 50 100))" );
+  }
+
+  public void testSelfCrossDartInside() {
+    checkOffsetCurve(
+        "LINESTRING (60 50, 10 80, 50 10, 90 80, 40 50)", 10,
+        "MULTILINESTRING ((54.86 41.43, 50 44.34, 45.14 41.43), (43.9 40.83, 50 30.16, 56.1 40.83))" );
+  }
+
+  public void testSelfCrossDartOutside() {
+    checkOffsetCurve(
+        "LINESTRING (60 50, 10 80, 50 10, 90 80, 40 50)", -10,
+        "LINESTRING (50 67.66, 15.14 88.57, 13.32 89.43, 11.35 89.91, 9.33 89.98, 7.34 89.64, 5.46 88.91, 3.76 87.82, 2.32 86.4, 1.19 84.73, 0.42 82.86, 0.04 80.88, 0.07 78.86, 0.5 76.88, 1.32 75.04, 41.32 5.04, 42.42 3.48, 43.8 2.16, 45.4 1.12, 47.17 0.41, 49.05 0.05, 50.95 0.05, 52.83 0.41, 54.6 1.12, 56.2 2.16, 57.58 3.48, 58.68 5.04, 98.68 75.04, 99.5 76.88, 99.93 78.86, 99.96 80.88, 99.58 82.86, 98.81 84.73, 97.68 86.4, 96.24 87.82, 94.54 88.91, 92.66 89.64, 90.67 89.98, 88.65 89.91, 86.68 89.43, 84.86 88.57, 50 67.66)" );
+  }
+
+  public void testSelfCrossDart2Inside() {
+    checkOffsetCurve(
+        "LINESTRING (64 45, 10 80, 50 10, 90 80, 35 45)", 10,
+        "LINESTRING (55.00 38.91, 49.58 42.42, 44.74 39.34, 50 30.15, 55.00 38.91)" );
   }
 
   public void testRing() {
@@ -135,11 +166,41 @@ public class OffsetCurveTest extends GeometryTestCase {
     );
   }
   
+  public void testOverlapTriangleInside() {
+    checkOffsetCurve(
+        "LINESTRING (70 80, 10 80, 50 10, 90 80, 40 80))", 10,
+        "LINESTRING (70 70, 40 70, 27.23 70, 50 30.15, 72.76 70, 70 70)"
+        );
+  }
+  
+  public void testOverlapTriangleOutside() {
+    checkOffsetCurve(
+        "LINESTRING (70 80, 10 80, 50 10, 90 80, 40 80))", -10,
+        "LINESTRING (70 90, 40 90, 10 90, 8.11 89.82, 6.29 89.29, 4.6 88.42, 3.11 87.25, 1.87 85.82, 0.91 84.18, 0.29 82.39, 0.01 80.51, 0.1 78.61, 0.54 76.77, 1.32 75.04, 41.32 5.04, 42.42 3.48, 43.8 2.16, 45.4 1.12, 47.17 0.41, 49.05 0.05, 50.95 0.05, 52.83 0.41, 54.6 1.12, 56.2 2.16, 57.58 3.48, 58.68 5.04, 98.68 75.04, 99.46 76.77, 99.9 78.61, 99.99 80.51, 99.71 82.39, 99.09 84.18, 98.13 85.82, 96.89 87.25, 95.4 88.42, 93.71 89.29, 91.89 89.82, 90 90, 70 90)"
+        );
+  }
+  
+  //--------------------------------------------------------
+  
+  public void testMultiPoint() {
+    checkOffsetCurve(
+        "MULTIPOINT ((0 0), (1 1))", 1,
+        "LINESTRING EMPTY"
+        );
+  }
+  
   public void testMultiLine() {
     checkOffsetCurve(
         "MULTILINESTRING ((20 30, 60 10, 80 60), (40 50, 80 30))", 10,
         "MULTILINESTRING ((24.47 38.94, 54.75 23.8, 70.72 63.71), (44.47 58.94, 84.47 38.94))"
     );
+  }
+  
+  public void testMixedWithPoint() {
+    checkOffsetCurve(
+        "GEOMETRYCOLLECTION (LINESTRING (20 30, 60 10, 80 60), POINT (0 0))", 10,
+        "LINESTRING (24.47 38.94, 54.75 23.8, 70.72 63.71)"
+        );
   }
   
   public void testPolygon() {
@@ -162,7 +223,15 @@ public class OffsetCurveTest extends GeometryTestCase {
         "POLYGON ((20 80, 80 80, 80 20, 20 20, 20 80), (30 70, 70 70, 70 30, 30 30, 30 70))", -10,
         "LINESTRING EMPTY"
     );
-
+  }
+  
+  //-------------------------------------------------
+  
+  public void testInfiniteLoop() {
+    checkOffsetCurve(
+        "LINESTRING (21 101, -1 78, 12 43, 50 112, 73 -5, 19 2, 87 85, -7 38, 105 40)", 4,
+        null
+    );
   }
   
   //---------------------------------------

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -18,7 +18,8 @@ import test.jts.GeometryTestCase;
 /**
  * 
  * Note: most expected results are rounded to precision of 100, to reduce
- * size and improve robustness.
+ * size and improve robustness.  
+ * The test cases are chosen so that this has no effect on comparing expected to actual.
  * 
  * @author Martin Davis
  *
@@ -231,6 +232,17 @@ public class OffsetCurveTest extends GeometryTestCase {
     checkOffsetCurve(
         "LINESTRING (21 101, -1 78, 12 43, 50 112, 73 -5, 19 2, 87 85, -7 38, 105 40)", 4,
         null
+    );
+  }
+  
+  /**
+   * Test bug fix for removing repeated points in input for raw curve.
+   * See https://github.com/locationtech/jts/issues/957
+   */
+  public void testRepeatedPoint() {
+    checkOffsetCurve(
+        "LINESTRING (4 9, 1 2, 7 5, 7 5, 4 9)", 1,
+        "LINESTRING (4.24 7.02, 2.99 4.12, 5.48 5.36, 4.24 7.02)"
     );
   }
   

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -123,6 +123,26 @@ public class OffsetCurveTest extends GeometryTestCase {
         );
   }
 
+  public void testAsymmetricU() {
+    String wkt = "LINESTRING (1 1, 9 1, 9 2, 5 2)";
+    checkOffsetCurve( wkt, 1,
+        "LINESTRING (1 2, 4 2)"
+        );
+    checkOffsetCurve( wkt, -1,
+        "LINESTRING (1 0, 9 0, 9.2 0.02, 9.38 0.08, 9.56 0.17, 9.71 0.29, 9.83 0.44, 9.92 0.62, 9.98 0.8, 10 1, 10 2, 9.98 2.2, 9.92 2.38, 9.83 2.56, 9.71 2.71, 9.56 2.83, 9.38 2.92, 9.2 2.98, 9 3, 5 3)"
+        );
+  }
+  
+  public void testSymmetricU() {
+    String wkt = "LINESTRING (1 1, 9 1, 9 2, 1 2)";
+    checkOffsetCurve( wkt, 1,
+        "LINESTRING EMPTY"
+        );
+    checkOffsetCurve( wkt, -1,
+        "LINESTRING (1 0, 9 0, 9.2 0.02, 9.38 0.08, 9.56 0.17, 9.71 0.29, 9.83 0.44, 9.92 0.62, 9.98 0.8, 10 1, 10 2, 9.98 2.2, 9.92 2.38, 9.83 2.56, 9.71 2.71, 9.56 2.83, 9.38 2.92, 9.2 2.98, 9 3, 1 3)"
+        );
+  }
+  
   public void testEmptyResult() {
     checkOffsetCurve(
         "LINESTRING (3 5, 5 7, 7 5)", -4,


### PR DESCRIPTION
The `OffsetCurve` class added in #810 had an intentional design for the generated output.  It only provides a single line output.  This semantic was motivated by discussions with the GEOS community (see https://github.com/libgeos/geos/issues/477).   

However, it is recognized that in some cases this behaviour doesn't fully represent the linework which can be considered to be part of an offset curve.  In particular, input lines with self-intersections produce curves which are shorter than desirable in some cases.  Also, it doesn't match the output generated by the original GEOS/PostGIS OffsetCurve implementation.   This is discussed in https://github.com/libgeos/geos/issues/816.

It seems like a good thing to produce as much offset linework as feasible.  This PR enhances the `OffsetCurve` class to return as much as possible of the linework which can form an offset curve.  It also adds a "Joined mode" to produce continuous lines.

Fixes #957.

## Enhanced Output
The output contains as much linework as possible that can be determined to be in the offset curve (based on the buffer boundary of the input).  This will be a single line in simple cases (which matches the previous implementation, and the old GEOS code).  For more complex cases containing "narrow corridors" or self-intersections the output will be a MultiLineString containing the various disjoint curves which lie at the given offset distance from the input line.  The output is structured to make it possible to reduce if necessary; in particular, the line elements are ordered along the raw offset curve as much as possible, with the main or outer curve appearing first.

### Examples
Linework with "necks" narrower than twice the offset distance produce additional ring elements in the offset curve:
![image](https://user-images.githubusercontent.com/3529053/220766773-f0c607c7-4d3c-4d65-90be-348ae69bbe9b.png)

Self-intersections can produce ring elements in the offset curve:

_Offset Distance = 8_
![image](https://user-images.githubusercontent.com/3529053/220767031-dc29386f-411e-4388-b4d1-ffa8baa7befe.png)

_Offset Distance = -5_
![image](https://user-images.githubusercontent.com/3529053/220767124-88733239-56fb-49b4-9925-f04a915fe25e.png)

Self-intersections may produce linear elements as well as rings in the offset curve:
![image](https://user-images.githubusercontent.com/3529053/220765831-02bef161-7921-466b-8951-c5991af60414.png)

Example showing offsets on both sides:
![image](https://user-images.githubusercontent.com/3529053/220788442-d4df6fc6-9714-4f8a-85c6-40df4ee62435.png)


## Joined Mode
The class also adds a "Joined mode", which joins computed offset curve sections into a single continuous line.  (See below for examples).  In cases of self-intersecting input this produces output which may better correspond to expectations of what the offset curve should look like.  (Note that this mode may cause the output to contain "flattening" artifacts at large offset distances.)

### Examples of Joined Mode
![image](https://user-images.githubusercontent.com/3529053/220767950-79a3891c-10d3-4e8d-8a06-a13b35c26d7d.png)

![image](https://user-images.githubusercontent.com/3529053/220768024-09138597-c492-4d7a-a67f-828bd31343ba.png)

An example of a flattening artifact in Join mode:
![image](https://user-images.githubusercontent.com/3529053/220786454-33142b25-02e2-4d76-ad6f-9dc43a677ced.png)



