### PR TITLE
Fix MIC and LEC for thin geometries

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircle.java
@@ -142,6 +142,7 @@ public class LargestEmptyCircle {
   private Point centerPoint = null;
   private Coordinate radiusPt;
   private Point radiusPoint = null;
+  private Geometry bounds;
 
   /**
    * Creates a new instance of a Largest Empty Circle construction,
@@ -235,7 +236,7 @@ public class LargestEmptyCircle {
   }
   
   private void initBoundary() {
-    Geometry bounds = this.boundary;
+    bounds = this.boundary;
     if (bounds == null || bounds.isEmpty()) {
       bounds = obstacles.convexHull();
     }
@@ -278,7 +279,10 @@ public class LargestEmptyCircle {
      * Carry out the branch-and-bound search
      * of the cell space
      */
-    while (! cellQueue.isEmpty()) {
+    long maxIter = MaximumInscribedCircle.computeMaximumIterations(bounds, tolerance);
+    long iter = 0;
+    while (! cellQueue.isEmpty() && iter < maxIter) {
+      iter++;
       // pick the cell with greatest distance from the queue
       Cell cell = cellQueue.remove();
 
@@ -351,6 +355,8 @@ public class LargestEmptyCircle {
     return potentialIncrease > tolerance;
   }
 
+  private static final int INITIAL_GRID_SIDE = 25;
+
   /**
    * Initializes the queue with a grid of cells covering 
    * the extent of the area.
@@ -363,9 +369,7 @@ public class LargestEmptyCircle {
     double maxX = env.getMaxX();
     double minY = env.getMinY();
     double maxY = env.getMaxY();
-    double width = env.getWidth();
-    double height = env.getHeight();
-    double cellSize = Math.min(width, height);
+    double cellSize = env.getDiameter() / INITIAL_GRID_SIDE;
     double hSize = cellSize / 2.0;
 
     // compute initial grid of cells to cover area

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircleTest.java
@@ -41,8 +41,8 @@ public class LargestEmptyCircleTest extends GeometryTestCase {
   }
 
   public void testLinesZigzag() {
-    checkCircle("MULTILINESTRING ((100 100, 200 150, 100 200, 250 250, 100 300, 300 350, 100 400), (50 400, 0 350, 50 300, 0 250, 50 200, 0 150, 50 100))", 
-       0.01, 77.52, 349.99, 54.81 );
+    checkCircle("MULTILINESTRING ((100 100, 200 150, 100 200, 250 250, 100 300, 300 350, 100 400), (70 380, 0 350, 50 300, 0 250, 50 200, 0 150, 50 120))", 
+       0.01, 77.52, 249.99, 54.81 );
   }
 
   public void testPointsLinesTriangle() {
@@ -111,11 +111,11 @@ public class LargestEmptyCircleTest extends GeometryTestCase {
     Geometry centerPoint = lec.getCenter();
     Coordinate centerPt = centerPoint.getCoordinate();
     Coordinate expectedCenter = new Coordinate(x, y);
-    checkEqualXY(expectedCenter, centerPt, tolerance);
+    checkEqualXY(expectedCenter, centerPt, 2 * tolerance);
     
     LineString radiusLine = lec.getRadiusLine();
     double actualRadius = radiusLine.getLength();
-    assertEquals("Radius: ", expectedRadius, actualRadius, tolerance);
+    assertEquals("Radius: ", expectedRadius, actualRadius, 2 * tolerance);
     
     checkEqualXY("Radius line center point: ", centerPt, radiusLine.getCoordinateN(0));
     Coordinate radiusPt = lec.getRadiusPoint().getCoordinate();

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircleTest.java
@@ -59,6 +59,11 @@ public class LargestEmptyCircleTest extends GeometryTestCase {
     checkCircleZeroRadius("LINESTRING (0 0, 50 50)", 
        0.01 );
   }
+  
+  public void testPolygonThin() {
+    checkCircle("MULTIPOINT ((100 100), (300 100), (200 100.1))", 
+       0.01 );
+  }
 
   //---------------------------------------------------------
   // Obstacles and Boundary
@@ -94,6 +99,22 @@ public class LargestEmptyCircleTest extends GeometryTestCase {
   }
   
   //========================================================
+  
+  /**
+   * A coarse distance check, mainly testing 
+   * that there is not a huge number of iterations.
+   * (This will be revealed by CI taking a very long time!)
+   * 
+   * @param wkt
+   * @param tolerance
+   */
+  private void checkCircle(String wkt, double tolerance) {
+    Geometry geom = read(wkt);
+    LargestEmptyCircle mic = new LargestEmptyCircle(geom, null, tolerance); 
+    Geometry centerPoint = mic.getCenter();
+    double dist = geom.distance(centerPoint);
+    assert(dist < 2 * tolerance);
+  }
   
   private void checkCircle(String wktObstacles, double tolerance, 
       double x, double y, double expectedRadius) {

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircleTest.java
@@ -110,10 +110,12 @@ public class LargestEmptyCircleTest extends GeometryTestCase {
    */
   private void checkCircle(String wkt, double tolerance) {
     Geometry geom = read(wkt);
-    LargestEmptyCircle mic = new LargestEmptyCircle(geom, null, tolerance); 
-    Geometry centerPoint = mic.getCenter();
+    LargestEmptyCircle lec = new LargestEmptyCircle(geom, null, tolerance); 
+    Geometry centerPoint = lec.getCenter();
     double dist = geom.distance(centerPoint);
-    assert(dist < 2 * tolerance);
+    LineString radiusLine = lec.getRadiusLine();
+    double actualRadius = radiusLine.getLength();
+    assertTrue(Math.abs(actualRadius - dist) < 2 * tolerance);
   }
   
   private void checkCircle(String wktObstacles, double tolerance, 

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscibedCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscibedCircleTest.java
@@ -72,6 +72,37 @@ public class MaximumInscibedCircleTest extends GeometryTestCase {
        0.01, 100, 100, 0 );
   }
   
+  /**
+   * Tests that a nearly flat geometry doesn't make the initial cell grid huge.
+   * 
+   * See https://github.com/libgeos/geos/issues/875
+   */
+  public void testNearlyFlat() {
+    checkCircle("POLYGON ((59.3 100.00000000000001, 99.7 100.00000000000001, 99.7 100, 59.3 100, 59.3 100.00000000000001))", 
+       0.01 );
+  }
+  
+  public void testVeryThin() {
+    checkCircle("POLYGON ((100 100, 200 300, 300 100, 450 250, 300 99.999999, 200 299.99999, 100 100))", 
+       0.01 );
+  }
+  
+  /**
+   * A coarse distance check, mainly testing 
+   * that there is not a huge number of iterations.
+   * (This will be revealed by CI taking a very long time!)
+   * 
+   * @param wkt
+   * @param tolerance
+   */
+  private void checkCircle(String wkt, double tolerance) {
+    Geometry geom = read(wkt);
+    MaximumInscribedCircle mic = new MaximumInscribedCircle(geom, tolerance); 
+    Geometry centerPoint = mic.getCenter();
+    double dist = geom.distance(centerPoint);
+    assert(dist < 2 * tolerance);
+  }
+  
   private void checkCircle(String wkt, double tolerance, 
       double x, double y, double expectedRadius) {
     checkCircle(read(wkt), tolerance, x, y, expectedRadius);
@@ -83,11 +114,11 @@ public class MaximumInscibedCircleTest extends GeometryTestCase {
     Geometry centerPoint = mic.getCenter();
     Coordinate centerPt = centerPoint.getCoordinate();
     Coordinate expectedCenter = new Coordinate(x, y);
-    checkEqualXY(expectedCenter, centerPt, tolerance);
+    checkEqualXY(expectedCenter, centerPt, 2 * tolerance);
     
     LineString radiusLine = mic.getRadiusLine();
     double actualRadius = radiusLine.getLength();
-    assertEquals("Radius: ", expectedRadius, actualRadius, tolerance);
+    assertEquals("Radius: ", expectedRadius, actualRadius, 2 * tolerance);
     
     checkEqualXY("Radius line center point: ", centerPt, radiusLine.getCoordinateN(0));
     Coordinate radiusPt = mic.getRadiusPoint().getCoordinate();

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscibedCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscibedCircleTest.java
@@ -100,7 +100,7 @@ public class MaximumInscibedCircleTest extends GeometryTestCase {
     MaximumInscribedCircle mic = new MaximumInscribedCircle(geom, tolerance); 
     Geometry centerPoint = mic.getCenter();
     double dist = geom.distance(centerPoint);
-    assert(dist < 2 * tolerance);
+    assertTrue(dist < 2 * tolerance);
   }
   
   private void checkCircle(String wkt, double tolerance, 

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircleTest.java
@@ -7,13 +7,13 @@ import org.locationtech.jts.geom.LineString;
 import junit.textui.TestRunner;
 import test.jts.GeometryTestCase;
 
-public class MaximumInscibedCircleTest extends GeometryTestCase {
+public class MaximumInscribedCircleTest extends GeometryTestCase {
   
   public static void main(String args[]) {
-    TestRunner.run(MaximumInscibedCircleTest.class);
+    TestRunner.run(MaximumInscribedCircleTest.class);
   }
 
-  public MaximumInscibedCircleTest(String name) { super(name); }
+  public MaximumInscribedCircleTest(String name) { super(name); }
   
   public void testSquare() {
     checkCircle("POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))", 


### PR DESCRIPTION
This PR adds heuristics to `MaximumInscribedCircle` and `LargestEmptyCircle` to prevent long-running (and memory-intensive) processing for nearly flat and very thin inputs.

There are two problems solved:
1. if the input extent was very small in one dimension, the cell grid was initialized with cells of very small size, causing a memory explosion
2. Very thin geometries cause a long search to find a cell with a centre inside the geometry (since very few cells in the search space satisfy this condition).  A heuristic is used to determine a maximum number of iterations permitted.  This means that the computed result may lie outside the input geometry.  This can be mitigated by using a smaller tolerance distance; but there is no way to guarantee the centre will lie inside.

This fixes the issue reported in https://github.com/libgeos/geos/issues/875.