### PR TITLE
Enable ring-endpoint-handling for LineString with isRing() == true

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerLineSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerLineSimplifier.java
@@ -33,7 +33,7 @@ class DouglasPeuckerLineSimplifier
     return simp.simplify();
   }
 
-  private Coordinate[] pts;
+  private final Coordinate[] pts;
   private boolean[] usePt;
   private double distanceTolerance;
   private boolean isPreserveEndpoint = false;
@@ -93,7 +93,7 @@ class DouglasPeuckerLineSimplifier
     }
   }
 
-  private LineSegment seg = new LineSegment();
+  private final LineSegment seg = new LineSegment();
 
   private void simplifySection(int i, int j)
   {

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerLineSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerLineSimplifier.java
@@ -56,7 +56,7 @@ class DouglasPeuckerLineSimplifier
   private void setPreserveEndpoint(boolean isPreserveEndpoint) {
     this.isPreserveEndpoint  = isPreserveEndpoint;
   }
-  
+
   public Coordinate[] simplify()
   {
     usePt = new boolean[pts.length];
@@ -64,13 +64,13 @@ class DouglasPeuckerLineSimplifier
       usePt[i] = true;
     }
     simplifySection(0, pts.length - 1);
-    
+
     CoordinateList coordList = new CoordinateList();
     for (int i = 0; i < pts.length; i++) {
       if (usePt[i])
         coordList.add(new Coordinate(pts[i]));
     }
-    
+
     if (! isPreserveEndpoint && CoordinateArrays.isRing(pts)) {
       simplifyRingEndpoint(coordList);
     }
@@ -84,7 +84,7 @@ class DouglasPeuckerLineSimplifier
       return;
     //-- base segment for endpoint
     seg.p0 = pts.get(1);
-    seg.p1 = pts.get(pts.size() - 2); 
+    seg.p1 = pts.get(pts.size() - 2);
     double distance = seg.distance(pts.get(0));
     if (distance <= distanceTolerance) {
       pts.remove(0);

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifier.java
@@ -24,7 +24,7 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
  * Simplifies a {@link Geometry} using the Douglas-Peucker algorithm.
  * Ensures that any polygonal geometries returned are valid.
  * Simple lines are not guaranteed to remain simple after simplification.
- * All geometry types are handled. 
+ * All geometry types are handled.
  * Empty and point geometries are returned unchanged.
  * Empty geometry components are deleted.
  * <p>
@@ -49,7 +49,7 @@ public class DouglasPeuckerSimplifier
 
   /**
    * Simplifies a geometry using a given tolerance.
-   * 
+   *
    * @param geom geometry to simplify
    * @param distanceTolerance the tolerance to use
    * @return a simplified version of the geometry
@@ -64,10 +64,10 @@ public class DouglasPeuckerSimplifier
   private final Geometry inputGeom;
   private double distanceTolerance;
   private boolean isEnsureValidTopology = true;
-  
+
   /**
    * Creates a simplifier for a given geometry.
-   * 
+   *
    * @param inputGeom the geometry to simplify
    */
   public DouglasPeuckerSimplifier(Geometry inputGeom)
@@ -79,7 +79,7 @@ public class DouglasPeuckerSimplifier
    * Sets the distance tolerance for the simplification.
    * All vertices in the simplified geometry will be within this
    * distance of the original geometry.
-   * The tolerance value must be non-negative. 
+   * The tolerance value must be non-negative.
    *
    * @param distanceTolerance the approximation tolerance to use
    */
@@ -98,26 +98,26 @@ public class DouglasPeuckerSimplifier
    * <li>fixing topology is a relative expensive operation
    * <li>in some pathological cases the topology fixing operation may either fail or run for too long
    * </ul>
-   * 
+   *
    * The default is to fix polygon topology.
-   * 
+   *
    * @param isEnsureValidTopology
    */
   public void setEnsureValid(boolean isEnsureValidTopology)
   {
   	this.isEnsureValidTopology = isEnsureValidTopology;
   }
-  
+
   /**
    * Gets the simplified geometry.
-   * 
+   *
    * @return the simplified geometry
    */
   public Geometry getResultGeometry()
   {
     // empty input produces an empty result
     if (inputGeom.isEmpty()) return inputGeom.copy();
-    
+
     return (new DPTransformer(isEnsureValidTopology, distanceTolerance)).transform(inputGeom);
   }
 
@@ -132,12 +132,12 @@ static class DPTransformer
 		this.isEnsureValidTopology = isEnsureValidTopology;
 		this.distanceTolerance = distanceTolerance;
 	}
-	
+
   protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent)
   {
     boolean isPreserveEndpoint = ! (parent instanceof LinearRing);
     Coordinate[] inputPts = coords.toCoordinateArray();
-    Coordinate[] newPts = null;
+    Coordinate[] newPts;
     if (inputPts.length == 0) {
       newPts = new Coordinate[0];
     }
@@ -163,13 +163,12 @@ static class DPTransformer
   }
 
   /**
-   * Simplifies a LinearRing.  If the simplification results 
+   * Simplifies a LinearRing.  If the simplification results
    * in a degenerate ring, remove the component.
-   * 
+   *
    * @return null if the simplification results in a degenerate ring
    */
