### PR TITLE
Improve Convex Hull performance by avoiding duplicate uniquing

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
@@ -14,10 +14,9 @@ package org.locationtech.jts.algorithm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
-import java.util.TreeSet;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateArrays;
@@ -30,7 +29,6 @@ import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.util.Assert;
-import org.locationtech.jts.util.UniqueCoordinateArrayFilter;
 
 /**
  * Computes the convex hull of a {@link Geometry}.
@@ -43,6 +41,8 @@ import org.locationtech.jts.util.UniqueCoordinateArrayFilter;
  */
 public class ConvexHull
 {
+  private static final int TUNING_REDUCE_SIZE = 50;
+  
   private GeometryFactory geomFactory;
   private Coordinate[] inputPts;
 
@@ -51,23 +51,15 @@ public class ConvexHull
    */
   public ConvexHull(Geometry geometry)
   {
-    this(extractCoordinates(geometry), geometry.getFactory());
+    this(geometry.getCoordinates(), geometry.getFactory());
   }
   /**
    * Create a new convex hull construction for the input {@link Coordinate} array.
    */
   public ConvexHull(Coordinate[] pts, GeometryFactory geomFactory)
   {
-    inputPts = UniqueCoordinateArrayFilter.filterCoordinates(pts);
-    //inputPts = pts;
+    inputPts = pts;
     this.geomFactory = geomFactory;
-  }
-
-  private static Coordinate[] extractCoordinates(Geometry geom)
-  {
-    UniqueCoordinateArrayFilter filter = new UniqueCoordinateArrayFilter();
-    geom.apply(filter);
-    return filter.getCoordinates();
   }
 
   /**
@@ -84,20 +76,18 @@ public class ConvexHull
    */
   public Geometry getConvexHull() {
 
-    if (inputPts.length == 0) {
-      return geomFactory.createGeometryCollection();
-    }
-    if (inputPts.length == 1) {
-      return geomFactory.createPoint(inputPts[0]);
-    }
-    if (inputPts.length == 2) {
-      return geomFactory.createLineString(inputPts);
-    }
-
+    Geometry fewPointsGeom = createFewPointsResult();
+    if (fewPointsGeom != null) 
+      return fewPointsGeom;
+    
     Coordinate[] reducedPts = inputPts;
     // use heuristic to reduce points, if large
-    if (inputPts.length > 50) {
+    if (inputPts.length > TUNING_REDUCE_SIZE) {
       reducedPts = reduce(inputPts);
+    }
+    else {
+      // the points must be made unique
+      reducedPts = extractUnique(inputPts);
     }
     // sort points for Graham scan.
     Coordinate[] sortedPts = preSort(reducedPts);
@@ -112,6 +102,46 @@ public class ConvexHull
     return lineOrPolygon(cH);
   }
 
+  private Geometry createFewPointsResult() {
+    Coordinate[] uniquePts = extractUnique(inputPts, 3);
+    if (uniquePts == null) {
+      return null;
+    }
+    else if (uniquePts.length == 0) {
+      return geomFactory.createGeometryCollection();
+    }
+    else if (uniquePts.length == 1) {
+      return geomFactory.createPoint(uniquePts[0]);
+    }
+    else {
+      return geomFactory.createLineString(uniquePts);
+    }
+  }
+  
+  private static Coordinate[] extractUnique(Coordinate[] pts) {
+    return extractUnique(pts, -1);
+  }
+  
+  /**
+   * Extracts unique coordinates from an array of coordinates, 
+   * up to a maximum count of values.
+   * If there are more than the given maximum of unique values
+   * found, indicates this by returning <code>null</code>
+   * (the expectation is that the original array can then be used).
+   * 
+   * @param pts an array of Coordinates
+   * @param maxPts the maximum number of unique points to scan
+   * @return an array of unique values, or null
+   */
+  private static Coordinate[] extractUnique(Coordinate[] pts, int maxPts) {
+    Set<Coordinate> uniquePts = new HashSet<Coordinate>();
+    for (Coordinate pt : pts) {
+      uniquePts.add(pt);
+      if (maxPts >= 0 && uniquePts.size() >= maxPts) return null;
+    }
+    return CoordinateArrays.toCoordinateArray(uniquePts);
+  }
+  
   /**
    * An alternative to Stack.toArray, which is not present in earlier versions
    * of Java.
@@ -140,6 +170,9 @@ public class ConvexHull
    * <p>
    * To satisfy the requirements of the Graham Scan algorithm, 
    * the returned array has at least 3 entries.
+   * <p>
+   * This has the side effect of making the reduced points unique,
+   * as required by the convex hull algorithm used.
    *
    * @param pts the points to reduce
    * @return the reduced list of points (at least 3)
@@ -148,8 +181,7 @@ public class ConvexHull
   {
     //Coordinate[] polyPts = computeQuad(inputPts);
     Coordinate[] polyPts = computeOctRing(inputPts);
-    //Coordinate[] polyPts = null;
-
+ 
     // unable to compute interior polygon for some reason
     if (polyPts == null)
       return inputPts;
@@ -158,13 +190,13 @@ public class ConvexHull
 //    System.out.println(ring);
 
     // add points defining polygon
-    Set<Coordinate> reducedSet = new TreeSet<Coordinate>();
+    Set<Coordinate> reducedSet = new HashSet();
     for (int i = 0; i < polyPts.length; i++) {
       reducedSet.add(polyPts[i]);
     }
     /**
      * Add all unique points not in the interior poly.
-     * CGAlgorithms.isPointInRing is not defined for points actually on the ring,
+     * CGAlgorithms.isPointInRing is not defined for points exactly on the ring,
      * but this doesn't matter since the points of the interior polygon
      * are forced to be in the reduced set.
      */

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/ConvexHull.java
@@ -58,7 +58,10 @@ public class ConvexHull
    * Create a new convex hull construction for the input {@link Coordinate} array.
    */
   public ConvexHull(Coordinate[] pts, GeometryFactory geomFactory)
-  {
+  {  
+    //-- performance testing only
+    //inputPts = UniqueCoordinateArrayFilter.filterCoordinates(pts);
+    
     inputPts = pts;
     this.geomFactory = geomFactory;
   }
@@ -181,10 +184,10 @@ public class ConvexHull
   private Coordinate[] reduce(Coordinate[] inputPts)
   {
     //Coordinate[] polyPts = computeQuad(inputPts);
-    Coordinate[] polyPts = computeOctRing(inputPts);
+    Coordinate[] innerRingPts = computeInnerOctagonRing(inputPts);
  
     // unable to compute interior polygon for some reason
-    if (polyPts == null)
+    if (innerRingPts == null)
       return inputPts;
 
 //    LinearRing ring = geomFactory.createLinearRing(polyPts);
@@ -192,8 +195,8 @@ public class ConvexHull
 
     // add points defining polygon
     Set<Coordinate> reducedSet = new HashSet();
-    for (int i = 0; i < polyPts.length; i++) {
-      reducedSet.add(polyPts[i]);
+    for (int i = 0; i < innerRingPts.length; i++) {
+      reducedSet.add(innerRingPts[i]);
     }
     /**
      * Add all unique points not in the interior poly.
@@ -202,7 +205,7 @@ public class ConvexHull
      * are forced to be in the reduced set.
      */
     for (int i = 0; i < inputPts.length; i++) {
-      if (! PointLocation.isInRing(inputPts[i], polyPts)) {
+      if (! PointLocation.isInRing(inputPts[i], innerRingPts)) {
         reducedSet.add(inputPts[i]);
       }
     }
@@ -310,8 +313,8 @@ public class ConvexHull
     return false;
   }
 
-  private Coordinate[] computeOctRing(Coordinate[] inputPts) {
-    Coordinate[] octPts = computeOctPts(inputPts);
+  private Coordinate[] computeInnerOctagonRing(Coordinate[] inputPts) {
+    Coordinate[] octPts = computeInnerOctagonPts(inputPts);
     CoordinateList coordList = new CoordinateList();
     coordList.add(octPts, false);
 
@@ -323,7 +326,7 @@ public class ConvexHull
     return coordList.toCoordinateArray();
   }
 
-  private Coordinate[] computeOctPts(Coordinate[] inputPts)
+  private Coordinate[] computeInnerOctagonPts(Coordinate[] inputPts)
   {
     Coordinate[] pts = new Coordinate[8];
     for (int j = 0; j < pts.length; j++) {

--- a/modules/core/src/test/java/test/jts/perf/algorithm/ConvexHullPerfTest.java
+++ b/modules/core/src/test/java/test/jts/perf/algorithm/ConvexHullPerfTest.java
@@ -1,0 +1,48 @@
+package test.jts.perf.algorithm;
+
+import java.util.ArrayList;
+import java.util.Random;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.util.GeometricShapeFactory;
+
+import test.jts.perf.PerformanceTestCase;
+import test.jts.perf.PerformanceTestRunner;
+
+public class ConvexHullPerfTest extends PerformanceTestCase {
+  public static void main(String args[]) {
+    PerformanceTestRunner.run(ConvexHullPerfTest.class);
+  }
+
+  private MultiPoint geom;
+  
+  public ConvexHullPerfTest(String name)
+  {
+    super(name);
+    setRunSize(new int[] { 1000, 10_000, 100_000, 1_000_000 });
+    setRunIterations(100);
+  }
+ 
+  public void startRun(int num)
+  {
+    System.out.println("Running with size " + num);
+    geom = createRandomMultiPoint(num);
+  }
+
+  private MultiPoint createRandomMultiPoint(int num) {
+    Coordinate[] pts = new Coordinate[num];
+    Random rand = new Random(1324);
+    for (int i = 0; i < num; i++) {
+      pts[i] = new Coordinate(rand.nextDouble()*100, rand.nextDouble()*100);
+    }
+    GeometryFactory fact = new GeometryFactory();
+    return fact.createMultiPointFromCoords(pts);
+  }
+  
+  public void runConvexHull() {
+    Geometry convextHull = geom.convexHull();
+  }
+}


### PR DESCRIPTION
Improves Convex Hull performance by:

* optimizing the check for obviously degenerate inputs (those with 2 or fewer unique points)
* ensuring that scanning to extract all unique points is done only once (either via the Inner Octolateral Point Reduction heuristic, or for small inputs via a uniquing scan)

These changes can make computing the Convex Hull of large inputs more than 2x faster.