### PR TITLE
Fixes Checktype violations - removes wildcard imports

### DIFF
--- a/modules/io/ora/src/main/java/org/locationtech/jts/io/oracle/OraWriter.java
+++ b/modules/io/ora/src/main/java/org/locationtech/jts/io/oracle/OraWriter.java
@@ -19,16 +19,32 @@
  */
 package org.locationtech.jts.io.oracle;
 
+import java.util.List;
+import java.util.ArrayList;
 import java.sql.SQLException;
-import java.util.*;
 
 import org.locationtech.jts.algorithm.CGAlgorithms;
-import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.util.Assert;
 
+import oracle.jdbc.OracleConnection;
+
+import oracle.sql.ARRAY;
+import oracle.sql.Datum;
+import oracle.sql.NUMBER;
+import oracle.sql.STRUCT;
 
 import oracle.jdbc.OracleConnection;
-import oracle.sql.*;
 
 /**
  * Translates a JTS Geometry into an Oracle STRUCT representing an <code>MDSYS.SDO_GEOMETRY</code> object. 


### PR DESCRIPTION
When trying to compile the project with `mvn package -Dall=true` I encountered checkstyle violations:

```
[INFO] --- checkstyle:3.1.2:check (validate) @ jts-io-ora ---
[INFO] There are 3 errors reported by Checkstyle 8.44 with jts/checkstyle.xml ruleset.
[ERROR] src\main\java\org\locationtech\jts\io\oracle\OraWriter.java:[23,17] (imports) AvoidStarImport: Using the '.*' form of import should be avoided - java.util.*.
[ERROR] src\main\java\org\locationtech\jts\io\oracle\OraWriter.java:[26,33] (imports) AvoidStarImport: Using the '.*' form of import should be avoided - org.locationtech.jts.geom.*.
[ERROR] src\main\java\org\locationtech\jts\io\oracle\OraWriter.java:[31,18] (imports) AvoidStarImport: Using the '.*' form of import should be avoided - oracle.sql.*.
```

This commit removes the wilcard import which should be avoided.