-  //*
-  protected Geometry transformLinearRing(LinearRing geom, Geometry parent) 
+  protected Geometry transformLinearRing(LinearRing geom, Geometry parent)
   {
   	boolean removeDegenerateRings = parent instanceof Polygon;
   	Geometry simpResult = super.transformLinearRing(geom, parent);
@@ -177,8 +176,7 @@ static class DPTransformer
   		return null;
   	return simpResult;
   }
-  //*/
-  
+
   /**
    * Simplifies a MultiPolygon, fixing it if required.
    */
@@ -195,8 +193,8 @@ static class DPTransformer
    * topology.
    * Note this only works for area geometries, since buffer always returns
    * areas.  This also may return empty geometries, if the input
-   * has no actual area.  
-   * If the input is empty or is not polygonal, 
+   * has no actual area.
+   * If the input is empty or is not polygonal,
    * this ensures that POLYGON EMPTY is returned.
    *
    * @param rawAreaGeom an area geometry possibly containing self-intersections

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/DouglasPeuckerSimplifier.java
@@ -61,7 +61,7 @@ public class DouglasPeuckerSimplifier
     return tss.getResultGeometry();
   }
 
-  private Geometry inputGeom;
+  private final Geometry inputGeom;
   private double distanceTolerance;
   private boolean isEnsureValidTopology = true;
   
