### PR TITLE
Fix InteriorPoint for MultiLineString with EMPTY

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/InteriorPointLine.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/InteriorPointLine.java
@@ -69,6 +69,9 @@ public class InteriorPointLine {
    */
   private void addInterior(Geometry geom)
   {
+    if (geom.isEmpty())
+      return;
+    
     if (geom instanceof LineString) {
       addInterior(geom.getCoordinates());
     }
@@ -93,6 +96,9 @@ public class InteriorPointLine {
    */
   private void addEndpoints(Geometry geom)
   {
+    if (geom.isEmpty())
+      return;
+    
     if (geom instanceof LineString) {
       addEndpoints(geom.getCoordinates());
     }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/InteriorPointTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/InteriorPointTest.java
@@ -50,6 +50,10 @@ public class InteriorPointTest extends GeometryTestCase
     checkInteriorPoint(read("POLYGON ((10 10, 10 10, 10 10, 10 10))"), new Coordinate(10, 10));
   }
   
+  public void testMultiLineWithEmpty() {
+    checkInteriorPoint(read("MULTILINESTRING ((0 0, 1 1), EMPTY)"), new Coordinate(0, 0));
+  }
+  
   public void testAll() throws Exception
   {
     checkInteriorPointFile(TestFiles.getResourceFilePath("world.wkt"));

--- a/modules/tests/src/test/resources/testxml/general/TestInteriorPoint.xml
+++ b/modules/tests/src/test/resources/testxml/general/TestInteriorPoint.xml
@@ -1,5 +1,4 @@
 <run>
-  <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
 
 <case>
   <desc>P - empty</desc>
@@ -38,7 +37,7 @@
   <desc>L - linestring with single segment</desc>
   <a>    LINESTRING (0 0, 7 14)
   </a>
-<test><op name="getInteriorPoint" arg1="A" >   POINT (7 14)   </op></test>
+<test><op name="getInteriorPoint" arg1="A" >   POINT (0 0)   </op></test>
 </case>
 
 <case>
@@ -69,6 +68,13 @@
 </case>
 
 <case>
+  <desc>mL - multilinestring with empty</desc>
+  <a>    MULTILINESTRING ((0 0, 1 1), EMPTY)
+  </a>
+<test><op name="getInteriorPoint" arg1="A" >    POINT (0 0)   </op></test>
+</case>
+
+<case>
   <desc>A - box</desc>
   <a>    POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
 	</a>
@@ -93,7 +99,7 @@
   <desc>A - polygon with horizontal segment at centre (narrower L shape)</desc>
   <a>    POLYGON ((0 2, 0 4, 3 4, 3 0, 2 0, 2 2, 0 2))
 	</a>
-<test><op name="getInteriorPoint" arg1="A" >    POINT (2 3)   </op></test>
+<test><op name="getInteriorPoint" arg1="A" >    POINT (1.5 3)   </op></test>
 </case>
 
 <case>
@@ -101,6 +107,14 @@
   <a>    MULTIPOLYGON (((50 260, 240 340, 260 100, 20 60, 90 140, 50 260), (200 280, 140 240, 180 160, 240 140, 200 280)), ((380 280, 300 260, 340 100, 440 80, 380 280), (380 220, 340 200, 400 100, 380 220)))
 	</a>
 <test><op name="getInteriorPoint" arg1="A" >    POINT (115 200)  </op></test>
+</case>
+
+
+<case>
+  <desc>mA - multipolygon with empty</desc>
+  <a>    MULTIPOLYGON (((0 2, 0 4, 3 4, 3 0, 2 0, 2 2, 0 2)), EMPTY)
+  </a>
+<test><op name="getInteriorPoint" arg1="A" >    POINT (1.5 3)  </op></test>
 </case>
 
 <case>


### PR DESCRIPTION
Fix `InteriorPoint` to avoid crash for MultiLineString with EMPTY element.

Original report in [PostGIS 5621](https://trac.osgeo.org/postgis/ticket/5621).