### PR TITLE
Fix CoveragePolygonValidator to detect segment-equal covering polygons 

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageRing.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageRing.java
@@ -58,9 +58,16 @@ class CoverageRing extends BasicSegmentString {
     return new CoverageRing(pts, isInteriorOnRight);
   }
   
-  public static boolean isMatched(List<CoverageRing> rings) {
+  /**
+   * Tests if all rings have known status (matched or invalid)
+   * for all segments.
+   * 
+   * @param rings a list of rings
+   * @return true if all ring segments have known status
+   */
+  public static boolean isKnown(List<CoverageRing> rings) {
     for (CoverageRing ring : rings) {
-      if (! ring.isMatched())
+      if (! ring.isKnown())
         return false;
     }
     return true;
@@ -70,27 +77,58 @@ class CoverageRing extends BasicSegmentString {
   private boolean[] isInvalid;
   private boolean[] isMatched;
 
-  public CoverageRing(Coordinate[] pts, boolean isInteriorOnRight) {
+  private CoverageRing(Coordinate[] pts, boolean isInteriorOnRight) {
     super(pts, null);
     this.isInteriorOnRight = isInteriorOnRight;
     isInvalid = new boolean[size() - 1];
     isMatched = new boolean[size() - 1];
   }
   
+  /**
+   * Reports if the ring has canonical orientation,
+   * with the polygon interior on the right (shell is CW).
+   * 
+   * @return true if the polygon interior is on the right
+   */
   public boolean isInteriorOnRight() {
     return isInteriorOnRight;
   }
+
   
   /**
-   * Tests if a segment is matched.
+   * Marks a segment as invalid.
    * 
-   * @param index the segment index
-   * @return true if the segment is matched
+   * @param i the segment index
    */
-  public boolean isMatched(int index) {
-    return isMatched[index];
+  public void markInvalid(int i) {
+    isInvalid[i] = true;
   }
 
+  /**
+   * Marks a segment as valid.
+   * 
+   * @param i the segment index
+   */
+  public void markMatched(int i) {
+    //if (isInvalid[i])
+    //  throw new IllegalStateException("Setting invalid edge to matched");
+    isMatched[i] = true;
+  }
+  
+  /**
+   * Tests if all segments in the ring have known status
+   * (matched or invalid).
+   * 
+   * @return true if all segments have known status
+   */
+  public boolean isKnown() {
+    for (int i = 0; i < isMatched.length; i++) {
+      if (! (isMatched[i] && isInvalid[i]))
+        return false;
+    }
+    return true;
+  }
+  
   /**
    * Tests if a segment is marked invalid.
    * 
@@ -101,19 +139,6 @@ class CoverageRing extends BasicSegmentString {
     return isInvalid[index];
   }
   
-  /**
-   * Tests whether all segments are valid.
-   * 
-   * @return true if all segments are valid
-   */
-  public boolean isMatched() {
-    for (int i = 0; i < isMatched.length; i++) {
-      if (! isMatched[i])
-        return false;
-    }
-    return true;
-  }
-
   /**
    * Tests whether all segments are invalid.
    * 
@@ -207,26 +232,6 @@ class CoverageRing extends BasicSegmentString {
     if (index < size() - 2) 
       return index + 1;
     return 0;
-  }
-  
-  /**
-   * Marks a segment as invalid.
-   * 
-   * @param i the segment index
-   */
-  public void markInvalid(int i) {
-    isInvalid[i] = true;
-  }
-
-  /**
-   * Marks a segment as valid.
-   * 
-   * @param i the segment index
-   */
-  public void markMatched(int i) {
-    if (isInvalid[i])
-      throw new IllegalStateException("Setting invalid edge to matched");
-    isMatched[i] = true;
   }
 
   public void createInvalidLines(GeometryFactory geomFactory, List<LineString> lines) {

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/InvalidSegmentDetector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/InvalidSegmentDetector.java
@@ -53,9 +53,12 @@ class InvalidSegmentDetector implements SegmentIntersector {
     // note the source of the edges is important
     CoverageRing target = (CoverageRing) ssTarget;
     CoverageRing adj = (CoverageRing) ssAdj;
+
+    //-- Assert: rings are not equal (because used with SegmentSetMutualIntersector
     
     //-- skip target segments with known status
-    if (target.isKnown(iTarget)) return;
+    //if (target.isKnown(iTarget)) return;
+    if (target.isInvalid(iTarget)) return;
     
     Coordinate t0 = target.getCoordinate(iTarget);
     Coordinate t1 = target.getCoordinate(iTarget + 1);
@@ -69,6 +72,8 @@ class InvalidSegmentDetector implements SegmentIntersector {
     //-- skip zero-length segments
     if (t0.equals2D(t1) || adj0.equals2D(adj1))
       return;
+    if (isEqual(t0, t1, adj0, adj1))
+      return;
 
     /*
     //-- skip segments beyond distance tolerance
@@ -81,6 +86,14 @@ class InvalidSegmentDetector implements SegmentIntersector {
     if (isInvalid) {
       target.markInvalid(iTarget);
     }
+  }
+
+  private boolean isEqual(Coordinate t0, Coordinate t1, Coordinate adj0, Coordinate adj1) {
+    if (t0.equals2D(adj0) && t1.equals2D(adj1))
+      return true;
+    if (t0.equals2D(adj1) && t1.equals2D(adj0))
+      return true;
+    return false;
   }
 
   private boolean isInvalid(Coordinate tgt0, Coordinate tgt1, 
@@ -149,6 +162,12 @@ class InvalidSegmentDetector implements SegmentIntersector {
     //-- find adjacent-ring vertices on either side of intersection vertex
     Coordinate adjPrev = adj.findVertexPrev(indexAdj, intVertex);
     Coordinate adjNext = adj.findVertexNext(indexAdj, intVertex);
+    
+    //-- don't check if test segment is equal to either corner segment
+    if (tgtEnd.equals2D(adjPrev) || tgtEnd.equals2D(adjNext)) {
+      return false;
+    }
+    
     //-- if needed, re-orient corner to have interior on right
     if (! adj.isInteriorOnRight()) {
       Coordinate temp = adjPrev;

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/InvalidSegmentDetector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/InvalidSegmentDetector.java
@@ -24,6 +24,9 @@ import org.locationtech.jts.noding.SegmentString;
  * must be {@link CoverageRing}s.
  * If an invalid situation is detected the input target segment is 
  * marked invalid using {@link CoverageRing#markInvalid(int)}.
+ * <p>
+ * This class assumes it is used with {@link SegmentSetMutualIntersector},
+ * so that segments in the same ring are not evaluated.
  * 
  * @author Martin Davis
  *
@@ -54,11 +57,10 @@ class InvalidSegmentDetector implements SegmentIntersector {
     CoverageRing target = (CoverageRing) ssTarget;
     CoverageRing adj = (CoverageRing) ssAdj;
 
-    //-- Assert: rings are not equal (because used with SegmentSetMutualIntersector
+    //-- Assert: rings are not equal (because this is used with SegmentSetMutualIntersector)
     
     //-- skip target segments with known status
-    //if (target.isKnown(iTarget)) return;
-    if (target.isInvalid(iTarget)) return;
+    if (target.isKnown(iTarget)) return;
     
     Coordinate t0 = target.getCoordinate(iTarget);
     Coordinate t1 = target.getCoordinate(iTarget + 1);

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoveragePolygonValidatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoveragePolygonValidatorTest.java
@@ -127,6 +127,12 @@ public class CoveragePolygonValidatorTest extends GeometryTestCase {
         "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
         "LINESTRING (3 7, 7 7, 7 3, 3 3, 3 7)");
   }
+  
+  public void testFullyCoveredAndMatched() {
+    checkInvalid("POLYGON ((1 3, 2 3, 2 2, 1 2, 1 3))",
+        "MULTIPOLYGON (((1 1, 1 2, 2 2, 2 1, 1 1)), ((3 1, 2 1, 2 2, 3 2, 3 1)), ((3 3, 3 2, 2 2, 2 3, 3 3)), ((2 3, 3 3, 3 2, 3 1, 2 1, 1 1, 1 2, 1 3, 2 3)))",
+        "LINESTRING (1 2, 2 2, 2 3)");
+  }
 
   //========  Gap cases   =============================
   

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoveragePolygonValidatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoveragePolygonValidatorTest.java
@@ -39,9 +39,15 @@ public class CoveragePolygonValidatorTest extends GeometryTestCase {
         "LINESTRING (100 200, 200 200)");
   }
 
-  public void testDuplicateGeometry() {
+  public void testDuplicate() {
     checkInvalid("POLYGON ((1 3, 3 3, 3 1, 1 1, 1 3))",
         "MULTIPOLYGON (((1 3, 3 3, 3 1, 1 1, 1 3)), ((5 3, 5 1, 3 1, 3 3, 5 3)))",
+        "LINEARRING (1 3, 1 1, 3 1, 3 3, 1 3)");
+  }
+
+  public void testDuplicateReversed() {
+    checkInvalid("POLYGON ((1 3, 3 3, 3 1, 1 1, 1 3))",
+        "MULTIPOLYGON (((1 3, 1 1, 3 1, 3 3, 1 3))), ((5 3, 5 1, 3 1, 3 3, 5 3)))",
         "LINEARRING (1 3, 1 1, 3 1, 3 3, 1 3)");
   }
 
@@ -107,7 +113,7 @@ public class CoveragePolygonValidatorTest extends GeometryTestCase {
   public void testInteriorSegmentsWithMatch() {
     checkInvalid("POLYGON ((7 6, 1 1, 3 6, 7 6))",
         "MULTIPOLYGON (((1 9, 9 9, 9 1, 1 1, 3 6, 1 9)), ((0 1, 0 9, 1 9, 3 6, 1 1, 0 1)))",
-        "LINESTRING (3 6, 7 6, 1 1)");
+        "LINESTRING (7 6, 1 1, 3 6, 7 6)");
   }
 
   public void testAdjacentHoleOverlap() {
@@ -131,9 +137,21 @@ public class CoveragePolygonValidatorTest extends GeometryTestCase {
   public void testFullyCoveredAndMatched() {
     checkInvalid("POLYGON ((1 3, 2 3, 2 2, 1 2, 1 3))",
         "MULTIPOLYGON (((1 1, 1 2, 2 2, 2 1, 1 1)), ((3 1, 2 1, 2 2, 3 2, 3 1)), ((3 3, 3 2, 2 2, 2 3, 3 3)), ((2 3, 3 3, 3 2, 3 1, 2 1, 1 1, 1 2, 1 3, 2 3)))",
-        "LINESTRING (1 2, 2 2, 2 3)");
+        "LINESTRING (1 2, 1 3, 2 3)");
   }
 
+  public void testTargetCoveredAndMatching() {
+    checkInvalid("POLYGON ((1 7, 5 7, 9 7, 9 3, 5 3, 1 3, 1 7))",
+        "MULTIPOLYGON (((5 9, 9 7, 5 7, 1 7, 5 9)), ((1 7, 5 7, 5 3, 1 3, 1 7)), ((9 3, 5 3, 5 7, 9 7, 9 3)), ((1 3, 5 3, 9 3, 5 1, 1 3)))",
+        "LINESTRING (1 7, 5 7, 9 7, 9 3, 5 3, 1 3, 1 7))");
+  }
+  
+  public void testCoveredBy2AndMatching() {
+    checkInvalid("POLYGON ((1 9, 9 9, 9 5, 1 5, 1 9))",
+        "MULTIPOLYGON (((1 5, 9 5, 9 1, 1 1, 1 5)), ((1 9, 5 9, 5 1, 1 1, 1 9)), ((9 9, 9 1, 5 1, 5 9, 9 9)))",
+        "LINESTRING (1 5, 1 9, 9 9, 9 5)");
+  }
+  
   //========  Gap cases   =============================
   
   public void testGap() {
@@ -153,11 +171,6 @@ public class CoveragePolygonValidatorTest extends GeometryTestCase {
   public void testRingsCCW() {
     checkValid("POLYGON ((1 1, 6 5, 4 9, 1 9, 1 1))",
         "POLYGON ((1 1, 9 1, 9 4, 6 5, 1 1))");
-  }
-  
-  public void testTargetCoveredAndMatching() {
-    checkValid("POLYGON ((1 7, 5 7, 9 7, 9 3, 5 3, 1 3, 1 7))",
-        "MULTIPOLYGON (((5 9, 9 7, 5 7, 1 7, 5 9)), ((1 7, 5 7, 5 3, 1 3, 1 7)), ((9 3, 5 3, 5 7, 9 7, 9 3)), ((1 3, 5 3, 9 3, 5 1, 1 3)))");
   }
   
   //-- confirms zero-length segments are skipped in processing

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageValidatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageValidatorTest.java
@@ -49,6 +49,19 @@ public class CoverageValidatorTest extends GeometryTestCase
             );
   }
   
+  public void testFullyCoveredTriangles() {
+    checkInvalid(readArray(
+        "POLYGON ((1 9, 9 1, 1 1, 1 9))",
+        "POLYGON ((9 9, 1 9, 9 1, 9 9))",
+        "POLYGON ((9 9, 9 1, 1 1, 1 9, 9 9))"
+        ),
+        readArray(
+            "LINESTRING (9 1, 1 1, 1 9)",
+            "LINESTRING (9 1, 9 9, 1 9)",
+            "LINESTRING (9 9, 9 1, 1 1, 1 9, 9 9)")
+            );
+  }
+  
   //========  Gap cases   =============================
 
   public void testGap() {


### PR DESCRIPTION
This fixes `CoveragePolygonValidator` to detect covering polygons with all equal segments.  It does this by taking into account segment orientation.  Segments with identical orientation (in normalized polygons) indicate an invalid coverage, since the parent polygons must overlap.

This also detects duplicate polygons, which allow removing the special check for this situation.

Performance is similar to the old code, and may even be improved in some situations.
 