### PR TITLE
Fix predicates for MultiPoint with EMPTY

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/PointLocator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/PointLocator.java
@@ -107,6 +107,9 @@ public class PointLocator
 
   private void computeLocation(Coordinate p, Geometry geom)
   {
+    if (geom.isEmpty())
+      return;
+    
     if (geom instanceof Point) {
       updateLocationInfo(locateOnPoint(p, (Point) geom));
     }

--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/GeometryGraph.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/GeometryGraph.java
@@ -222,7 +222,9 @@ public class GeometryGraph
   {
     for (int i = 0; i < gc.getNumGeometries(); i++) {
       Geometry g = gc.getGeometryN(i);
-      add(g);
+      if (! g.isEmpty()) {
+        add(g);
+      }
     }
   }
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relate/RelateTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relate/RelateTest.java
@@ -101,6 +101,12 @@ public class RelateTest
     runRelateTest(a, b,  "FF10F0102"  );
   }
   
+  public void testMultiPointWithEmpty()
+  {
+    String a = "MULTIPOINT(EMPTY,(0 0))";
+    String b = "POLYGON ((1 0,0 1,-1 0,0 -1, 1 0))";
+    runRelateTest(a, b,  "0FFFFF212"  );
+  }
   
   void runRelateTest(String wkt1, String wkt2, String expectedIM)
   {

--- a/modules/tests/src/test/resources/testxml/general/TestRelatePA.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestRelatePA.xml
@@ -100,4 +100,29 @@
 </test>
 </case>
 
+<case>
+  <desc>mPA - empty Point element</desc>
+  <a>
+    MULTIPOINT(EMPTY,(0 0))
+  </a>
+  <b>
+    POLYGON ((1 0,0 1,-1 0,0 -1, 1 0))
+  </b>
+<test>
+  <op name="relate" arg3="0FFFFF212" arg1="A" arg2="B">
+    true
+  </op>
+</test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> true  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> true  </op></test>
+</case>
+
 </run>


### PR DESCRIPTION
Fixes spatial predicates to handle MultiPoint with EMPTY element (and cleans up the handling of all collections with EMPTY elements).

See https://github.com/libgeos/geos/issues/988