### PR TITLE
Enforce OffsetCurve to use a minimum QuadrantSegs value

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
@@ -76,6 +76,12 @@ public class OffsetCurve {
    * The nearness tolerance for matching the the raw offset linework and the buffer curve.
    */
   private static final int MATCH_DISTANCE_FACTOR = 10000;
+  
+  /**
+   * A QuadSegs minimum value that will prevent generating
+   * unwanted offset curve artifacts near end caps.
+   */
+  private static final int MIN_QUADRANT_SEGMENTS = 8;
 
   /**
    * Computes the offset curve of a geometry at a given distance.
@@ -164,7 +170,15 @@ public class OffsetCurve {
     //-- make new buffer params since the end cap style must be the default
     this.bufferParams = new BufferParameters();
     if (bufParams != null) {
-      bufferParams.setQuadrantSegments(bufParams.getQuadrantSegments());
+      /**
+       * Prevent using a very small QuadSegs value, to avoid 
+       * offset curve artifacts near the end caps. 
+       */
+      int quadSegs = bufParams.getQuadrantSegments();
+      if (quadSegs < MIN_QUADRANT_SEGMENTS) {
+        quadSegs = MIN_QUADRANT_SEGMENTS;
+      }
+      bufferParams.setQuadrantSegments(quadSegs);
       bufferParams.setJoinStyle(bufParams.getJoinStyle());
       bufferParams.setMitreLimit(bufParams.getMitreLimit());
     }

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -319,6 +319,24 @@ public class OffsetCurveTest extends GeometryTestCase {
     );
   }
   
+  // See https://github.com/qgis/QGIS/issues/53165
+  public void testMinQuadrantSegments() {
+    checkOffsetCurve(
+        "LINESTRING (553772.0645892698 177770.05079236583, 553780.9235869241 177768.99614978794, 553781.8325485934 177768.41771963477)", 
+        -11, 0, BufferParameters.JOIN_MITRE, -1,
+        "LINESTRING (553770.76 177759.13, 553777.54 177758.32)"
+    );
+  }
+  
+  // See https://github.com/qgis/QGIS/issues/53165#issuecomment-1563214857
+  public void testMinQuadrantSegments_QGIS() {
+    checkOffsetCurve(
+        "LINESTRING (421 622, 446 625, 449 627)", 
+        133, 0, BufferParameters.JOIN_MITRE, -1,
+        "LINESTRING (405.15 754.05, 416.3 755.39)"
+    );
+  }
+  
   //=======================================
   
   private static final double EQUALS_TOL = 0.05;

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -298,8 +298,8 @@ public class OffsetCurveTest extends GeometryTestCase {
   public void testQuadSegs() {
     checkOffsetCurve(
         "LINESTRING (20 20, 50 50, 80 20)", 
-        10, 2, -1, -1,
-        "LINESTRING (12.93 27.07, 42.93 57.07, 50 60, 57.07 57.07, 87.07 27.07)"
+        10, 10, -1, -1,
+        "LINESTRING (12.93 27.07, 42.93 57.07, 44.12 58.09, 45.46 58.91, 46.91 59.51, 48.44 59.88, 50 60, 51.56 59.88, 53.09 59.51, 54.54 58.91, 55.88 58.09, 57.07 57.07, 87.07 27.07)"
     );
   }
 


### PR DESCRIPTION
Enforce a minimum value for the Offset Curve Quadrant Segments (a value of 8 works well).  This fixes an issue with offset curve artifacts appearing when very small QuadSeg values are used.  This is due to the need to have a relatively circular end cap in the associated buffer polygon.

At some future point it might be possible to enforce the minimum QS value for just the end caps, since using a small at joins should not cause a problem.  

Fixes #980
See also https://github.com/libgeos/geos/pull/917