### PR TITLE
Add MinimumAreaRectangle

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/ConstructionFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/ConstructionFunctions.java
@@ -14,7 +14,7 @@ package org.locationtech.jtstest.function;
 import org.locationtech.jts.algorithm.Angle;
 import org.locationtech.jts.algorithm.MinimumBoundingCircle;
 import org.locationtech.jts.algorithm.MinimumDiameter;
-import org.locationtech.jts.algorithm.MinimumRectangle;
+import org.locationtech.jts.algorithm.MinimumAreaRectangle;
 import org.locationtech.jts.algorithm.construct.LargestEmptyCircle;
 import org.locationtech.jts.algorithm.construct.MaximumInscribedCircle;
 import org.locationtech.jts.algorithm.hull.ConcaveHull;
@@ -30,9 +30,10 @@ public class ConstructionFunctions {
   
   public static Geometry minimumDiameter(Geometry g) {      return (new MinimumDiameter(g)).getDiameter();  }
   public static double minimumDiameterLength(Geometry g) {      return (new MinimumDiameter(g)).getDiameter().getLength();  }
+  public static Geometry minimumDiameterRectangle(Geometry g) { return MinimumDiameter.getMinimumRectangle(g);  }
 
-  public static Geometry minimumRectangle(Geometry g) { return MinimumRectangle.getMinimumRectangle(g);  }
-  
+  public static Geometry minimumAreaRectangle(Geometry g) { return MinimumAreaRectangle.getMinimumRectangle(g);  }
+    
   public static Geometry minimumBoundingCircle(Geometry g) { return (new MinimumBoundingCircle(g)).getCircle();  }
   public static double minimumBoundingCircleDiameterLen(Geometry g) {      return 2 * (new MinimumBoundingCircle(g)).getRadius();  }
 

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/ConstructionFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/ConstructionFunctions.java
@@ -14,6 +14,7 @@ package org.locationtech.jtstest.function;
 import org.locationtech.jts.algorithm.Angle;
 import org.locationtech.jts.algorithm.MinimumBoundingCircle;
 import org.locationtech.jts.algorithm.MinimumDiameter;
+import org.locationtech.jts.algorithm.MinimumRectangle;
 import org.locationtech.jts.algorithm.construct.LargestEmptyCircle;
 import org.locationtech.jts.algorithm.construct.MaximumInscribedCircle;
 import org.locationtech.jts.algorithm.hull.ConcaveHull;
@@ -30,7 +31,7 @@ public class ConstructionFunctions {
   public static Geometry minimumDiameter(Geometry g) {      return (new MinimumDiameter(g)).getDiameter();  }
   public static double minimumDiameterLength(Geometry g) {      return (new MinimumDiameter(g)).getDiameter().getLength();  }
 
-  public static Geometry minimumRectangle(Geometry g) { return (new MinimumDiameter(g)).getMinimumRectangle();  }
+  public static Geometry minimumRectangle(Geometry g) { return MinimumRectangle.getMinimumRectangle(g);  }
   
   public static Geometry minimumBoundingCircle(Geometry g) { return (new MinimumBoundingCircle(g)).getCircle();  }
   public static double minimumBoundingCircleDiameterLen(Geometry g) {      return 2 * (new MinimumBoundingCircle(g)).getRadius();  }

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/Distance.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/Distance.java
@@ -219,4 +219,21 @@ public class Distance {
     return Math.abs(s) * Math.sqrt(len2);
   }
 
+  public static double pointToLinePerpendicularSigned(Coordinate p,
+      Coordinate A, Coordinate B)
+  {
+    // use comp.graphics.algorithms Frequently Asked Questions method
+    /*
+     * (2) s = (Ay-Cy)(Bx-Ax)-(Ax-Cx)(By-Ay) 
+     *         ----------------------------- 
+     *                    L^2
+     * 
+     * Then the distance from C to P = |s|*L.
+     */
+    double len2 = (B.x - A.x) * (B.x - A.x) + (B.y - A.y) * (B.y - A.y);
+    double s = ((A.y - p.y) * (B.x - A.x) - (A.x - p.x) * (B.y - A.y))
+        / len2;
+  
+    return s * Math.sqrt(len2);
+  }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
@@ -30,13 +30,16 @@ import org.locationtech.jts.geom.Polygon;
  * <p>
  * In degenerate cases the minimum enclosing geometry 
  * may be a {@link LineString} or a {@link Point}.
- * </ul>
+ * <p>
+ * The minimum-area rectangle does not necessarily
+ * have the minimum possible width.
+ * Use {@link MinimumDiameter} to compute this.
  * 
  * @see MinimumDiameter
  * @see ConvexHull
  *
  */
-public class MinimumRectangle
+public class MinimumAreaRectangle
 {
   /**
    * Gets the minimum-area rectangular {@link Polygon} which encloses the input geometry.
@@ -50,7 +53,7 @@ public class MinimumRectangle
    * @return the minimum rectangle enclosing the geometry
    */
   public static Geometry getMinimumRectangle(Geometry geom) {
-    return (new MinimumRectangle(geom)).getMinimumRectangle();
+    return (new MinimumAreaRectangle(geom)).getMinimumRectangle();
   }
   
   private final Geometry inputGeom;
@@ -60,11 +63,11 @@ public class MinimumRectangle
   private LineSegment minBaseSeg = new LineSegment();
 
   /**
-   * Compute a minimum rectangle for a given {@link Geometry}.
+   * Compute a minimum-area rectangle for a given {@link Geometry}.
    *
    * @param inputGeom a Geometry
    */
-  public MinimumRectangle(Geometry inputGeom)
+  public MinimumAreaRectangle(Geometry inputGeom)
   {
     this(inputGeom, false);
   }
@@ -79,7 +82,7 @@ public class MinimumRectangle
    * @param inputGeom a Geometry which is convex
    * @param isConvex <code>true</code> if the input geometry is convex
    */
-  public MinimumRectangle(Geometry inputGeom, boolean isConvex)
+  public MinimumAreaRectangle(Geometry inputGeom, boolean isConvex)
   {
     this.inputGeom = inputGeom;
     this.isConvex = isConvex;

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023 Martin Davis.
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * and Eclipse Distribution License v. 1.0 which accompanies this distribution.

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
@@ -12,11 +12,11 @@
 package org.locationtech.jts.algorithm;
 
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineSegment;
 import org.locationtech.jts.geom.LineString;
-import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
@@ -22,7 +22,7 @@ import org.locationtech.jts.geom.Polygon;
 
 /**
  * Computes the minimum-area rectangle enclosing a {@link Geometry}.
- * Unlike the {@link Envelope, the rectangle may not be axis-parallel.
+ * Unlike the {@link Envelope}, the rectangle may not be axis-parallel.
  * <p>
  * The first step in the algorithm is computing the convex hull of the Geometry.
  * If the input Geometry is known to be convex, a hint can be supplied to
@@ -31,7 +31,7 @@ import org.locationtech.jts.geom.Polygon;
  * In degenerate cases the minimum enclosing geometry 
  * may be a {@link LineString} or a {@link Point}.
  * <p>
- * The minimum-area rectangle does not necessarily
+ * The minimum-area enclosing rectangle does not necessarily
  * have the minimum possible width.
  * Use {@link MinimumDiameter} to compute this.
  * 

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
@@ -36,31 +36,37 @@ import org.locationtech.jts.geom.Polygon;
  * <ul>
  * <li>a line segment representing the minimum diameter
  * <li>the <b>supporting line segment</b> of the minimum diameter
- * <li>the <b>minimum enclosing rectangle</b> of the input geometry.
+ * <li>the <b>minimum-width rectangle</b> of the input geometry.
  * The rectangle has width equal to the minimum diameter, and has one side
  * parallel to the supporting segment.
- * In degenerate cases the minimum enclosing geometry may be a LineString or a Point.
+ * (Note: this may <b>not</b> be the enclosing rectangle with minimum area; 
+ * use {@link MinimumAreaRectangle} to compute this.)
+ * In degenerate cases the rectangle may be a LineString or a Point.
  * </ul>
  * 
  *
  * @see ConvexHull
+ * @see MinimumAreaRectangle
  *
  * @version 1.7
  */
 public class MinimumDiameter
 {
   /**
-   * Gets the minimum rectangular {@link Polygon} which encloses the input geometry.
+   * Gets the minimum-width rectangular {@link Polygon} which encloses the input geometry
+   * and is based along the supporting segment.
    * The rectangle has width equal to the minimum diameter, 
    * and a longer length.
    * If the convex hull of the input is degenerate (a line or point)
    * a {@link LineString} or {@link Point} is returned.
    * <p>
-   * The minimum rectangle can be used as an extremely generalized representation
-   * for the given geometry.
+   * This is not necessarily the rectangle with minimum area.
+   * Use {@link MinimumAreaRectangle} to compute this.
    * 
    * @param geom the geometry
-   * @return the minimum rectangle enclosing the geometry
+   * @return the minimum-width rectangle enclosing the geometry
+   * 
+   * @see MinimumAreaRectangle
    */
   public static Geometry getMinimumRectangle(Geometry geom) {
     return (new MinimumDiameter(geom)).getMinimumRectangle();
@@ -260,17 +266,18 @@ public class MinimumDiameter
   }
   
   /**
-   * Gets the rectangular {@link Polygon} which encloses the input geometry,
-   * and is based along the minimum diameter supporting segment.
-   * This is NOT necessarily the minimum-area rectangle.
+   * Gets the rectangular {@link Polygon} which encloses the input geometry
+   * and is based on the minimum diameter supporting segment.
    * The rectangle has width equal to the minimum diameter, 
    * and a longer length.
    * If the convex hull of the input is degenerate (a line or point)
    * a {@link LineString} or {@link Point} is returned.
+   * <p>
+   * This is not necessarily the enclosing rectangle with minimum area.
    * 
    * @return a rectangle enclosing the input (or a line or point if degenerate)
    * 
-   * @deprecated use {@link MinimumDiameter}
+   * @see MinimumAreaRectangle
    */
   public Geometry getMinimumRectangle()
   {

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
@@ -39,9 +39,9 @@ import org.locationtech.jts.geom.Polygon;
  * <li>the <b>minimum-width rectangle</b> of the input geometry.
  * The rectangle has width equal to the minimum diameter, and has one side
  * parallel to the supporting segment.
- * (Note: this may <b>not</b> be the enclosing rectangle with minimum area; 
- * use {@link MinimumAreaRectangle} to compute this.)
  * In degenerate cases the rectangle may be a LineString or a Point.
+ * (Note that this may not be the enclosing rectangle with minimum area; 
+ * use {@link MinimumAreaRectangle} to compute this.)
  * </ul>
  * 
  *

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
@@ -287,7 +287,7 @@ public class MinimumDiameter
     if (minWidth == 0.0) {
       //-- Min rectangle is a point
       if (minBaseSeg.p0.equals2D(minBaseSeg.p1)) {
-        return inputGeom.getFactory().createPoint(minBaseSeg.p0);
+        return inputGeom.getFactory().createPoint(minBaseSeg.p0.copy());
       }
       //-- Min rectangle is a line. Use the diagonal of the extent
       return computeMaximumLine(convexHullPts, inputGeom.getFactory());

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumDiameter.java
@@ -217,7 +217,7 @@ public class MinimumDiameter
     int currMaxIndex = 1;
 
     LineSegment seg = new LineSegment();
-    // compute the max distance for all segments in the ring, and pick the minimum
+    // for each segment, find a vertex at max distance, and pick the minimum
     for (int i = 0; i < pts.length - 1; i++) {
       seg.p0 = pts[i];
       seg.p1 = pts[i + 1];
@@ -260,16 +260,17 @@ public class MinimumDiameter
   }
   
   /**
-   * Gets the minimum rectangular {@link Polygon} which encloses the input geometry.
+   * Gets the rectangular {@link Polygon} which encloses the input geometry,
+   * and is based along the minimum diameter supporting segment.
+   * This is NOT necessarily the minimum-area rectangle.
    * The rectangle has width equal to the minimum diameter, 
    * and a longer length.
    * If the convex hull of the input is degenerate (a line or point)
    * a {@link LineString} or {@link Point} is returned.
-   * <p>
-   * The minimum rectangle can be used as an extremely generalized representation
-   * for the given geometry.
    * 
-   * @return the minimum rectangle enclosing the input (or a line or point if degenerate)
+   * @return a rectangle enclosing the input (or a line or point if degenerate)
+   * 
+   * @deprecated use {@link MinimumDiameter}
    */
   public Geometry getMinimumRectangle()
   {

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumRectangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumRectangle.java
@@ -153,15 +153,18 @@ public class MinimumRectangle
       
       segMaxLeftIndex = findFurthestVertex(ring, segDiam, segMaxLeftIndex, 1);
       
+      //-- init the max right index
       if (i == 0) {
         segMaxRightIndex = segMaxDiamIndex;
       }
       segMaxRightIndex = findFurthestVertex(ring, segDiam, segMaxRightIndex, -1);
       
-      double rectWidth = segDiam.distancePerpendicular(ring[segMaxLeftIndex]) 
+      double rectangleWidth = segDiam.distancePerpendicular(ring[segMaxLeftIndex]) 
           + segDiam.distancePerpendicular(ring[segMaxRightIndex]);
-      double rectangleArea = segDiam.getLength() * rectWidth;
+      double rectangleArea = segDiam.getLength() * rectangleWidth;
+      
       if (rectangleArea < minRectangleArea) {
+        //System.out.println("Min Rect area: " + rectangleArea);
         minRectangleArea = rectangleArea;
         baseSegIndex = i;  
         maxDiamIndex = segMaxDiamIndex;
@@ -179,8 +182,7 @@ public class MinimumRectangle
     double nextPerpDistance = maxPerpDistance;
     int maxIndex = startIndex;
     int nextIndex = maxIndex;
-    while (isGreaterOrEqual(nextPerpDistance,
-        maxPerpDistance, orient)) {
+    while (isGreaterOrEqual(nextPerpDistance, maxPerpDistance, orient)) {
       maxPerpDistance = nextPerpDistance;
       maxIndex = nextIndex;
 
@@ -201,15 +203,12 @@ public class MinimumRectangle
     throw new IllegalArgumentException("Invalid orientation value: " + orient);
   }
 
-
   private static double orientedDistance(LineSegment seg, Coordinate p, int orient) {
     double dist = seg.distancePerpendicularOriented(p);
-    switch (orient) {
-    case 0: return Math.abs(dist);
-    case 1: return dist;
-    case -1: return -dist;
+    if (orient == 0) {
+      return Math.abs(dist);
     }
-    throw new IllegalArgumentException("Invalid orientation value: " + orient);
+    return dist;
   }
 
   private static int nextIndex(Coordinate[] ring, int index)

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumRectangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumRectangle.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineSegment;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+/**
+ * Computes the minimum-area rectangle enclosing a {@link Geometry}.
+ * Unlike the {@link Envelope, the rectangle may not be axis-parallel.
+ * <p>
+ * The first step in the algorithm is computing the convex hull of the Geometry.
+ * If the input Geometry is known to be convex, a hint can be supplied to
+ * avoid this computation.
+ * <p>
+ * In degenerate cases the minimum enclosing geometry 
+ * may be a {@link LineString} or a {@link Point}.
+ * </ul>
+ * 
+ * @see MinimumDiameter
+ * @see ConvexHull
+ *
+ */
+public class MinimumRectangle
+{
+  /**
+   * Gets the minimum-area rectangular {@link Polygon} which encloses the input geometry.
+   * If the convex hull of the input is degenerate (a line or point)
+   * a {@link LineString} or {@link Point} is returned.
+   * <p>
+   * The minimum rectangle can be used as a generalized representation
+   * for the given geometry.
+   * 
+   * @param geom the geometry
+   * @return the minimum rectangle enclosing the geometry
+   */
+  public static Geometry getMinimumRectangle(Geometry geom) {
+    return (new MinimumRectangle(geom)).getMinimumRectangle();
+  }
+  
+  private final Geometry inputGeom;
+  private final boolean isConvex;
+
+  private Coordinate[] convexHullPts = null;
+  private LineSegment minBaseSeg = new LineSegment();
+
+  /**
+   * Compute a minimum rectangle for a given {@link Geometry}.
+   *
+   * @param inputGeom a Geometry
+   */
+  public MinimumRectangle(Geometry inputGeom)
+  {
+    this(inputGeom, false);
+  }
+
+  /**
+   * Compute a minimum rectangle for a giver {@link Geometry},
+   * with a hint if
+   * the Geometry is convex
+   * (e.g. a convex Polygon or LinearRing,
+   * or a two-point LineString, or a Point).
+   *
+   * @param inputGeom a Geometry which is convex
+   * @param isConvex <code>true</code> if the input geometry is convex
+   */
+  public MinimumRectangle(Geometry inputGeom, boolean isConvex)
+  {
+    this.inputGeom = inputGeom;
+    this.isConvex = isConvex;
+  }
+
+  private Geometry getMinimumRectangle()
+  {
+    if (isConvex) {
+      return computeConvex(inputGeom);
+    }
+    Geometry convexGeom = (new ConvexHull(inputGeom)).getConvexHull();
+    return computeConvex(convexGeom);
+  }
+
+  private Geometry computeConvex(Geometry convexGeom)
+  {
+//System.out.println("Input = " + geom);
+    if (convexGeom instanceof Polygon)
+      convexHullPts = ((Polygon) convexGeom).getExteriorRing().getCoordinates();
+    else
+      convexHullPts = convexGeom.getCoordinates();
+
+    // special cases for lines or points or degenerate rings
+    if (convexHullPts.length == 0) {
+    }
+    else if (convexHullPts.length == 1) {
+      return inputGeom.getFactory().createPoint(convexHullPts[0].copy());
+    }
+    else if (convexHullPts.length == 2 || convexHullPts.length == 3) {
+      //-- Min rectangle is a line. Use the diagonal of the extent
+      return computeMaximumLine(convexHullPts, inputGeom.getFactory());
+    }
+    //TODO: ensure ring is CW
+    return computeConvexRing(convexHullPts);
+  }
+
+  /**
+   * Compute the minimum-area rectangle for a convex ring of {@link Coordinate}s.
+   * Leaves the width information in the instance variables.
+   * <p>
+   * This algorithm uses the standard "rotating calipers" technique, 
+   * so is linear in the number of segments.
+   *
+   * @param ring
+   */
+  private Polygon computeConvexRing(Coordinate[] ring)
+  {
+    // for each segment in the ring
+    double minRectangleArea = Double.MAX_VALUE;
+    int baseSegIndex = -1;
+    int maxDiamIndex = -1;
+    int maxLeftIndex = -1;
+    int maxRightIndex = -1;
+    
+    int segMaxDiamIndex = 1;
+    int segMaxLeftIndex = 1;
+    int segMaxRightIndex = 0;
+
+    LineSegment seg = new LineSegment();
+    LineSegment segDiam = new LineSegment();
+    // for each segment, find the next vertex which is at maximum distance
+    for (int i = 0; i < ring.length - 1; i++) {
+      seg.p0 = ring[i];
+      seg.p1 = ring[i + 1];
+      segMaxDiamIndex = findFurthestVertex(ring, seg, segMaxDiamIndex, 0);
+      
+      Coordinate diamPt = ring[segMaxDiamIndex];
+      Coordinate diamBasePt = seg.project(diamPt);  
+      segDiam.p0 = diamBasePt;
+      segDiam.p1 = diamPt;
+      
+      segMaxLeftIndex = findFurthestVertex(ring, segDiam, segMaxLeftIndex, 1);
+      
+      if (i == 0) {
+        segMaxRightIndex = segMaxDiamIndex;
+      }
+      segMaxRightIndex = findFurthestVertex(ring, segDiam, segMaxRightIndex, -1);
+      
+      double rectWidth = segDiam.distancePerpendicular(ring[segMaxLeftIndex]) 
+          + segDiam.distancePerpendicular(ring[segMaxRightIndex]);
+      double rectangleArea = segDiam.getLength() * rectWidth;
+      if (rectangleArea < minRectangleArea) {
+        minRectangleArea = rectangleArea;
+        baseSegIndex = i;  
+        maxDiamIndex = segMaxDiamIndex;
+        maxLeftIndex = segMaxLeftIndex;
+        maxRightIndex = segMaxRightIndex;
+      }
+    }
+    return computeRectangle(ring[baseSegIndex], ring[baseSegIndex + 1],
+        ring[maxDiamIndex], ring[maxLeftIndex], ring[maxRightIndex]);
+  }
+
+  private int findFurthestVertex(Coordinate[] pts, LineSegment seg, int startIndex, int orient)
+  {
+    double maxPerpDistance = orientedDistance(seg, pts[startIndex], orient);
+    double nextPerpDistance = maxPerpDistance;
+    int maxIndex = startIndex;
+    int nextIndex = maxIndex;
+    while (isGreaterOrEqual(nextPerpDistance,
+        maxPerpDistance, orient)) {
+      maxPerpDistance = nextPerpDistance;
+      maxIndex = nextIndex;
+
+      nextIndex = nextIndex(pts, maxIndex);
+      if (nextIndex == startIndex)
+        break;
+      nextPerpDistance = orientedDistance(seg, pts[nextIndex], orient);
+    }
+    return maxIndex;
+  }
+
+  private boolean isGreaterOrEqual(double d1, double d2, int orient) {
+    switch (orient) {
+    case 0: return Math.abs(d1) >= Math.abs(d2);
+    case 1: return d1 >= d2;
+    case -1: return d1 <= d2;  
+    }
+    throw new IllegalArgumentException("Invalid orientation value: " + orient);
+  }
+
+
+  private static double orientedDistance(LineSegment seg, Coordinate p, int orient) {
+    double dist = seg.distancePerpendicularOriented(p);
+    switch (orient) {
+    case 0: return Math.abs(dist);
+    case 1: return dist;
+    case -1: return -dist;
+    }
+    throw new IllegalArgumentException("Invalid orientation value: " + orient);
+  }
+
+  private static int nextIndex(Coordinate[] ring, int index)
+  {
+    index++;
+    if (index >= ring.length - 1) index = 0;
+    return index;
+  }
+  
+  private Polygon computeRectangle(Coordinate base0, Coordinate base1, 
+      Coordinate para, Coordinate perp1, Coordinate perp2)
+  {
+    // deltas for the base segment provide slope
+    double dx = base1.x - base0.x;
+    double dy = base1.y - base0.y;
+    
+    double minParaC = computeC(dx, dy, base0);
+    double maxParaC = computeC(dx, dy, para);
+    double minPerpC = computeC(-dy, dx, perp1);
+    double maxPerpC = computeC(-dy, dx, perp2);
+    
+    // compute lines along edges of minimum rectangle
+    LineSegment maxPerpLine = computeSegmentForLine(-dx, -dy, maxPerpC);
+    LineSegment minPerpLine = computeSegmentForLine(-dx, -dy, minPerpC);
+    LineSegment maxParaLine = computeSegmentForLine(-dy, dx, maxParaC);
+    LineSegment minParaLine = computeSegmentForLine(-dy, dx, minParaC);
+    
+    // compute vertices of rectangle (where the para/perp max & min lines intersect)
+    Coordinate p0 = maxParaLine.lineIntersection(maxPerpLine);
+    Coordinate p1 = minParaLine.lineIntersection(maxPerpLine);
+    Coordinate p2 = minParaLine.lineIntersection(minPerpLine);
+    Coordinate p3 = maxParaLine.lineIntersection(minPerpLine);
+    
+    LinearRing shell = inputGeom.getFactory().createLinearRing(
+        new Coordinate[] { p0, p1, p2, p3, p0 });
+    return inputGeom.getFactory().createPolygon(shell);
+  }
+
+  private Polygon computeRectangle2(Coordinate base0, Coordinate base1, 
+      Coordinate para, Coordinate perp1, Coordinate perp2)
+  {
+    // deltas for the base segment of the minimum diameter
+    double dx = base1.x - base0.x;
+    double dy = base1.y - base0.y;
+    
+    double minPara = Double.MAX_VALUE;
+    double maxPara = -Double.MAX_VALUE;
+    double minPerp = Double.MAX_VALUE;
+    double maxPerp = -Double.MAX_VALUE;
+    
+    // compute maxima and minima of lines parallel and perpendicular to base segment
+    for (int i = 0; i < convexHullPts.length; i++) {
+      
+      double paraC = computeC(dx, dy, convexHullPts[i]);
+      if (paraC > maxPara) maxPara = paraC;
+      if (paraC < minPara) minPara = paraC;
+      
+      double perpC = computeC(-dy, dx, convexHullPts[i]);
+      if (perpC > maxPerp) maxPerp = perpC;
+      if (perpC < minPerp) minPerp = perpC;
+    }
+    
+    // compute lines along edges of minimum rectangle
+    LineSegment maxPerpLine = computeSegmentForLine(-dx, -dy, maxPerp);
+    LineSegment minPerpLine = computeSegmentForLine(-dx, -dy, minPerp);
+    LineSegment maxParaLine = computeSegmentForLine(-dy, dx, maxPara);
+    LineSegment minParaLine = computeSegmentForLine(-dy, dx, minPara);
+    
+    // compute vertices of rectangle (where the para/perp max & min lines intersect)
+    Coordinate p0 = maxParaLine.lineIntersection(maxPerpLine);
+    Coordinate p1 = minParaLine.lineIntersection(maxPerpLine);
+    Coordinate p2 = minParaLine.lineIntersection(minPerpLine);
+    Coordinate p3 = maxParaLine.lineIntersection(minPerpLine);
+    
+    LinearRing shell = inputGeom.getFactory().createLinearRing(
+        new Coordinate[] { p0, p1, p2, p3, p0 });
+    return inputGeom.getFactory().createPolygon(shell);
+
+  }
+
+  
+  /**
+   * Gets the minimum-area rectangular {@link Polygon} which encloses the input geometry.
+   * The rectangle has width equal to the minimum diameter, 
+   * and a longer length.
+   * If the convex hull of the input is degenerate (a line or point)
+   * a {@link LineString} or {@link Point} is returned.
+   * <p>
+   * The minimum rectangle can be used as an extremely generalized representation
+   * for the given geometry.
+   * 
+   * @return the minimum rectangle enclosing the input (or a line or point if degenerate)
+   */
+  private Geometry OLDgetMinimumRectangle()
+  {
+    // deltas for the base segment of the minimum diameter
+    double dx = minBaseSeg.p1.x - minBaseSeg.p0.x;
+    double dy = minBaseSeg.p1.y - minBaseSeg.p0.y;
+    
+    double minPara = Double.MAX_VALUE;
+    double maxPara = -Double.MAX_VALUE;
+    double minPerp = Double.MAX_VALUE;
+    double maxPerp = -Double.MAX_VALUE;
+    
+    // compute maxima and minima of lines parallel and perpendicular to base segment
+    for (int i = 0; i < convexHullPts.length; i++) {
+      
+      double paraC = computeC(dx, dy, convexHullPts[i]);
+      if (paraC > maxPara) maxPara = paraC;
+      if (paraC < minPara) minPara = paraC;
+      
+      double perpC = computeC(-dy, dx, convexHullPts[i]);
+      if (perpC > maxPerp) maxPerp = perpC;
+      if (perpC < minPerp) minPerp = perpC;
+    }
+    
+    // compute lines along edges of minimum rectangle
+    LineSegment maxPerpLine = computeSegmentForLine(-dx, -dy, maxPerp);
+    LineSegment minPerpLine = computeSegmentForLine(-dx, -dy, minPerp);
+    LineSegment maxParaLine = computeSegmentForLine(-dy, dx, maxPara);
+    LineSegment minParaLine = computeSegmentForLine(-dy, dx, minPara);
+    
+    // compute vertices of rectangle (where the para/perp max & min lines intersect)
+    Coordinate p0 = maxParaLine.lineIntersection(maxPerpLine);
+    Coordinate p1 = minParaLine.lineIntersection(maxPerpLine);
+    Coordinate p2 = minParaLine.lineIntersection(minPerpLine);
+    Coordinate p3 = maxParaLine.lineIntersection(minPerpLine);
+    
+    LinearRing shell = inputGeom.getFactory().createLinearRing(
+        new Coordinate[] { p0, p1, p2, p3, p0 });
+    return inputGeom.getFactory().createPolygon(shell);
+
+  }
+  
+  /**
+   * Creates a line of maximum extent from the provided vertices
+   * @param pts the vertices
+   * @param factory the geometry factory
+   * @return the line of maximum extent
+   */
+  private static LineString computeMaximumLine(Coordinate[] pts, GeometryFactory factory) {
+    //-- find max and min pts for X and Y
+    Coordinate ptMinX = null;
+    Coordinate ptMaxX = null;
+    Coordinate ptMinY = null;
+    Coordinate ptMaxY = null;
+    for (Coordinate p : pts) {
+      if (ptMinX == null || p.getX() < ptMinX.getX()) ptMinX = p;
+      if (ptMaxX == null || p.getX() > ptMaxX.getX()) ptMaxX = p;
+      if (ptMinY == null || p.getY() < ptMinY.getY()) ptMinY = p;
+      if (ptMaxY == null || p.getY() > ptMaxY.getY()) ptMaxY = p;
+    }
+    Coordinate p0 = ptMinX;
+    Coordinate p1 = ptMaxX;
+    //-- line is vertical - use Y pts
+    if (p0.getX() == p1.getX()) {
+      p0 = ptMinY;
+      p1 = ptMaxY;
+    }
+    return factory.createLineString(new Coordinate[] { p0.copy(), p1.copy() });
+  }
+
+  private static double computeC(double a, double b, Coordinate p)
+  {
+    return a * p.y - b * p.x;
+  }
+  
+  private static LineSegment computeSegmentForLine(double a, double b, double c)
+  {
+    Coordinate p0;
+    Coordinate p1;
+    /*
+    * Line eqn is ax + by = c
+    * Slope is a/b.
+    * If slope is steep, use y values as the inputs
+    */
+    if (Math.abs(b) > Math.abs(a)) {
+      p0 = new Coordinate(0.0, c/b);
+      p1 = new Coordinate(1.0, c/b - a/b);
+    }
+    else {
+      p0 = new Coordinate(c/a, 0.0);
+      p1 = new Coordinate(c/a - b/a, 1.0);
+    }
+    return new LineSegment(p0, p1);
+  }
+}

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/Rectangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/Rectangle.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023 Martin Davis.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineSegment;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+
+class Rectangle {
+  
+  /**
+   * Creates a rectangular {@link Polygon} from a base segment
+   * defining the position and orientation of one side of the rectangle, and 
+   * three points defining the locations of the line segments 
+   * forming the opposite, left and right sides of the rectangle.
+   * The base segment and side points must be presented so that the 
+   * rectangle has CW orientation.
+   * <p>
+   * The rectangle corners are computed as intersections of
+   * lines, which generally cannot produce exact values.
+   * If a rectangle corner is determined to coincide with a side point
+   * the side point value is used to avoid numerical inaccuracy.
+   * <p>
+   * The first side of the constructed rectangle contains the base segment.
+   * 
+   * @param baseRightPt the right point of the base segment
+   * @param baseLeftPt the left point of the base segment
+   * @param oppositePt the point defining the opposite side
+   * @param leftSidePt the point defining the left side
+   * @param rightSidePt the point defining the right side
+   * @param factory the geometry factory to use
+   * @return the rectangular polygon
+   */
+  public static Polygon createFromSidePts(Coordinate baseRightPt, Coordinate baseLeftPt, 
+      Coordinate oppositePt, 
+      Coordinate leftSidePt, Coordinate rightSidePt, 
+      GeometryFactory factory)
+  {
+    //-- deltas for the base segment provide slope
+    double dx = baseLeftPt.x - baseRightPt.x;
+    double dy = baseLeftPt.y - baseRightPt.y;
+    // Assert: dx and dy are not both zero
+    
+    double baseC = computeLineEquationC(dx, dy, baseRightPt);
+    double oppC = computeLineEquationC(dx, dy, oppositePt);
+    double leftC = computeLineEquationC(-dy, dx, leftSidePt);
+    double rightC = computeLineEquationC(-dy, dx, rightSidePt);
+    
+    //-- compute lines along edges of rectangle
+    LineSegment baseLine = createLineForStandardEquation(-dy, dx, baseC);
+    LineSegment oppLine = createLineForStandardEquation(-dy, dx, oppC);
+    LineSegment leftLine = createLineForStandardEquation(-dx, -dy, leftC);
+    LineSegment rightLine = createLineForStandardEquation(-dx, -dy, rightC);
+    
+    /**
+     * Corners of rectangle are the intersections of the 
+     * base and opposite, and left and right lines.
+     * The rectangle is constructed with CW orientation.
+     * The first side of the constructed rectangle contains the base segment.
+     * 
+     * If a corner coincides with a input point
+     * the exact value is used to avoid numerical inaccuracy.
+     */
+    Coordinate p0 = rightSidePt.equals2D(baseRightPt) ? baseRightPt.copy() 
+        : baseLine.lineIntersection(rightLine);
+    Coordinate p1 = leftSidePt.equals2D(baseLeftPt) ? baseLeftPt.copy() 
+        : baseLine.lineIntersection(leftLine);
+    Coordinate p2 = leftSidePt.equals2D(oppositePt) ? oppositePt.copy() 
+        : oppLine.lineIntersection(leftLine);
+    Coordinate p3 = rightSidePt.equals2D(oppositePt) ? oppositePt.copy() 
+        : oppLine.lineIntersection(rightLine);
+    
+    LinearRing shell = factory.createLinearRing(
+        new Coordinate[] { p0, p1, p2, p3, p0.copy() });
+    return factory.createPolygon(shell);
+  }
+
+  /**
+   * Computes the constant C in the standard line equation Ax + By = C
+   * from A and B and a point on the line.
+   * 
+   * @param a the X coefficient
+   * @param b the Y coefficient
+   * @param p a point on the line
+   * @return the constant C
+   */
+  private static double computeLineEquationC(double a, double b, Coordinate p)
+  {
+    return a * p.y - b * p.x;
+  }
+  
+  private static LineSegment createLineForStandardEquation(double a, double b, double c)
+  {
+    Coordinate p0;
+    Coordinate p1;
+    /*
+    * Line equation is ax + by = c
+    * Slope m = -a/b.
+    * Y-intercept = c/b
+    * X-intercept = c/a
+    * 
+    * If slope is low, use constant X values; if high use Y values.
+    * This handles lines that are vertical (b = 0, m = Inf ) 
+    * and horizontal (a = 0, m = 0).
+    */
+    if (Math.abs(b) > Math.abs(a)) {
+      //-- abs(m) < 1
+      p0 = new Coordinate(0.0, c/b);
+      p1 = new Coordinate(1.0, c/b - a/b);
+    }
+    else {
+      //-- abs(m) >= 1
+      p0 = new Coordinate(c/a, 0.0);
+      p1 = new Coordinate(c/a - b/a, 1.0);
+    }
+    return new LineSegment(p0, p1);
+  }
+}

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -268,6 +268,14 @@ public class LineSegment
     return Distance.pointToLinePerpendicular(p, p0, p1);
   }
 
+  public double distancePerpendicularOriented(Coordinate p)
+  {
+    double dist = Distance.pointToLinePerpendicular(p, p0, p1);
+    if (orientationIndex(p) < 0)
+      return -dist;
+    return dist;
+  }
+  
   /**
    * Computes the {@link Coordinate} that lies a given
    * fraction along the line defined by this segment.

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -260,12 +260,16 @@ public class LineSegment
   /**
    * Computes the perpendicular distance between the (infinite) line defined
    * by this line segment and a point.
+   * If the segment has zero length this returns the distance between
+   * the segment and the point.
    *
    * @param p the point to compute the distance to
    * @return the perpendicular distance between the line and point
    */
   public double distancePerpendicular(Coordinate p)
   {
+    if (p0.equals2D(p1))
+      return p0.distance(p);
     return Distance.pointToLinePerpendicular(p, p0, p1);
   }
 
@@ -274,13 +278,17 @@ public class LineSegment
    * defined by this line segment and a point.
    * The oriented distance is positive if the point on the left of the line,
    * and negative if it is on the right.
+   * If the segment has zero length this returns the distance between
+   * the segment and the point.
    * 
    * @param p the point to compute the distance to
    * @return the oriented perpendicular distance between the line and point
    */
   public double distancePerpendicularOriented(Coordinate p)
   {
-    double dist = Distance.pointToLinePerpendicular(p, p0, p1);
+    if (p0.equals2D(p1))
+      return p0.distance(p);
+    double dist = distancePerpendicular(p);
     if (orientationIndex(p) < 0)
       return -dist;
     return dist;

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -261,13 +261,23 @@ public class LineSegment
    * Computes the perpendicular distance between the (infinite) line defined
    * by this line segment and a point.
    *
-   * @return the perpendicular distance between the defined line and the given point
+   * @param p the point to compute the distance to
+   * @return the perpendicular distance between the line and point
    */
   public double distancePerpendicular(Coordinate p)
   {
     return Distance.pointToLinePerpendicular(p, p0, p1);
   }
 
+  /**
+   * Computes the oriented perpendicular distance between the (infinite) line
+   * defined by this line segment and a point.
+   * The oriented distance is positive if the point on the left of the line,
+   * and negative if it is on the right.
+   * 
+   * @param p the point to compute the distance to
+   * @return the oriented perpendicular distance between the line and point
+   */
   public double distancePerpendicularOriented(Coordinate p)
   {
     double dist = Distance.pointToLinePerpendicular(p, p0, p1);

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumAreaRectanglelTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumAreaRectanglelTest.java
@@ -30,6 +30,10 @@ public class MinimumAreaRectanglelTest extends GeometryTestCase {
 
   public MinimumAreaRectanglelTest(String name) { super(name); }
 
+  public void testEmpty() {
+    checkMinRectangle("POLYGON EMPTY", "POLYGON EMPTY");
+  }
+  
   public void testLengthZero() {
     checkMinRectangle("LINESTRING (1 1, 1 1)", "POINT (1 1)");
   }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumAreaRectanglelTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumAreaRectanglelTest.java
@@ -34,26 +34,36 @@ public class MinimumAreaRectanglelTest extends GeometryTestCase {
     checkMinRectangle("POLYGON EMPTY", "POLYGON EMPTY");
   }
   
-  public void testLengthZero() {
+  public void testLineLengthZero() {
     checkMinRectangle("LINESTRING (1 1, 1 1)", "POINT (1 1)");
   }
   
-  public void testHorizontal() {
+  public void testLineHorizontal() {
     checkMinRectangle("LINESTRING (1 1, 3 1, 5 1, 7 1)", "LINESTRING (1 1, 7 1)");
   }
   
-  public void testVertical() {
+  public void testLineVertical() {
     checkMinRectangle("LINESTRING (1 1, 1 4, 1 7, 1 9)", "LINESTRING (1 1, 1 9)");
   }
   
-  public void testBentLine() {
+  public void testLineObtuseAngle() {
     checkMinRectangle("LINESTRING (1 2, 3 8, 9 8)", 
-        "POLYGON ((6.84 10.88, 9 8, 1 2, -1.16 4.88, 6.84 10.88))");
+        "POLYGON ((9 8, 1 2, -1.16 4.88, 6.84 10.88, 9 8))");
   }
   
-  public void testNotMinDiamter() {
+  public void testLineAcuteAngle() {
+    checkMinRectangle("LINESTRING (5 2, 3 8, 9 8)", 
+        "POLYGON ((5 2, 3 8, 8.4 9.8, 10.4 3.8, 5 2))");
+  }
+  
+  public void testNotMinDiameter() {
     checkMinRectangle("POLYGON ((150 300, 200 300, 300 300, 300 250, 280 120, 210 100, 100 100, 100 240, 150 300))", 
         "POLYGON ((100 100, 100 300, 300 300, 300 100, 100 100))");
+  }
+  
+  public void testTriangle() {
+    checkMinRectangle("POLYGON ((100 100, 200 200, 160 240, 100 100))",
+        "POLYGON ((100 100, 160 240, 208.2758620689651 219.31034482758352, 148.2758620689666 79.31034482758756, 100 100))");
   }
   
   public void testConvex() {

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumAreaRectanglelTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumAreaRectanglelTest.java
@@ -20,15 +20,15 @@ import test.jts.GeometryTestCase;
 /**
  * @version 1.7
  */
-public class MinimumRectanglelTest extends GeometryTestCase {
+public class MinimumAreaRectanglelTest extends GeometryTestCase {
 
   private static final double TOL = 1e-10;
 
   public static void main(String args[]) {
-    TestRunner.run(MinimumRectanglelTest.class);
+    TestRunner.run(MinimumAreaRectanglelTest.class);
   }
 
-  public MinimumRectanglelTest(String name) { super(name); }
+  public MinimumAreaRectanglelTest(String name) { super(name); }
 
   public void testLengthZero() {
     checkMinRectangle("LINESTRING (1 1, 1 1)", "POINT (1 1)");
@@ -63,7 +63,7 @@ public class MinimumRectanglelTest extends GeometryTestCase {
    */
   public void testFlatDiagonal() throws Exception {
     checkMinRectangle("LINESTRING(-99.48710639268086 34.79029839231914,-99.48370699999998 34.78689899963806,-99.48152167568102 34.784713675318976)", 
-        "LINESTRING (-99.48710639268086 34.79029839231914, -99.48152167568102 34.784713675318976)");
+        "POLYGON ((-99.48710639268066 34.790298392318675, -99.48710639268066 34.790298392318675, -99.48152167568082 34.78471367531866, -99.48152167568082 34.78471367531866, -99.48710639268066 34.790298392318675))");
   } 
   
   public void testBadRectl() throws Exception {
@@ -73,7 +73,7 @@ public class MinimumRectanglelTest extends GeometryTestCase {
 
   private void checkMinRectangle(String wkt, String wktExpected) {
     Geometry geom = read(wkt);
-    Geometry actual = MinimumRectangle.getMinimumRectangle(geom);
+    Geometry actual = MinimumAreaRectangle.getMinimumRectangle(geom);
     Geometry expected = read(wktExpected);
     checkEqual(expected, actual, TOL);
   }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumRectanglelTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumRectanglelTest.java
@@ -46,6 +46,11 @@ public class MinimumRectanglelTest extends GeometryTestCase {
     checkMinRectangle("LINESTRING (1 2, 3 8, 9 6)", "POLYGON ((9 6, 7 10, -1 6, 1 2, 9 6))");
   }
   
+  public void testNotMinDiamter() {
+    checkMinRectangle("POLYGON ((150 300, 200 300, 300 300, 300 250, 280 120, 210 100, 100 100, 100 240, 150 300))", 
+        "POLYGON ((100 100, 100 300, 300 300, 300 100, 100 100))");
+  }
+  
   /**
    * Failure case from https://trac.osgeo.org/postgis/ticket/5163
    * @throws Exception
@@ -53,11 +58,16 @@ public class MinimumRectanglelTest extends GeometryTestCase {
   public void testFlatDiagonal() throws Exception {
     checkMinRectangle("LINESTRING(-99.48710639268086 34.79029839231914,-99.48370699999998 34.78689899963806,-99.48152167568102 34.784713675318976)", 
         "LINESTRING (-99.48710639268086 34.79029839231914, -99.48152167568102 34.784713675318976)");
+  } 
+  
+  public void testBadRectl() throws Exception {
+    checkMinRectangle("POLYGON ((-5.21175 49.944633, -5.77435 50.021367, -5.7997 50.0306, -5.81815 50.0513, -5.82625 50.073567, -5.83085 50.1173, -6.2741 56.758767, -5.93245 57.909, -5.1158 58.644533, -5.07915 58.661733, -3.42575 58.686633, -3.1392 58.6685, -3.12495 58.666233, -1.88745 57.6444, 1.68845 52.715133, 1.7057 52.6829, 1.70915 52.6522, 1.7034 52.585433, 1.3867 51.214033, 1.36595 51.190267, 1.30485 51.121967, 0.96365 50.928567, 0.93025 50.912433, 0.1925 50.7436, -5.21175 49.944633))", 
+        "LINESTRING (-99.48710639268086 34.79029839231914, -99.48152167568102 34.784713675318976)");
   }  
 
   private void checkMinRectangle(String wkt, String wktExpected) {
     Geometry geom = read(wkt);
-    Geometry actual = MinimumDiameter.getMinimumRectangle(geom);
+    Geometry actual = MinimumRectangle.getMinimumRectangle(geom);
     Geometry expected = read(wktExpected);
     checkEqual(expected, actual, TOL);
   }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumRectanglelTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumRectanglelTest.java
@@ -43,12 +43,18 @@ public class MinimumRectanglelTest extends GeometryTestCase {
   }
   
   public void testBentLine() {
-    checkMinRectangle("LINESTRING (1 2, 3 8, 9 6)", "POLYGON ((9 6, 7 10, -1 6, 1 2, 9 6))");
+    checkMinRectangle("LINESTRING (1 2, 3 8, 9 8)", 
+        "POLYGON ((6.84 10.88, 9 8, 1 2, -1.16 4.88, 6.84 10.88))");
   }
   
   public void testNotMinDiamter() {
     checkMinRectangle("POLYGON ((150 300, 200 300, 300 300, 300 250, 280 120, 210 100, 100 100, 100 240, 150 300))", 
         "POLYGON ((100 100, 100 300, 300 300, 300 100, 100 100))");
+  }
+  
+  public void testConvex() {
+    checkMinRectangle("POLYGON ((3 8, 6 8, 9 5, 7 3, 3 1, 2 4, 3 8))", 
+        "POLYGON ((0.2 6.6, 6.6 9.8, 9.4 4.2, 3 1, 0.2 6.6))");
   }
   
   /**
@@ -62,7 +68,7 @@ public class MinimumRectanglelTest extends GeometryTestCase {
   
   public void testBadRectl() throws Exception {
     checkMinRectangle("POLYGON ((-5.21175 49.944633, -5.77435 50.021367, -5.7997 50.0306, -5.81815 50.0513, -5.82625 50.073567, -5.83085 50.1173, -6.2741 56.758767, -5.93245 57.909, -5.1158 58.644533, -5.07915 58.661733, -3.42575 58.686633, -3.1392 58.6685, -3.12495 58.666233, -1.88745 57.6444, 1.68845 52.715133, 1.7057 52.6829, 1.70915 52.6522, 1.7034 52.585433, 1.3867 51.214033, 1.36595 51.190267, 1.30485 51.121967, 0.96365 50.928567, 0.93025 50.912433, 0.1925 50.7436, -5.21175 49.944633))", 
-        "LINESTRING (-99.48710639268086 34.79029839231914, -99.48152167568102 34.784713675318976)");
+        "POLYGON ((1.8583607388069103 50.41649058582797, -5.816631979932251 49.904263313964535, -6.395241388167441 58.57389735949991, 1.2797513305717105 59.08612463136336, 1.8583607388069103 50.41649058582797))");
   }  
 
   private void checkMinRectangle(String wkt, String wktExpected) {

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/RectangleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/RectangleTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Martin Davis.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
+
+import junit.textui.TestRunner;
+import test.jts.GeometryTestCase;
+
+public class RectangleTest extends GeometryTestCase 
+{
+  private static final double TOL = 1e-10;
+  
+  public static void main(String args[]) {
+    TestRunner.run(RectangleTest.class);
+  }
+
+  public RectangleTest(String name) { super(name); }
+  
+  public void testOrthogonal() {
+    checkRectangle("LINESTRING (9 1, 1 1, 0 5, 7 10, 10 6)",
+        "POLYGON ((0 1, 0 10, 10 10, 10 1, 0 1))");
+  }
+  
+  public void test45() {
+    checkRectangle("LINESTRING (10 5, 5 0, 2 1, 2 7, 9 9)",
+        "POLYGON ((-1 4, 6.5 11.5, 11.5 6.5, 4 -1, -1 4))");
+  }
+  
+  public void testCoincidentBaseSides() {
+    checkRectangle("LINESTRING (10 5, 7 0, 7 0, 2 7, 10 5)",
+        "POLYGON ((0.2352941176470591 4.0588235294117645, 3.2352941176470598 9.058823529411764, 10 5, 7 0, 0.2352941176470591 4.0588235294117645))");
+  }
+  
+  private void checkRectangle(String wkt, String wktExpected) {
+    LineString line = (LineString) read(wkt);
+    Coordinate baseRightPt = line.getCoordinateN(0);
+    Coordinate baseLeftPt = line.getCoordinateN(1);
+    Coordinate leftSidePt = line.getCoordinateN(2);
+    Coordinate oppositePt = line.getCoordinateN(3);
+    Coordinate rightSidePt = line.getCoordinateN(4);
+    Geometry actual = Rectangle.createFromSidePts(baseRightPt, baseLeftPt,
+        oppositePt, leftSidePt, rightSidePt, line.getFactory());
+    Geometry expected = read(wktExpected);
+    checkEqual(expected, actual, TOL);
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/geom/LineSegmentTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/LineSegmentTest.java
@@ -82,6 +82,37 @@ public class LineSegmentTest extends TestCase {
     assertTrue(dist <= MAX_ABS_ERROR_INTERSECTION);
   }
 
+  public void testDistancePerpendicular() {
+    checkDistancePerpendicular(1,1,  1,3,  2,4, 1);
+    checkDistancePerpendicular(1,1,  1,3,  0,4, 1);
+    checkDistancePerpendicular(1,1,  1,3,  1,4, 0);
+    checkDistancePerpendicular(1,1,  2,2,  4,4, 0);
+  }
+  
+  public void testDistancePerpendicularOriented() {
+    // right of line
+    checkDistancePerpendicularOriented(1,1,  1,3,  2,4, -1);
+    // left of line
+    checkDistancePerpendicularOriented(1,1,  1,3,  0,4, 1);
+    //on line
+    checkDistancePerpendicularOriented(1,1,  1,3,  1,4, 0);
+    checkDistancePerpendicularOriented(1,1,  2,2,  4,4, 0);
+  }
+  
+  private void checkDistancePerpendicular(double x0, double y0, double x1, double y1, double px, double py, 
+      double expected) {
+    LineSegment seg = new LineSegment(x0, y0, x1, y1);
+    double dist = seg.distancePerpendicular(new Coordinate(px, py));
+    assertEquals(expected, dist, 0.000001);
+  }
+  
+  private void checkDistancePerpendicularOriented(double x0, double y0, double x1, double y1, double px, double py, 
+      double expected) {
+    LineSegment seg = new LineSegment(x0, y0, x1, y1);
+    double dist = seg.distancePerpendicularOriented(new Coordinate(px, py));
+    assertEquals(expected, dist, 0.000001);
+  }
+  
   public void testOffsetPoint() throws Exception
   {
     checkOffsetPoint(0, 0, 10, 10, 0.0, ROOT2, -1, 1);

--- a/modules/core/src/test/java/org/locationtech/jts/geom/LineSegmentTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/LineSegmentTest.java
@@ -87,16 +87,20 @@ public class LineSegmentTest extends TestCase {
     checkDistancePerpendicular(1,1,  1,3,  0,4, 1);
     checkDistancePerpendicular(1,1,  1,3,  1,4, 0);
     checkDistancePerpendicular(1,1,  2,2,  4,4, 0);
+    //-- zero-length line segment
+    checkDistancePerpendicular(1,1,  1,1,  1,2, 1);
   }
   
   public void testDistancePerpendicularOriented() {
-    // right of line
+    //-- right of line
     checkDistancePerpendicularOriented(1,1,  1,3,  2,4, -1);
-    // left of line
+    //-- left of line
     checkDistancePerpendicularOriented(1,1,  1,3,  0,4, 1);
-    //on line
+    //-- on line
     checkDistancePerpendicularOriented(1,1,  1,3,  1,4, 0);
     checkDistancePerpendicularOriented(1,1,  2,2,  4,4, 0);
+    //-- zero-length segment
+    checkDistancePerpendicularOriented(1,1,  1,1,  1,2, 1);    
   }
   
   private void checkDistancePerpendicular(double x0, double y0, double x1, double y1, double px, double py, 


### PR DESCRIPTION
To address https://github.com/libgeos/geos/issues/679 (see #907), this adds a `MinimumAreaRectangle` class implementing the standard "rotating-calipers` algorithm for computing a **Minimum-Area Rectangle**.

`MinimumDiameter.getMinimumRectangle` was previously used for this, but it does not always compute the Minimum-Area Rectangle.  It is kept available, for backwards compatibility.  Also, it computes the **Minimum-Width Rectangle**, which may be useful.

![image](https://user-images.githubusercontent.com/3529053/234163221-865855ea-91d3-4f3b-8dc4-50873e8ee8c6.png)


