### PR TITLE
Fix PointLocator with BoundaryNodeRule for lines

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/PointLocator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/PointLocator.java
@@ -165,11 +165,11 @@ public class PointLocator
     if (! l.getEnvelopeInternal().intersects(p)) return Location.EXTERIOR;
     
     CoordinateSequence seq = l.getCoordinateSequence();
-    if (! l.isClosed()) {
-          if (p.equals(seq.getCoordinate(0))
+    if (p.equals(seq.getCoordinate(0))
           || p.equals(seq.getCoordinate(seq.size() - 1)) ) {
-        return Location.BOUNDARY;
-      }
+      int boundaryCount = l.isClosed() ? 2 : 1;
+      int loc = boundaryRule.isInBoundary(boundaryCount) ? Location.BOUNDARY : Location.INTERIOR;
+      return loc;
     }
     if (PointLocation.isOnLine(p, seq)) {
       return Location.INTERIOR;

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/PointLocatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/PointLocatorTest.java
@@ -67,11 +67,31 @@ public class PointLocatorTest extends TestCase {
     assertEquals(Location.INTERIOR, pointLocator.locate(new Coordinate(190, 150), polygon));
   }
 
-   private void runPtLocator(int expected, Coordinate pt, String wkt)
+  public void testRingBoundaryNodeRule() throws Exception
+  {
+    String wkt = "LINEARRING(10 10, 10 20, 20 10, 10 10)";
+    Coordinate pt = new Coordinate(10, 10);
+    runPtLocator(Location.INTERIOR, pt, wkt, BoundaryNodeRule.MOD2_BOUNDARY_RULE);
+    runPtLocator(Location.BOUNDARY, pt, wkt, BoundaryNodeRule.ENDPOINT_BOUNDARY_RULE);
+    runPtLocator(Location.INTERIOR, pt, wkt, BoundaryNodeRule.MONOVALENT_ENDPOINT_BOUNDARY_RULE);
+    runPtLocator(Location.BOUNDARY, pt, wkt, BoundaryNodeRule.MULTIVALENT_ENDPOINT_BOUNDARY_RULE);
+  }
+
+  private void runPtLocator(int expected, Coordinate pt, String wkt)
       throws Exception
   {
     Geometry geom = reader.read(wkt);
     PointLocator pointLocator = new PointLocator();
+    int loc = pointLocator.locate(pt, geom);
+    assertEquals(expected, loc);
+  }
+
+  private void runPtLocator(int expected, Coordinate pt, String wkt,
+      BoundaryNodeRule bnr)
+      throws Exception
+  {
+    Geometry geom = reader.read(wkt);
+    PointLocator pointLocator = new PointLocator(bnr);
     int loc = pointLocator.locate(pt, geom);
     assertEquals(expected, loc);
   }


### PR DESCRIPTION
Fixes `PointLocator` to use the supplied `BoundaryNodeRule` for single linear geometries.