### PR TITLE
Fix Geometry.getCoordinate for collections with empty first element

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Geometry.java
@@ -346,13 +346,14 @@ public abstract class Geometry
   }
 
   /**
-   *  Returns a vertex of this <code>Geometry</code>
-   *  (usually, but not necessarily, the first one).
+   *  Returns a vertex of this geometry
+   *  (usually, but not necessarily, the first one),
+   *  or <code>null</code> if the geometry is empty.
    *  The returned coordinate should not be assumed
-   *  to be an actual Coordinate object used in
+   *  to be an actual <code>Coordinate</code> object used in
    *  the internal representation.
    *
-   *@return    a {@link Coordinate} which is a vertex of this <code>Geometry</code>.
+   *@return a coordinate which is a vertex of this <code>Geometry</code>.
    *@return null if this Geometry is empty
    */
   public abstract Coordinate getCoordinate();

--- a/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/GeometryCollection.java
@@ -57,8 +57,12 @@ public class GeometryCollection extends Geometry {
   }
 
   public Coordinate getCoordinate() {
-    if (isEmpty()) return null;
-    return geometries[0].getCoordinate();
+    for (int i = 0; i < geometries.length; i++) {
+      if (! geometries[i].isEmpty()) {
+        return geometries[i].getCoordinate();
+      }
+    }
+    return null;
   }
 
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/geom/GeometryCoordinateTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/GeometryCoordinateTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Martin Davis.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.geom;
+
+import test.jts.GeometryTestCase;
+
+public class GeometryCoordinateTest extends GeometryTestCase {
+
+  public static void main(String[] args) throws Exception {
+    junit.textui.TestRunner.run(GeometryCoordinateTest.class);
+  }
+  
+  public GeometryCoordinateTest(String name) {
+    super(name);
+  }
+  
+  public void testPoint() {
+    checkCoordinate( "POINT (1 1)", 1, 1);
+  }  
+  
+  public void testLineString() {
+    checkCoordinate( "LINESTRING (1 1, 2 2)", 1, 1);
+  }  
+  
+  public void testPolygon() {
+    checkCoordinate( "POLYGON ((1 1, 1 2, 2 1, 1 1))", 1, 1);
+  }  
+  
+  public void testEmptyElementsAll() {
+    checkCoordinate( "GEOMETRYCOLLECTION ( LINESTRING EMPTY, POINT EMPTY )");
+  }
+
+  public void testEmptyFirstElementPolygonal() {
+    checkCoordinate( "MULTIPOLYGON ( EMPTY, ((1 1, 1 2, 2 1, 1 1)) )", 1, 1);
+  }
+  
+  public void testEmptyFirstElement() {
+    checkCoordinate( "GEOMETRYCOLLECTION ( LINESTRING EMPTY, POINT(1 1) )", 1, 1);
+  }
+  
+  public void testEmptySecondElement() {
+    checkCoordinate( "GEOMETRYCOLLECTION ( POINT(1 1), LINESTRING EMPTY )", 1, 1);
+  }
+
+  private void checkCoordinate(String wkt, int x, int y) {
+    checkCoordinate(read(wkt), new Coordinate(x, y));
+  }
+  
+  private void checkCoordinate(final Geometry g, Coordinate expected) {
+    Coordinate actual = g.getCoordinate();
+    checkEqualXY( expected, actual );
+  }
+  
+  private void checkCoordinate(String wkt) {
+    Geometry g = read(wkt);
+    Coordinate actual = g.getCoordinate();
+    assertNull(actual);   
+  }
+}


### PR DESCRIPTION
Fixes `Geometry.getCoordinate` to return a coordinate from a non-empty collection with an empty first element.