### PR TITLE
Improve use of isFreeRing in createEdges

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/coverage/TPVWSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/TPVWSimplifier.java
@@ -124,11 +124,10 @@ class TPVWSimplifier {
     List<Edge> edges = new ArrayList<Edge>();
     if (lines == null)
       return edges;
-    if (isFreeRing == null)
-      isFreeRing = new BitSet(lines.getNumGeometries());
     for (int i = 0 ; i < lines.getNumGeometries(); i++) {
       LineString line = (LineString) lines.getGeometryN(i);
-      edges.add(new Edge(line, isFreeRing.get(i), areaTolerance));
+      boolean isFree = isFreeRing == null ? false : isFreeRing.get(i);
+      edges.add(new Edge(line, isFree, areaTolerance));
     }
     return edges;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/TPVWSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/TPVWSimplifier.java
@@ -104,8 +104,8 @@ class TPVWSimplifier {
   }
 
   private Geometry simplify() {
-    List<Edge> edges = createEdges(inputLines);
-    List<Edge> constraintEdges = createEdges(constraintLines);
+    List<Edge> edges = createEdges(inputLines, this.isFreeRing);
+    List<Edge> constraintEdges = createEdges(constraintLines, null);
 
     EdgeIndex edgeIndex = new EdgeIndex();
     edgeIndex.add(edges);
@@ -120,7 +120,7 @@ class TPVWSimplifier {
     return geomFactory.createMultiLineString(result);
   }
 
-  private List<Edge> createEdges(MultiLineString lines) {
+  private List<Edge> createEdges(MultiLineString lines, BitSet isFreeRing) {
     List<Edge> edges = new ArrayList<Edge>();
     if (lines == null)
       return edges;


### PR DESCRIPTION
The instance field `isFreeRing` refers to the geometry in the instance field `inputLines`. It has nothing to do with the geometry in the instance field `constraintLines` and thus should not be applied to it.