### PR TITLE
Fix OffsetCurve to handle zero offset distance

### DIFF
--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -39,16 +39,17 @@ Distributions for older JTS versions can be obtained at the
 ### Bug Fixes
 * Fix `PreparedGeometry` handling of EMPTY elements (#904)
 * Fix `WKBReader` parsing of WKB containing multiple empty elements (#905)
-* Fix `LineSegment.orientationIndex(LineSegment)` to correct orientation for non-collinear segments on right (#914) 
+* Fix `LineSegment.orientationIndex(LineSegment)` to correct orientation for non-collinear segments on right (#914)
 * Fix `DepthSegment` compareTo method (#920)
 * Ensure `GeometryFixer` does not change coordinate dimension (#922)
 * Improve `ConvexHull` radial sort robustness (#927)
 * Improve robustness of Delaunay Triangulation frame size heuristic (#931)
 * Fix `PreparedLineString.intersects` to handle mixed GCs correctly (#944)
 * Fix `QuadEdgeSubdivision.TriangleEdgesListVisitor` (#945)
-* Fix `PolygonHoleJoiner` to handle all valid inputs 
+* Fix `PolygonHoleJoiner` to handle all valid inputs
   (allows `PolygonTriangulator`, `ConstrainedDelaunayTriangulator`, and `ConcaveHullOfPolygons` to work correctly) (#946)
 * Fix `OffsetCurve` handling of input with repeated points (#956)
+* Fix `OffsetCurve` handling zero offset distance (#971)
 
 ### Performance Improvements
 

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
@@ -38,6 +38,7 @@ import org.locationtech.jts.util.Assert;
  * If the offset distance is positive the curve lies on the left side of the input;
  * if it is negative the curve is on the right side.
  * The curve(s) have the same direction as the input line(s).
+ * The result for a zero offset distance is a copy of the input linework.
  * <p>
  * The offset curve is based on the boundary of the buffer for the geometry
  * at the offset distance (see {@link BufferOp}.
@@ -255,6 +256,10 @@ public class OffsetCurve {
     //-- empty or single-point line
     if (lineGeom.getNumPoints() < 2 || lineGeom.getLength() == 0.0) {
       return geomFactory.createLineString();
+    }
+    //-- zero offset distance
+    if (distance == 0) {
+      return lineGeom.copy();
     }
     //-- two-point line
     if (lineGeom.getNumPoints() == 2) {

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -54,6 +54,20 @@ public class OffsetCurveTest extends GeometryTestCase {
         "LINESTRING EMPTY"
         );
   }
+  
+  public void testZeroOffsetLine() {
+    checkOffsetCurve(
+        "LINESTRING (0 0, 1 0, 1 1)", 0,
+        "LINESTRING (0 0, 1 0, 1 1)"
+        );
+  }
+
+  public void testZeroOffsetPolygon() {
+    checkOffsetCurve(
+        "POLYGON ((1 9, 9 1, 1 1, 1 9))", 0,
+        "LINESTRING (1 9, 1 1, 9 1, 1 9)"
+        );
+  }
 
   /**
    * Test bug fix for removing repeated points in input for raw curve.


### PR DESCRIPTION
Fixes OffsetCurve to handle zero offset distances correctly.

Reported in https://github.com/libgeos/geos/issues/850.