@@ -124,8 +124,8 @@ public class DouglasPeuckerSimplifier
 static class DPTransformer
     extends GeometryTransformer
 {
-  private boolean isEnsureValidTopology = true;
-  private double distanceTolerance;
+  private final boolean isEnsureValidTopology;
+  private final double distanceTolerance;
 
 	public DPTransformer(boolean isEnsureValidTopology, double distanceTolerance)
 	{

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineString.java
@@ -30,11 +30,11 @@ import org.locationtech.jts.geom.LinearRing;
 class TaggedLineString
 {
 
-  private LineString parentLine;
+  private final LineString parentLine;
   private TaggedLineSegment[] segs;
-  private List<LineSegment> resultSegs = new ArrayList<LineSegment>();
-  private int minimumSize;
-  private boolean isRing = true;
+  private final List<LineSegment> resultSegs = new ArrayList<LineSegment>();
+  private final int minimumSize;
+  private final boolean isRing;
 
   public TaggedLineString(LineString parentLine, int minimumSize, boolean isRing) {
     this.parentLine = parentLine;

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineString.java
@@ -21,10 +21,10 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
 
 /**
- * Represents a {@link LineString} which can be modified to a simplified shape.  
+ * Represents a {@link LineString} which can be modified to a simplified shape.
  * This class provides an attribute which specifies the minimum allowable length
  * for the modified result.
- * 
+ *
  * @version 1.7
  */
 class TaggedLineString
@@ -46,8 +46,8 @@ class TaggedLineString
   public boolean isRing() {
     return isRing;
   }
-  
-  public int getMinimumSize()  {    return minimumSize;  }
+
+  public int getMinimumSize()  { return minimumSize; }
   public LineString getParent() { return parentLine; }
   public Coordinate[] getParentCoordinates() { return parentLine.getCoordinates(); }
   public Coordinate[] getResultCoordinates() { return extractCoordinates(resultSegs); }
@@ -59,11 +59,11 @@ class TaggedLineString
   public int size() {
     return parentLine.getNumPoints();
   }
-  
+
   public Coordinate getComponentPoint() {
     return getParentCoordinates()[1];
   }
-  
+
   public int getResultSize()
   {
     int resultSegsSize = resultSegs.size();
@@ -102,7 +102,7 @@ class TaggedLineString
    * Add a simplified segment to the result.
    * This assumes simplified segments are computed in the order
    * they occur in the line.
-   * 
+   *
    * @param seg the result segment to add
    */
   public void addToResult(LineSegment seg)

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineString.java
@@ -78,12 +78,11 @@ class TaggedLineString
    * @param i the segment index to retrieve
    * @return the result segment
    */
-  public LineSegment getResultSegment(int i) { 
-    int index = i;
+  public LineSegment getResultSegment(int i) {
     if (i < 0) {
-      index = resultSegs.size() + i;
+      i = resultSegs.size() + i;
     }
-    return (LineSegment) resultSegs.get(index);
+    return resultSegs.get(i);
   }
 
   private void init()
@@ -125,7 +124,7 @@ class TaggedLineString
     Coordinate[] pts = new Coordinate[segs.size() + 1];
     LineSegment seg = null;
     for (int i = 0; i < segs.size(); i++) {
-      seg = (LineSegment) segs.get(i);
+      seg = segs.get(i);
       pts[i] = seg.p0;
     }
     // add last point
@@ -135,8 +134,8 @@ class TaggedLineString
 
   void removeRingEndpoint()
   {
-    LineSegment firstSeg = (LineSegment) resultSegs.get(0);
-    LineSegment lastSeg = (LineSegment) resultSegs.get(resultSegs.size() - 1);
+    LineSegment firstSeg = resultSegs.get(0);
+    LineSegment lastSeg = resultSegs.get(resultSegs.size() - 1);
 
     firstSeg.p0 = lastSeg.p0;
     resultSegs.remove(resultSegs.size() - 1);

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineStringSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineStringSimplifier.java
@@ -40,7 +40,7 @@ public class TaggedLineStringSimplifier
   private Coordinate[] linePts;
 
   public TaggedLineStringSimplifier(LineSegmentIndex inputIndex,
-                                     LineSegmentIndex outputIndex, 
+                                     LineSegmentIndex outputIndex,
                                      ComponentJumpChecker crossChecker)
   {
     this.inputIndex = inputIndex;
@@ -51,7 +51,7 @@ public class TaggedLineStringSimplifier
   /**
    * Simplifies the given {@link TaggedLineString}
    * using the distance tolerance specified.
-   * 
+   *
    * @param line the linestring to simplify
    * @param distanceTolerance the simplification distance tolerance
    */
@@ -60,7 +60,7 @@ public class TaggedLineStringSimplifier
     this.line = line;
     linePts = line.getParentCoordinates();
     simplifySection(0, linePts.length - 1, 0, distanceTolerance);
-    
+
     if (line.isRing() && CoordinateArrays.isRing(linePts)) {
       simplifyRingEndpoint(distanceTolerance);
     }
@@ -94,12 +94,12 @@ public class TaggedLineStringSimplifier
 
     double[] distance = new double[1];
     int furthestPtIndex = findFurthestPoint(linePts, i, j, distance);
-    
+
     // flattening must be less than distanceTolerance
     if (distance[0] > distanceTolerance) {
       isValidToSimplify = false;
     }
-    
+
     if (isValidToSimplify) {
       // test if flattened section would cause intersection or jump
       LineSegment flatSeg = new LineSegment();
@@ -107,7 +107,7 @@ public class TaggedLineStringSimplifier
       flatSeg.p1 = linePts[j];
       isValidToSimplify = isTopologyValid(line, i, j, flatSeg);
     }
-    
+
     if (isValidToSimplify) {
       LineSegment newSeg = flatten(i, j);
       line.addToResult(newSeg);
@@ -163,7 +163,7 @@ public class TaggedLineStringSimplifier
    * replacing them with a line between the endpoints.
    * The input and output indexes are updated
    * to reflect this.
-   * 
+   *
    * @param start the start index of the flattened section
    * @param end the end index of the flattened section
    * @return the new segment created
@@ -177,16 +177,16 @@ public class TaggedLineStringSimplifier
     // update the input and output indexes
     outputIndex.add(newSeg);
     remove(line, start, end);
-    
+
     return newSeg;
   }
 
   /**
    * Tests if line topology remains valid after flattening a section of the line.
-   * The flattened section is being replaced by the flattening segment, 
-   * so there is no need to test it 
+   * The flattened section is being replaced by the flattening segment,
+   * so there is no need to test it
    * (and it may well intersect the segment).
-   * 
+   *
    * @param line
    * @param sectionStart
    * @param sectionEnd
@@ -197,11 +197,11 @@ public class TaggedLineStringSimplifier
                        int sectionStart, int sectionEnd,
                        LineSegment flatSeg)
   {
-    if (hasOutputIntersection(flatSeg)) 
+    if (hasOutputIntersection(flatSeg))
       return false;
-    if (hasInputIntersection(line, sectionStart, sectionEnd, flatSeg)) 
+    if (hasInputIntersection(line, sectionStart, sectionEnd, flatSeg))
       return false;
-    if (jumpChecker.hasJump(line, sectionStart, sectionEnd, flatSeg)) 
+    if (jumpChecker.hasJump(line, sectionStart, sectionEnd, flatSeg))
       return false;
     return true;
   }
@@ -210,17 +210,17 @@ public class TaggedLineStringSimplifier
       LineSegment flatSeg) {
     //-- if segments are already flat, topology is unchanged and so is valid
     //-- (otherwise, output and/or input intersection test would report false positive)
-    if (isCollinear(seg1.p0, flatSeg)) 
+    if (isCollinear(seg1.p0, flatSeg))
       return true;
-    if (hasOutputIntersection(flatSeg)) 
+    if (hasOutputIntersection(flatSeg))
       return false;
-    if (hasInputIntersection(flatSeg)) 
+    if (hasInputIntersection(flatSeg))
       return false;
-    if (jumpChecker.hasJump(line, seg1, seg2, flatSeg)) 
+    if (jumpChecker.hasJump(line, seg1, seg2, flatSeg))
       return false;
     return true;
   }
-  
+
   private boolean isCollinear(Coordinate pt, LineSegment seg) {
     return Orientation.COLLINEAR == seg.orientationIndex(pt);
   }
@@ -241,7 +241,7 @@ public class TaggedLineStringSimplifier
   {
     return hasInputIntersection(null, -1, -1, flatSeg);
   }
-  
+
   private boolean hasInputIntersection(TaggedLineString line,
                         int excludeStart, int excludeEnd,
                        LineSegment flatSeg)
@@ -250,11 +250,11 @@ public class TaggedLineStringSimplifier
     for (Iterator i = querySegs.iterator(); i.hasNext(); ) {
       TaggedLineSegment querySeg = (TaggedLineSegment) i.next();
       if (hasInvalidIntersection(querySeg, flatSeg)) {
-        /**
+        /*
          * Ignore the intersection if the intersecting segment is part of the section being collapsed
          * to the candidate segment
          */
-        if (line != null 
+        if (line != null
             && isInLineSection(line, excludeStart, excludeEnd, querySeg))
           continue;
         return true;
@@ -265,12 +265,12 @@ public class TaggedLineStringSimplifier
 
   /**
    * Tests whether a segment is in a section of a TaggedLineString.
-   * Sections may wrap around the endpoint of the line, 
+   * Sections may wrap around the endpoint of the line,
    * to support ring endpoint simplification.
    * This is indicated by excludedStart > excludedEnd
-   * 
+   *
    * @param line the TaggedLineString containing the section segments
-   * @param excludeStart  the index of the first segment in the excluded section  
+   * @param excludeStart  the index of the first segment in the excluded section
    * @param excludeEnd the index of the last segment in the excluded section
    * @param seg the segment to test
    * @return true if the test segment intersects some segment in the line not in the excluded section
@@ -292,7 +292,7 @@ public class TaggedLineStringSimplifier
     else {
       //-- section wraps around the end of a ring
       if (segIndex >= excludeStart || segIndex <= excludeEnd)
-      return true;
+        return true;
     }
     return false;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineStringSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineStringSimplifier.java
@@ -80,7 +80,7 @@ public class TaggedLineStringSimplifier
 
     boolean isValidToSimplify = true;
 
-    /**
+    /*
      * Following logic ensures that there is enough points in the output line.
      * If there is already more points than the minimum, there's nothing to check.
      * Otherwise, if in the worst case there wouldn't be enough points,
@@ -309,9 +309,8 @@ public class TaggedLineStringSimplifier
   /**
    * Remove the segs in the section of the line
    * @param line
-   * @param pts
-   * @param sectionStartIndex
-   * @param sectionEndIndex
+   * @param start
+   * @param end
    */
   private void remove(TaggedLineString line,
                        int start, int end)

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineStringSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineStringSimplifier.java
@@ -32,10 +32,10 @@ import org.locationtech.jts.geom.LineSegment;
  */
 public class TaggedLineStringSimplifier
 {
-  private LineIntersector li = new RobustLineIntersector();
-  private LineSegmentIndex inputIndex;
-  private LineSegmentIndex outputIndex;
-  private ComponentJumpChecker jumpChecker;
+  private final LineIntersector li = new RobustLineIntersector();
+  private final LineSegmentIndex inputIndex;
+  private final LineSegmentIndex outputIndex;
+  private final ComponentJumpChecker jumpChecker;
   private TaggedLineString line;
   private Coordinate[] linePts;
 

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java
@@ -162,10 +162,10 @@ public class TopologyPreservingSimplifier
         LineString line = (LineString) geom;
         // skip empty geometries
         if (line.isEmpty()) return;
-        
-        int minSize = ((LineString) line).isClosed() ? 4 : 2;
-        boolean isRing = (line instanceof LinearRing) ? true : false;
-        TaggedLineString taggedLine = new TaggedLineString((LineString) line, minSize, isRing);
+
+        int minSize = line.isClosed() ? 4 : 2;
+        boolean isRing = line instanceof LinearRing || line.isRing();
+        TaggedLineString taggedLine = new TaggedLineString(line, minSize, isRing);
         tps.linestringMap.put(line, taggedLine);
       }
     }

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java
@@ -73,8 +73,8 @@ public class TopologyPreservingSimplifier
     return tss.getResultGeometry();
   }
 
-  private Geometry inputGeom;
-  private TaggedLinesSimplifier lineSimplifier = new TaggedLinesSimplifier();
+  private final Geometry inputGeom;
+  private final TaggedLinesSimplifier lineSimplifier = new TaggedLinesSimplifier();
   private Map<LineString, TaggedLineString> linestringMap;
 
   public TopologyPreservingSimplifier(Geometry inputGeom)
@@ -112,8 +112,8 @@ public class TopologyPreservingSimplifier
   static class LineStringTransformer
       extends GeometryTransformer
   {
-    private Map<LineString, TaggedLineString> linestringMap;
-    
+    private final Map<LineString, TaggedLineString> linestringMap;
+
     public LineStringTransformer(Map<LineString, TaggedLineString> linestringMap) {
       this.linestringMap = linestringMap;
     }

--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TopologyPreservingSimplifier.java
@@ -36,9 +36,9 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
  * <li>The result has the same number of shells and holes as the input,
  * with the same topological structure
  * <li>The result rings touch at <b>no more</b> than the number of touching points in the input
- * (although they may touch at fewer points).  
- * The key implication of this statement is that if the 
- * input is topologically valid, so is the simplified output. 
+ * (although they may touch at fewer points).
+ * The key implication of this statement is that if the
+ * input is topologically valid, so is the simplified output.
  * </ul>
  * For linear geometries, if the input does not contain
  * any intersecting line segments, this property
@@ -47,19 +47,19 @@ import org.locationtech.jts.geom.util.GeometryTransformer;
  * For polygonal geometries and LinearRings the ring endpoint will be simplified.
  * For LineStrings the endpoints will be unchanged.
  * <p>
- * For all geometry types, the result will contain 
+ * For all geometry types, the result will contain
  * enough vertices to ensure validity.  For polygons
  * and closed linear geometries, the result will have at
  * least 4 vertices; for open linestrings the result
  * will have at least 2 vertices.
  * <p>
- * All geometry types are handled. 
+ * All geometry types are handled.
  * Empty and point geometries are returned unchanged.
  * Empty geometry components are deleted.
  * <p>
  * The simplification uses a maximum-distance difference algorithm
  * similar to the Douglas-Peucker algorithm.
- * 
+ *
  * @author Martin Davis
  * @see DouglasPeuckerSimplifier
  *
@@ -97,11 +97,11 @@ public class TopologyPreservingSimplifier
     lineSimplifier.setDistanceTolerance(distanceTolerance);
   }
 
-  public Geometry getResultGeometry() 
+  public Geometry getResultGeometry()
   {
     // empty input produces an empty result
     if (inputGeom.isEmpty()) return inputGeom.copy();
-    
+
     linestringMap = new HashMap<LineString, TaggedLineString>();
     inputGeom.apply(new LineStringMapBuilderFilter(this));
     lineSimplifier.simplify(linestringMap.values());
@@ -117,7 +117,7 @@ public class TopologyPreservingSimplifier
     public LineStringTransformer(Map<LineString, TaggedLineString> linestringMap) {
       this.linestringMap = linestringMap;
     }
-    
+
     protected CoordinateSequence transformCoordinates(CoordinateSequence coords, Geometry parent)
     {
       if (coords.size() == 0) return null;
@@ -132,13 +132,13 @@ public class TopologyPreservingSimplifier
   }
 
   /**
-   * A filter to add linear geometries to the linestring map 
+   * A filter to add linear geometries to the linestring map
    * with the appropriate minimum size constraint.
    * Closed {@link LineString}s (including {@link LinearRing}s
-   * have a minimum output size constraint of 4, 
+   * have a minimum output size constraint of 4,
    * to ensure the output is valid.
    * For all other linestrings, the minimum size is 2 points.
-   * 
+   *
    * @author Martin Davis
    *
    */
@@ -146,15 +146,15 @@ public class TopologyPreservingSimplifier
       implements GeometryComponentFilter
   {
     TopologyPreservingSimplifier tps;
-    
+
     LineStringMapBuilderFilter(TopologyPreservingSimplifier tps) {
       this.tps = tps;
     }
-    
+
     /**
      * Filters linear geometries.
-     * 
-     * geom a geometry of any type 
+     *
+     * @param geom a geometry of any type
      */
     public void filter(Geometry geom)
     {

--- a/modules/core/src/test/java/org/locationtech/jts/simplify/TopologyPreservingSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/simplify/TopologyPreservingSimplifierTest.java
@@ -156,6 +156,11 @@ public class TopologyPreservingSimplifierTest
         40,
         "LINEARRING (30 220, 380 220, 300 40, 140 30, 30 220)"
         );
+    checkTPS(
+      "LINESTRING (220 180, 261 175, 380 220, 300 40, 140 30, 30 220, 176 176, 220 180)",
+      40,
+      "LINESTRING (30 220, 380 220, 300 40, 140 30, 30 220)"
+    );
   }
   
   public void testPolygonKeepFlatEndpointWithTouch() throws Exception {

--- a/modules/core/src/test/java/org/locationtech/jts/simplify/TopologyPreservingSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/simplify/TopologyPreservingSimplifierTest.java
@@ -34,90 +34,90 @@ public class TopologyPreservingSimplifierTest
   public void testPoint() {
     checkTPSNoChange("POINT (10 10)", 1);
   }
-  
+
   public void testPolygonEmpty() {
     checkTPSNoChange("POLYGON(EMPTY)", 1);
   }
-  
+
   public void testPolygonFlatVertices() throws Exception {
     checkTPS("POLYGON ((20 220, 40 220, 60 220, 80 220, 100 220, 120 220, 140 220, 140 180, 100 180, 60 180,     20 180, 20 220))",
         10,
         "POLYGON ((20 220, 140 220, 140 180, 20 180, 20 220))");
   }
-  
+
   public void testPolygonNoReduction() throws Exception {
     checkTPSNoChange("POLYGON ((20 220, 140 220, 140 180, 20 180, 20 220))",
         10);
   }
-  
+
   public void testPolygonNoReductionWithConflicts() throws Exception {
     checkTPSNoChange("POLYGON ((40 240, 160 241, 280 240, 280 160, 160 240, 40 140, 40 240))",
         10);
   }
-  
+
   public void testPolygonWithTouchingHole() throws Exception {
     checkTPS("POLYGON ((80 200, 240 200, 240 60, 80 60, 80 200), (120 120, 220 120, 180 199, 160 200, 140 199, 120 120))",
         10,
         "POLYGON ((80 200, 240 200, 240 60, 80 60, 80 200), (120 120, 220 120, 180 199, 160 200, 140 199, 120 120))");
   }
-  
+
   public void testFlattishPolygon() throws Exception {
     checkTPS("POLYGON ((0 0, 50 0, 53 0, 55 0, 100 0, 70 1,  60 1, 50 1, 40 1, 0 0))",
         10,
         "POLYGON ((0 0, 50 0, 100 0, 70 1, 0 0))");
   }
-  
+
   public void testPolygonWithFlattishHole() throws Exception {
     checkTPS("POLYGON ((0 0, 0 200, 200 200, 200 0, 0 0), (140 40, 90 95, 40 160, 95 100, 140 40))",
         20,
         "POLYGON ((0 0, 0 200, 200 200, 200 0, 0 0), (140 40, 90 95, 40 160, 95 100, 140 40))");
   }
-  
+
   public void testTinySquare() throws Exception {
     checkTPS("POLYGON ((0 5, 5 5, 5 0, 0 0, 0 1, 0 5))",
         10,
         "POLYGON ((0 0, 5 5, 5 0, 0 0))");
   }
-  
+
   public void testTinyLineString() throws Exception {
     checkTPS("LINESTRING (0 5, 1 5, 2 5, 5 5)",
         10,
         "LINESTRING (0 5, 5 5)");
   }
-  
+
   public void testTinyClosedLineString() throws Exception {
     checkTPSNoChange("LINESTRING (0 0, 5 0, 5 5, 0 0)",
         10);
   }
-  
+
   public void testMultiPoint() throws Exception {
     checkTPSNoChange("MULTIPOINT(80 200, 240 200, 240 60, 80 60, 80 200, 140 199, 120 120)",
         10);
   }
-  
+
   public void testMultiLineString() throws Exception {
     checkTPS("MULTILINESTRING( (0 0, 50 0, 70 0, 80 0, 100 0), (0 0, 50 1, 60 1, 100 0) )",
         10,
         "MULTILINESTRING ((0 0, 100 0), (0 0, 50 1, 100 0))");
   }
-  
+
   public void testMultiLineStringWithEmpty() throws Exception {
     checkTPS("MULTILINESTRING(EMPTY, (0 0, 50 0, 70 0, 80 0, 100 0), (0 0, 50 1, 60 1, 100 0) )",
         10,
         "MULTILINESTRING ((0 0, 100 0), (0 0, 50 1, 100 0))");
   }
-  
+
   public void testMultiPolygonWithEmpty() throws Exception {
     checkTPS("MULTIPOLYGON (EMPTY, ((10 90, 10 10, 90 10, 50 60, 10 90)), ((70 90, 90 90, 90 70, 70 70, 70 90)))",
         10,
         "MULTIPOLYGON (((10 90, 10 10, 90 10, 50 60, 10 90)), ((70 90, 90 90, 90 70, 70 70, 70 90)))");
   }
-  
+
   public void testGeometryCollection() {
     checkTPSNoChange("GEOMETRYCOLLECTION (MULTIPOINT (80 200, 240 200, 240 60, 80 60, 80 200, 140 199, 120 120), POLYGON ((80 200, 240 200, 240 60, 80 60, 80 200)), LINESTRING (80 200, 240 200, 240 60, 80 60, 80 200, 140 199, 120 120))",
       10);
   }
-  
+
   public void testNoCollapse_mL() throws Exception {
     checkTPS(
       "MULTILINESTRING ((0 0, 100 0), (0 0, 60 1, 100 0))",
@@ -141,7 +141,7 @@ public class TopologyPreservingSimplifierTest
         "POLYGON ((0 0, 5 5, 5 0, 0 0))"
         );
   }
-  
+
   public void testPolygonRemoveEndpoint() throws Exception {
     checkTPS(
       "POLYGON ((220 180, 261 175, 380 220, 300 40, 140 30, 30 220, 176 176, 220 180))",
@@ -149,7 +149,7 @@ public class TopologyPreservingSimplifierTest
         "POLYGON ((30 220, 380 220, 300 40, 140 30, 30 220))"
         );
   }
-  
+
   public void testLinearRingRemoveEndpoint() throws Exception {
     checkTPS(
       "LINEARRING (220 180, 261 175, 380 220, 300 40, 140 30, 30 220, 176 176, 220 180)",
@@ -162,12 +162,12 @@ public class TopologyPreservingSimplifierTest
       "LINESTRING (30 220, 380 220, 300 40, 140 30, 30 220)"
     );
   }
-  
+
   public void testPolygonKeepFlatEndpointWithTouch() throws Exception {
     checkTPSNoChange("POLYGON ((0 0, 5 2.05, 10 0, 10 10, 0 10, 0 0),  (5 2.1, 6 2, 6 4, 4 4, 4 2, 5 2.1))",
         0.1 );
   }
-  
+
   public void testPolygonKeepEndpointWithCross() throws Exception {
     checkTPS(
       "POLYGON ((50 52, 60 50, 90 60, 90 10, 10 10, 10 90, 60 90, 50 55, 40 80, 20 60, 40 50, 50 52))",
@@ -175,7 +175,7 @@ public class TopologyPreservingSimplifierTest
         "POLYGON ((20 60, 50 52, 90 60, 90 10, 10 10, 10 90, 60 90, 50 55, 40 80, 20 60))"
         );
   }
-  
+
   // see https://trac.osgeo.org/geos/ticket/1064
   public void testPolygonRemoveFlatEndpoint() throws Exception {
     checkTPS(
@@ -192,8 +192,8 @@ public class TopologyPreservingSimplifierTest
         "POLYGON ((9 5, 9 1, 1 1, 1 5, 9 5))"
         );
   }
-  
-  //-- vertex is not removed due to overly-restrictive heuristic result length calculation? 
+
+  //-- vertex is not removed due to overly-restrictive heuristic result length calculation?
   public void testPolygonSize5NotSimplfied() throws Exception {
     checkTPS(
       "POLYGON ((10 90, 10 10, 90 10, 47 57, 10 90))",
@@ -201,12 +201,12 @@ public class TopologyPreservingSimplifierTest
         "POLYGON ((10 90, 10 10, 90 10, 47 57, 10 90))"
         );
   }
-  
+
   /**
    * Test is from http://postgis.refractions.net/pipermail/postgis-users/2008-April/019327.html
    * Exhibits the issue where simplified polygon shells can "jump" across
    * holes, causing invalid topology.
-   * 
+   *
    * @throws Exception
    */
   public void testMultiPolygonWithSmallComponents() throws Exception {
@@ -214,7 +214,7 @@ public class TopologyPreservingSimplifierTest
         0.0057,
         "MULTIPOLYGON (((13.73095 51.024734, 13.7123153 51.041449, 13.7412027 51.0463256, 13.7552745 51.0566237, 13.7484397 51.0324582, 13.73095 51.024734)), ((13.7390933 51.0471421, 13.7369099 51.0474154, 13.7390933 51.047209, 13.7390933 51.0471421)), ((13.7367293 51.0470057, 13.7346615 51.0466892, 13.7347106 51.0471899, 13.7367293 51.0470057)))");
   }
-  
+
   /**
    * Test is from http://lists.jump-project.org/pipermail/jts-devel/2008-February/002350.html
    * @throws Exception
@@ -224,25 +224,25 @@ public class TopologyPreservingSimplifierTest
         2,
         "POLYGON ((3312459.605 6646878.353, 3312460.524 6646875.969, 3312459.427 6646878.421, 3312460.014 6646886.391, 3312465.889 6646887.398, 3312470.827 6646884.839, 3312477.289 6646871.694, 3312472.748 6646869.547, 3312459.605 6646878.353))");
   }
-  
+
   public void testLineComponentCross() {
     checkTPS("MULTILINESTRING ((0 0, 10 2, 20 0), (9 1, 11 1))",
         4,
         "MULTILINESTRING ((0 0, 10 2, 20 0), (9 1, 11 1))");
   }
-  
+
   public void testPolygonComponentCrossAtEndpoint() {
     checkTPS("MULTIPOLYGON (((50 40, 40 60, 80 40, 0 0, 30 70, 50 40)), ((40 56, 40 57, 41 56, 40 56)))",
         30,
         "MULTIPOLYGON (((50 40, 80 40, 0 0, 30 70, 50 40)), ((40 56, 40 57, 41 56, 40 56)))");
   }
-  
+
   public void testPolygonIntersectingSegments() {
     checkTPS("MULTIPOLYGON (((0.63 0.2, 0.35 0, 0.73 0.66, 0.63 0.2)), ((1.42 4.01, 3.45 0.7, 1.79 1.47, 0 0.57, 1.42 4.01)))",
         10,
         "MULTIPOLYGON (((0.63 0.2, 0.35 0, 0.73 0.66, 0.63 0.2)), ((1.42 4.01, 3.45 0.7, 1.79 1.47, 0 0.57, 1.42 4.01)))");
   }
-  
+
   private void checkTPS(String wkt, double tolerance, String wktExpected) {
     Geometry geom = read(wkt);
     Geometry actual = TopologyPreservingSimplifier.simplify(geom, tolerance);
@@ -251,7 +251,7 @@ public class TopologyPreservingSimplifierTest
     //checkValid(actual);
     checkEqual(expected, actual);
   }
-  
+
   private void checkTPSNoChange(String wkt, double tolerance) {
     checkTPS(wkt, tolerance, wkt);
   }


### PR DESCRIPTION
With the current state of `TopologyPreservingSimplifier` and related classes, the `LINEARRING (220 180, 261 175, 380 220, 300 40, 140 30, 30 220, 176 176, 220 180)` simplifies to `LINEARRING (30 220, 380 220, 300 40, 140 30, 30 220)` using a tolerance value of `40`. (see [here](https://github.com/locationtech/jts/blob/7b1395b552a1cc1bede96ed23cc2c3ef390fd064/modules/core/src/test/java/org/locationtech/jts/simplify/TopologyPreservingSimplifierTest.java#L153-L159))

Performing the same operation on `LINESTRING (220 180, 261 175, 380 220, 300 40, 140 30, 30 220, 176 176, 220 180)` gives `LINESTRING (220 180, 380 220, 300 40, 140 30, 30 220, 220 180)`. 