### PR TITLE
Enhance coverage simplification to handle one tolerance per geometry

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
@@ -70,7 +70,7 @@ public class CoverageFunctions {
   @Metadata(description="Simplify a coverage by providing one tolerance per geometry")
   public static Geometry simplifyDynamicTolerance(Geometry coverage, String tolerances) {
     Geometry[] cov = toGeometryArray(coverage);
-    List<Double> toleranceList = toDoubleList(tolerances);
+    Double[] toleranceList = toDoubleArray(tolerances);
     Geometry[] result =  CoverageSimplifier.simplify(cov, toleranceList);
     return FunctionsUtil.buildGeometry(result);
   }
@@ -85,7 +85,7 @@ public class CoverageFunctions {
   @Metadata(description="Simplify inner edges of a coverage by providing one tolerance per geometry")
   public static Geometry simplifyinnerDynamicTolerance(Geometry coverage, String tolerances) {
     Geometry[] cov = toGeometryArray(coverage);
-    List<Double> toleranceList = toDoubleList(tolerances);
+    Double[] toleranceList = toDoubleArray(tolerances);
     Geometry[] result =  CoverageSimplifier.simplifyInner(cov, toleranceList);
     return FunctionsUtil.buildGeometry(result);
   }
@@ -104,7 +104,7 @@ public class CoverageFunctions {
     return geoms;
   }
 
-  private static List<Double> toDoubleList(String csvList) {
-    return Arrays.stream(csvList.split(",")).map(Double::parseDouble).collect(Collectors.toList());
+  private static Double[] toDoubleArray(String csvList) {
+    return Arrays.stream(csvList.split(",")).map(Double::parseDouble).toArray(Double[]::new);
   }
 }

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
@@ -64,11 +64,25 @@ public class CoverageFunctions {
     Geometry[] result =  CoverageSimplifier.simplify(cov, tolerance);
     return FunctionsUtil.buildGeometry(result);
   }
+
+  @Metadata(description="Simplify a coverage by providing one tolerance per geometry")
+  public static Geometry simplifyDynamicTolerance(Geometry coverage, String tolerances) {
+    Geometry[] cov = toGeometryArray(coverage);
+    Geometry[] result =  CoverageSimplifier.simplify(cov, tolerances);
+    return FunctionsUtil.buildGeometry(result);
+  }
   
   @Metadata(description="Simplify inner edges of a coverage")
   public static Geometry simplifyinner(Geometry coverage, double tolerance) {
     Geometry[] cov = toGeometryArray(coverage);
     Geometry[] result =  CoverageSimplifier.simplifyInner(cov, tolerance);
+    return FunctionsUtil.buildGeometry(result);
+  }
+
+  @Metadata(description="Simplify inner edges of a coverage by providing one tolerance per geometry")
+  public static Geometry simplifyinnerDynamicTolerance(Geometry coverage, String tolerances) {
+    Geometry[] cov = toGeometryArray(coverage);
+    Geometry[] result =  CoverageSimplifier.simplifyInner(cov, tolerances);
     return FunctionsUtil.buildGeometry(result);
   }
   

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
@@ -11,7 +11,9 @@
  */
 package org.locationtech.jtstest.function;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.locationtech.jts.coverage.CoverageGapFinder;
 import org.locationtech.jts.coverage.CoveragePolygonValidator;
@@ -68,7 +70,8 @@ public class CoverageFunctions {
   @Metadata(description="Simplify a coverage by providing one tolerance per geometry")
   public static Geometry simplifyDynamicTolerance(Geometry coverage, String tolerances) {
     Geometry[] cov = toGeometryArray(coverage);
-    Geometry[] result =  CoverageSimplifier.simplify(cov, tolerances);
+    List<Double> toleranceList = toDoubleList(tolerances);
+    Geometry[] result =  CoverageSimplifier.simplify(cov, toleranceList);
     return FunctionsUtil.buildGeometry(result);
   }
   
@@ -82,7 +85,8 @@ public class CoverageFunctions {
   @Metadata(description="Simplify inner edges of a coverage by providing one tolerance per geometry")
   public static Geometry simplifyinnerDynamicTolerance(Geometry coverage, String tolerances) {
     Geometry[] cov = toGeometryArray(coverage);
-    Geometry[] result =  CoverageSimplifier.simplifyInner(cov, tolerances);
+    List<Double> toleranceList = toDoubleList(tolerances);
+    Geometry[] result =  CoverageSimplifier.simplifyInner(cov, toleranceList);
     return FunctionsUtil.buildGeometry(result);
   }
   
@@ -99,5 +103,8 @@ public class CoverageFunctions {
     }
     return geoms;
   }
-  
+
+  private static List<Double> toDoubleList(String csvList) {
+    return Arrays.stream(csvList.split(",")).map(Double::parseDouble).collect(Collectors.toList());
+  }
 }

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageEdge.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageEdge.java
@@ -30,15 +30,15 @@ import org.locationtech.jts.io.WKTWriter;
  */
 class CoverageEdge {
 
-  public static CoverageEdge createEdge(Coordinate[] ring) {
+  public static CoverageEdge createEdge(Coordinate[] ring, double tolerance) {
     Coordinate[] pts = extractEdgePoints(ring, 0, ring.length - 1);
-    CoverageEdge edge = new CoverageEdge(pts, true);
+    CoverageEdge edge = new CoverageEdge(pts, true, tolerance);
     return edge;
   }
 
-  public static CoverageEdge createEdge(Coordinate[] ring, int start, int end) {
+  public static CoverageEdge createEdge(Coordinate[] ring, int start, int end, double tolerance) {
     Coordinate[] pts = extractEdgePoints(ring, start, end);
-    CoverageEdge edge = new CoverageEdge(pts, false);
+    CoverageEdge edge = new CoverageEdge(pts, false, tolerance);
     return edge;
   }
 
@@ -137,9 +137,12 @@ class CoverageEdge {
   private int ringCount = 0;
   private boolean isFreeRing = true;
 
-  public CoverageEdge(Coordinate[] pts, boolean isFreeRing) {
+  private double tolerance = -1;
+
+  public CoverageEdge(Coordinate[] pts, boolean isFreeRing, double tolerance) {
     this.pts = pts;
     this.isFreeRing = isFreeRing;
+    this.tolerance = tolerance;
   }
 
   public void incRingCount() {
@@ -159,6 +162,10 @@ class CoverageEdge {
   public boolean isFreeRing() {
     return isFreeRing;
   }
+
+  public double getTolerance() { return tolerance; }
+
+  public void setTolerance(double tolerance) { this.tolerance = tolerance; }
 
   public void setCoordinates(Coordinate[] pts) {
     this.pts = pts;

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageRingEdges.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageRingEdges.java
@@ -54,13 +54,13 @@ class CoverageRingEdges {
    * @param tolerances the simplification tolerances for each geometry
    * @return the edges of the coverage
    */
-  public static CoverageRingEdges create(Geometry[] coverage, List<Double> tolerances) {
+  public static CoverageRingEdges create(Geometry[] coverage, Double[] tolerances) {
     CoverageRingEdges edges = new CoverageRingEdges(coverage, tolerances);
     return edges;
   }
 
   public static CoverageRingEdges create(Geometry[] coverage) {
-    CoverageRingEdges edges = new CoverageRingEdges(coverage, new ArrayList<Double>(0));
+    CoverageRingEdges edges = new CoverageRingEdges(coverage, null);
     return edges;
   }
   
@@ -68,9 +68,9 @@ class CoverageRingEdges {
   private Map<LinearRing, List<CoverageEdge>> ringEdgesMap;
   private List<CoverageEdge> edges;
 
-  private List<Double> coverageTolerances;
+  private Double[] coverageTolerances;
 
-  public CoverageRingEdges(Geometry[] coverage, List<Double> tolerances) {
+  public CoverageRingEdges(Geometry[] coverage, Double[] tolerances) {
     this.coverage = coverage;
     ringEdgesMap = new HashMap<LinearRing, List<CoverageEdge>>();
     edges = new ArrayList<CoverageEdge>();
@@ -192,16 +192,17 @@ class CoverageRingEdges {
   }
 
   private CoverageEdge createEdge(int coverageId, Coordinate[] ring, HashMap<LineSegment, CoverageEdge> uniqueEdgeMap) {
+    boolean hasTolerance = coverageTolerances != null;
     CoverageEdge edge;
     LineSegment edgeKey = CoverageEdge.key(ring);
     if (uniqueEdgeMap.containsKey(edgeKey)) {
       edge = uniqueEdgeMap.get(edgeKey);
-      if (!coverageTolerances.isEmpty()){
-        edge.setTolerance((edge.getTolerance() < coverageTolerances.get(coverageId)) ? edge.getTolerance() : coverageTolerances.get(coverageId));
+      if (hasTolerance){
+        edge.setTolerance((edge.getTolerance() < coverageTolerances[coverageId]) ? edge.getTolerance() : coverageTolerances[coverageId]);
       }
     }
     else {
-      double tolerance = coverageTolerances.isEmpty() ? -1 : coverageTolerances.get(coverageId);
+      double tolerance = hasTolerance ? coverageTolerances[coverageId] : -1;
       edge = CoverageEdge.createEdge(ring, tolerance);
       uniqueEdgeMap.put(edgeKey, edge);
       edges.add(edge);
@@ -211,16 +212,17 @@ class CoverageRingEdges {
   }
   
   private CoverageEdge createEdge(int coverageId, Coordinate[] ring, int start, int end, HashMap<LineSegment, CoverageEdge> uniqueEdgeMap) {
+    boolean hasTolerance = coverageTolerances != null;
     CoverageEdge edge;
     LineSegment edgeKey = (end == start) ? CoverageEdge.key(ring) : CoverageEdge.key(ring, start, end);
     if (uniqueEdgeMap.containsKey(edgeKey)) {
       edge = uniqueEdgeMap.get(edgeKey);
-      if (!coverageTolerances.isEmpty()){
-        edge.setTolerance((edge.getTolerance() < coverageTolerances.get(coverageId)) ? edge.getTolerance() : coverageTolerances.get(coverageId));
+      if (hasTolerance){
+        edge.setTolerance((edge.getTolerance() < coverageTolerances[coverageId]) ? edge.getTolerance() : coverageTolerances[coverageId]);
       }
     }
     else {
-      double tolerance = coverageTolerances.isEmpty() ? -1 : coverageTolerances.get(coverageId);
+      double tolerance = hasTolerance ? coverageTolerances[coverageId] : -1;
       edge = CoverageEdge.createEdge(ring, start, end, tolerance);
       uniqueEdgeMap.put(edgeKey, edge);
       edges.add(edge);

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageRingEdges.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageRingEdges.java
@@ -212,23 +212,26 @@ class CoverageRingEdges {
   }
   
   private CoverageEdge createEdge(int coverageId, Coordinate[] ring, int start, int end, HashMap<LineSegment, CoverageEdge> uniqueEdgeMap) {
-    boolean hasTolerance = coverageTolerances != null;
     CoverageEdge edge;
     LineSegment edgeKey = (end == start) ? CoverageEdge.key(ring) : CoverageEdge.key(ring, start, end);
     if (uniqueEdgeMap.containsKey(edgeKey)) {
       edge = uniqueEdgeMap.get(edgeKey);
-      if (hasTolerance){
-        edge.setTolerance((edge.getTolerance() < coverageTolerances[coverageId]) ? edge.getTolerance() : coverageTolerances[coverageId]);
-      }
+      assignEdgeTolerance(coverageId, edge);
     }
     else {
-      double tolerance = hasTolerance ? coverageTolerances[coverageId] : -1;
+      double tolerance = coverageTolerances == null ? -1 : coverageTolerances[coverageId];
       edge = CoverageEdge.createEdge(ring, start, end, tolerance);
       uniqueEdgeMap.put(edgeKey, edge);
       edges.add(edge);
     }
     edge.incRingCount();
     return edge;
+  }
+
+  private void assignEdgeTolerance(int coverageId, CoverageEdge edge){
+      if (coverageTolerances != null){
+        edge.setTolerance((edge.getTolerance() < coverageTolerances[coverageId]) ? edge.getTolerance() : coverageTolerances[coverageId]);
+      }
   }
 
   private int findNextNodeIndex(Coordinate[] ring, int start, Set<Coordinate> nodes) {

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
@@ -81,7 +81,7 @@ public class CoverageSimplifier {
    * @param tolerances the simplification tolerances for each coverage
    * @return the simplified polygons
    */
-  public static Geometry[] simplify(Geometry[] coverage, List<Double> tolerances) {
+  public static Geometry[] simplify(Geometry[] coverage, Double[] tolerances) {
     CoverageSimplifier simplifier = new CoverageSimplifier(coverage);
     return simplifier.simplify(tolerances);
   }
@@ -109,7 +109,7 @@ public class CoverageSimplifier {
    * @param tolerances the simplification tolerances for each coverage
    * @return the simplified polygons
    */
-  public static Geometry[] simplifyInner(Geometry[] coverage, List<Double> tolerances) {
+  public static Geometry[] simplifyInner(Geometry[] coverage, Double[] tolerances) {
     CoverageSimplifier simplifier = new CoverageSimplifier(coverage);
     return simplifier.simplifyInner(tolerances);
   }
@@ -146,10 +146,10 @@ public class CoverageSimplifier {
    * @param tolerances the simplification tolerances for each coverage
    * @return the simplified polygons
    */
-  public Geometry[] simplify(List<Double> tolerances) {
-    if (input.length != tolerances.size()){
+  public Geometry[] simplify(Double[] tolerances) {
+    if (input.length != tolerances.length){
       throw new IllegalArgumentException(
-              String.format("Mismatch between provided tolerances (%d) and input geometry count (%d)", tolerances.size(), input.length));
+              String.format("Mismatch between provided tolerances (%d) and input geometry count (%d)", tolerances.length, input.length));
     }
 
     CoverageRingEdges cov = CoverageRingEdges.create(input, tolerances);
@@ -185,10 +185,10 @@ public class CoverageSimplifier {
    * @param tolerances the simplification tolerances for each coverage
    * @return the simplified polygons
    */
-  public Geometry[] simplifyInner(List<Double> tolerances) {
-    if (input.length != tolerances.size()){
+  public Geometry[] simplifyInner(Double[] tolerances) {
+    if (input.length != tolerances.length){
       throw new IllegalArgumentException(
-              String.format("Mismatch between provided tolerances (%d) and input geometry count (%d)", tolerances.size(), input.length));
+              String.format("Mismatch between provided tolerances (%d) and input geometry count (%d)", tolerances.length, input.length));
     }
 
     CoverageRingEdges cov = CoverageRingEdges.create(input, tolerances);

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
@@ -34,7 +34,12 @@ import org.locationtech.jts.geom.MultiLineString;
  * which is a non-negative quantity. It equates roughly to the maximum
  * distance by which a simplified line can change from the original.
  * (In fact, it is the square root of the area tolerance used 
- * in the Visvalingam-Whyatt algorithm.)
+ * in the Visvalingam-Whyatt algorithm.).
+ * The simplifier also allows specifying the simplification tolerance separately for each input geometry.
+ * Shared edges are simplified using the lowest of the tolerances for the adjacent geometries
+ * (i.e. the least amount of simplification is performed).
+ * This allows specific geometries in a coverage to be simplified less than other geometries
+ * (or to force their boundary to be preserved without simplification).
  * <p>
  * The simplified result coverage has the following characteristics:
  * <ul>

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
@@ -82,23 +82,6 @@ public class CoverageSimplifier {
   }
 
   /**
-   * Simplifies the boundaries of a set of polygonal geometries forming a coverage,
-   * preserving the coverage topology.
-   *
-   * @param coverage a set of polygonal geometries forming a coverage
-   * @param tolerances comma-separated string of simplification tolerances for each coverage
-   * @return the simplified polygons
-   */
-  public static Geometry[] simplify(Geometry[] coverage, String tolerances) {
-    List<Double> tolerancesList = Arrays.stream(tolerances.split(","))
-            .map(Double::parseDouble)
-            .collect(Collectors.toList());
-
-    CoverageSimplifier simplifier = new CoverageSimplifier(coverage);
-    return simplifier.simplify(tolerancesList);
-  }
-
-  /**
    * Simplifies the inner boundaries of a set of polygonal geometries forming a coverage,
    * preserving the coverage topology.
    * Edges which form the exterior boundary of the coverage are left unchanged.
@@ -124,24 +107,6 @@ public class CoverageSimplifier {
   public static Geometry[] simplifyInner(Geometry[] coverage, List<Double> tolerances) {
     CoverageSimplifier simplifier = new CoverageSimplifier(coverage);
     return simplifier.simplifyInner(tolerances);
-  }
-
-  /**
-   * Simplifies the inner boundaries of a set of polygonal geometries forming a coverage,
-   * preserving the coverage topology.
-   * Edges which form the exterior boundary of the coverage are left unchanged.
-   *
-   * @param coverage a set of polygonal geometries forming a coverage
-   * @param tolerances comma-separated string of simplification tolerances for each coverage
-   * @return the simplified polygons
-   */
-  public static Geometry[] simplifyInner(Geometry[] coverage, String tolerances) {
-    List<Double> tolerancesList = Arrays.stream(tolerances.split(","))
-            .map(Double::parseDouble)
-            .collect(Collectors.toList());
-
-    CoverageSimplifier simplifier = new CoverageSimplifier(coverage);
-    return simplifier.simplifyInner(tolerancesList);
   }
   
   private Geometry[] input;

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/TPVWSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/TPVWSimplifier.java
@@ -170,10 +170,14 @@ class TPVWSimplifier {
     for (int i = 0 ; i < lines.getNumGeometries(); i++) {
       LineString line = (LineString) lines.getGeometryN(i);
       boolean isFree = isFreeRing == null ? false : isFreeRing.get(i);
-      double areaTolerance = (areaTolerances.isEmpty()) ? -1 : ((areaTolerances.size() == 1) ? areaTolerances.get(0) : areaTolerances.get(i));
+      double areaTolerance = getAreaTolerance(i);
       edges.add(new Edge(line, isFree, areaTolerance));
     }
     return edges;
+  }
+
+  private double getAreaTolerance(int index) {
+    return (areaTolerances.isEmpty()) ? -1 : ((areaTolerances.size() == 1) ? areaTolerances.get(0) : areaTolerances.get(index));
   }
   
   private static class Edge {

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
@@ -99,8 +99,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testRepeatedPointRemovedDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(2.0);
+    Double[] tolerance = { 2.0 };
     checkResultDynamic(readArray(
                     "POLYGON ((5 9, 6.5 6.5, 9 5, 5 5, 5 5, 5 9))" ),
                     tolerance,
@@ -119,8 +118,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testRepeatedPointCollapseToLineDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(5.0);
+    Double[] tolerance = { 5.0 };
     checkResultDynamic(readArray(
             "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 30, 20 29, 30 30, 30 20, 20 19, 10 20, 10 30)), ((10 20, 20 19, 20 19, 10 20)))" ),
             tolerance,
@@ -139,8 +137,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testRepeatedPointCollapseToPointDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(5.0);
+    Double[] tolerance = { 5.0 };
     checkResultDynamic(readArray(
             "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 30, 20 29, 30 30, 30 20, 20 19, 10 20, 10 30)), ((20 19, 20 19, 20 19)))" ),
             tolerance,
@@ -159,8 +156,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testRepeatedPointCollapseToPoint2Dynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(40.0);
+    Double[] tolerance = { 40.0 };
     checkResultDynamic(readArray(
             "MULTIPOLYGON (((100 200, 150 195, 200 200, 200 100, 100 100, 100 200)), ((150 195, 150 195, 150 195, 150 195)))" ),
             tolerance,
@@ -183,7 +179,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testSimple2Dynamic() {
-    List<Double> tolerances = Arrays.asList(1.0, 10.0);
+    Double[] tolerances = { 1.0, 10.0 };
     checkResultDynamic(readArray(
             "POLYGON ((100 100, 200 200, 300 100, 200 101, 100 100))",
             "POLYGON ((150 0, 100 100, 200 101, 300 100, 250 0, 150 0))" ),
@@ -206,7 +202,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testMultiPolygonsDynamic() {
-    List<Double> tolerances = Arrays.asList(1.0, 3.0);
+    Double[] tolerances = { 1.0, 3.0 };
     checkResultDynamic(readArray(
             "MULTIPOLYGON (((5 9, 2.5 7.5, 1 5, 5 5, 5 9)), ((5 5, 9 5, 7.5 2.5, 5 1, 5 5)))",
             "MULTIPOLYGON (((5 9, 6.5 6.5, 9 5, 5 5, 5 9)), ((1 5, 5 5, 5 1, 3.5 3.5, 1 5)))" ),
@@ -227,8 +223,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testSingleRingNoCollapseDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(100000.0);
+    Double[] tolerance = { 100000.0 };
     checkResultDynamic(readArray(
             "POLYGON ((10 50, 60 90, 70 50, 60 10, 10 50))" ),
             tolerance,
@@ -253,7 +248,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testMultiEdgeRingNoCollapseDynamic() {
-    List<Double> tolerances = Arrays.asList(40.0, 40.0);
+    Double[] tolerances = { 40.0, 40.0 };
     checkResultDynamic(readArray(
                     "POLYGON ((50 250, 200 200, 180 170, 200 150, 50 50, 50 250))",
                     "POLYGON ((200 200, 180 170, 200 150, 200 200))"),
@@ -276,7 +271,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testFilledHoleDynamic() {
-    List<Double> tolerances = Arrays.asList(17.0, 28.0);
+    Double[] tolerances = { 17.0, 28.0 };
     checkResultDynamic(readArray(
              "POLYGON ((20 30, 20 80, 60 50, 80 20, 50 20, 20 30))",
              "POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (50 20, 20 30, 20 80, 60 50, 80 20, 50 20))" ),
@@ -301,7 +296,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testTouchingHolesDynamic() {
-    List<Double> tolerances = Arrays.asList(1.0 ,1.0 ,0.5);
+    Double[] tolerances = { 1.0, 1.0, 0.5 };
     checkResultDynamic(readArray(
             "POLYGON (( 0 0, 0 11, 19 11, 19 0, 0 0 ), ( 4 5, 12 5, 12 6, 10 6, 10 8, 9 8, 9 9, 7 9, 7 8, 6 8, 6 6, 4 6, 4 5 ), ( 12 6, 14 6, 14 9, 13 9, 13 7, 12 7, 12 6 ))",
             "POLYGON (( 12 6, 12 5, 4 5, 4 6, 6 6, 6 8, 7 8, 7 9, 9 9, 9 8, 10 8, 10 6, 12 6 ))",
@@ -328,7 +323,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testHoleTouchingShellDynamic() {
-    List<Double> tolerances = Arrays.asList(100.0, 100.0, 100.0);
+    Double[] tolerances = { 100.0, 100.0, 100.0 };
     checkResultInnerDynamic(readArray(
             "POLYGON ((200 300, 300 300, 300 100, 100 100, 100 300, 200 300), (170 220, 170 160, 200 140, 200 250, 170 220), (170 250, 200 250, 200 300, 170 250))",
             "POLYGON ((170 220, 200 250, 200 140, 170 160, 170 220))",
@@ -351,8 +346,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testHolesTouchingHolesAndShellInnerDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(4.0);
+    Double[] tolerance = { 4.0 };
     checkResultInnerDynamic(readArray(
             "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))"),
             tolerance,
@@ -371,8 +365,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testHolesTouchingHolesAndShellDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(4.0);
+    Double[] tolerance = { 4.0 };
     checkResultDynamic(readArray(
             "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))"),
             tolerance,
@@ -392,8 +385,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testMultiPolygonWithTouchingShellsInnerDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(4.0);
+    Double[] tolerance = { 4.0 };
     checkResultInnerDynamic(
         readArray(
         "MULTIPOLYGON ((( 2 7, 2 8, 3 8, 3 7, 2 7 )), (( 1 6, 1 7, 2 7, 2 6, 1 6 )), (( 0 7, 0 8, 1 8, 1 7, 0 7 )), (( 0 5, 0 6, 1 6, 1 5, 0 5 )), (( 2 5, 2 6, 3 6, 3 5, 2 5 )))"),
@@ -414,8 +406,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testMultiPolygonWithTouchingShellsDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(4.0);
+    Double[] tolerance = { 4.0 };
     checkResultDynamic(
         readArray(
             "MULTIPOLYGON ((( 2 7, 2 8, 3 8, 3 7, 2 7 )), (( 1 6, 1 7, 2 7, 2 6, 1 6 )), (( 0 7, 0 8, 1 8, 1 7, 0 7 )), (( 0 5, 0 6, 1 6, 1 5, 0 5 )), (( 2 5, 2 6, 3 6, 3 5, 2 5 )))"),
@@ -437,7 +428,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testTouchingShellsInnerDynamic() {
-    List<Double> tolerances = Arrays.asList(4.0, 4.0);
+    Double[] tolerances = { 4.0, 4.0 };
     checkResultInnerDynamic(readArray(
             "POLYGON ((0 0, 0 5, 5 6, 10 5, 10 0, 0 0))",
             "POLYGON ((0 10, 5 6, 10 10, 0 10))"),
@@ -458,8 +449,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testShellSimplificationAtStartingNodeDynamic() {
-    List<Double> tolerance = new ArrayList<Double>(1);
-    tolerance.add(1.5);
+    Double[] tolerance = { 1.5 };
     checkResultDynamic(readArray(
                     "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
             tolerance,
@@ -480,7 +470,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testSimplifyInnerAtStartingNodeDynamic() {
-    List<Double> tolerances = Arrays.asList(3.0, 2.0);
+    Double[] tolerances = { 3.0, 2.0 };
     checkResultInnerDynamic(readArray(
                     "POLYGON (( 0 5, 0 9, 6 9, 6 2, 1 2, 0 5 ), ( 1 5, 2 3, 5 3, 5 7, 1 7, 1 5 ))",
                     "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
@@ -503,7 +493,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testSimplifyAllAtStartingNodeDynamic() {
-    List<Double> tolerances = Arrays.asList(1.5, 3.0);
+    Double[] tolerances = { 1.5, 3.0 };
     checkResultDynamic(readArray(
                     "POLYGON (( 0 5, 0 9, 6 9, 6 2, 1 2, 0 5 ), ( 1 5, 2 3, 5 3, 5 7, 1 7, 1 5 ))",
                     "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
@@ -527,7 +517,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testInnerSimpleDynamic() {
-    List<Double> tolerances = Arrays.asList(50.0, 100.0);
+    Double[] tolerances = { 50.0, 100.0 };
     checkResultInnerDynamic(readArray(
                     "POLYGON ((50 50, 50 150, 100 190, 100 200, 200 200, 160 150, 120 120, 90 80, 50 50))",
                     "POLYGON ((100 0, 50 50, 90 80, 120 120, 160 150, 200 200, 250 100, 170 50, 100 0))" ),
@@ -552,7 +542,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testAllEmptyDynamic() {
-    List<Double> tolerances = Arrays.asList(1.0, 1.0);
+    Double[] tolerances = { 1.0, 1.0 };
     checkResultDynamic(readArray(
                     "POLYGON EMPTY",
                     "POLYGON EMPTY" ),
@@ -575,7 +565,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testOneEmptyDynamic() {
-    List<Double> tolerances = Arrays.asList(1.0, 1.0);
+    Double[] tolerances = { 1.0, 1.0 };
     checkResultDynamic(readArray(
                     "POLYGON ((1 9, 5 9.1, 9 9, 9 1, 1 1, 1 9))",
                     "POLYGON EMPTY" ),
@@ -598,7 +588,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   public void testEmptyHoleDynamic() {
-    List<Double> tolerances = Arrays.asList(1.0, 1.0);
+    Double[] tolerances = { 1.0, 1.0 };
     checkResultDynamic(readArray(
                     "POLYGON ((1 9, 5 9.1, 9 9, 9 1, 1 1, 1 9), EMPTY)",
                     "POLYGON EMPTY" ),
@@ -617,7 +607,8 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
 
   private void checkNoopDynamic(Geometry[] input) {
-    List<Double> tolerance = Collections.nCopies(input.length, 0.0);
+    Double[] tolerance = new Double[input.length];
+    Arrays.fill(tolerance, 0.0);
     Geometry[] actual = CoverageSimplifier.simplify(input, tolerance);
     checkEqual(input, actual);
   }
@@ -627,7 +618,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     checkEqual(expected, actual);
   }
 
-  private void checkResultDynamic(Geometry[] input, List<Double> tolerances, Geometry[] expected) {
+  private void checkResultDynamic(Geometry[] input, Double[] tolerances, Geometry[] expected) {
     Geometry[] actual = CoverageSimplifier.simplify(input, tolerances);
     checkEqual(expected, actual);
   }
@@ -637,7 +628,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     checkEqual(expected, actual);
   }
 
-  private void checkResultInnerDynamic(Geometry[] input, List<Double> tolerances, Geometry[] expected) {
+  private void checkResultInnerDynamic(Geometry[] input, Double[] tolerances, Geometry[] expected) {
     Geometry[] actual = CoverageSimplifier.simplifyInner(input, tolerances);
     checkEqual(expected, actual);
   }

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
@@ -16,6 +16,11 @@ import org.locationtech.jts.geom.Geometry;
 import junit.textui.TestRunner;
 import test.jts.GeometryTestCase;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+
 public class CoverageSimplifierTest extends GeometryTestCase {
   public static void main(String args[]) {
     TestRunner.run(CoverageSimplifierTest.class);
@@ -32,11 +37,26 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testNoopSimple2Dynamic() {
+    checkNoopDynamic(readArray(
+            "POLYGON ((100 100, 200 200, 300 100, 200 101, 100 100))",
+            "POLYGON ((150 0, 100 100, 200 101, 300 100, 250 0, 150 0))" )
+    );
+  }
+
   public void testNoopSimple3() {
     checkNoop(readArray(
         "POLYGON ((100 300, 200 200, 100 200, 100 300))",
         "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
         "POLYGON ((100 100, 200 100, 150 50, 100 100))" )
+    );
+  }
+
+  public void testNoopSimple3Dynamic() {
+    checkNoopDynamic(readArray(
+            "POLYGON ((100 300, 200 200, 100 200, 100 300))",
+            "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
+            "POLYGON ((100 100, 200 100, 150 50, 100 100))" )
     );
   }
 
@@ -47,6 +67,13 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testNoopHoleDynamic() {
+    checkNoopDynamic(readArray(
+            "POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (20 80, 80 80, 80 20, 20 20, 20 80))",
+            "POLYGON ((80 20, 20 20, 20 80, 80 80, 80 20))" )
+    );
+  }
+
   public void testNoopMulti() {
     checkNoop(readArray(
         "MULTIPOLYGON (((10 10, 10 50, 50 50, 50 10, 10 10)), ((90 90, 90 50, 50 50, 50 90, 90 90)))",
@@ -54,6 +81,12 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testNoopMultiDynamic() {
+    checkNoopDynamic(readArray(
+            "MULTIPOLYGON (((10 10, 10 50, 50 50, 50 10, 10 10)), ((90 90, 90 50, 50 50, 50 90, 90 90)))",
+            "MULTIPOLYGON (((10 90, 50 90, 50 50, 10 50, 10 90)), ((90 10, 50 10, 50 50, 90 50, 90 10)))" )
+    );
+  }
   //---------------------------------------------
   
   public void testRepeatedPointRemoved() {
@@ -64,7 +97,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "POLYGON ((5 5, 5 9, 9 5, 5 5))" )
     );
   }
-  
+
+  public void testRepeatedPointRemovedDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(2.0);
+    checkResultDynamic(readArray(
+                    "POLYGON ((5 9, 6.5 6.5, 9 5, 5 5, 5 5, 5 9))" ),
+                    tolerance,
+                    readArray(
+                            "POLYGON ((5 5, 5 9, 9 5, 5 5))" )
+    );
+  }
+
   public void testRepeatedPointCollapseToLine() {
     checkResult(readArray(
         "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 30, 20 29, 30 30, 30 20, 20 19, 10 20, 10 30)), ((10 20, 20 19, 20 19, 10 20)))" ),
@@ -73,13 +117,35 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "MULTIPOLYGON (((10 20, 20 19, 30 20, 30 10, 10 10, 10 20)), ((30 20, 20 19, 10 20, 10 30, 30 30, 30 20)), ((10 20, 20 19, 10 20)))" )
     );
   }
-  
+
+  public void testRepeatedPointCollapseToLineDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(5.0);
+    checkResultDynamic(readArray(
+            "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 30, 20 29, 30 30, 30 20, 20 19, 10 20, 10 30)), ((10 20, 20 19, 20 19, 10 20)))" ),
+            tolerance,
+            readArray(
+                    "MULTIPOLYGON (((10 20, 20 19, 30 20, 30 10, 10 10, 10 20)), ((30 20, 20 19, 10 20, 10 30, 30 30, 30 20)), ((10 20, 20 19, 10 20)))" )
+    );
+  }
+
   public void testRepeatedPointCollapseToPoint() {
     checkResult(readArray(
         "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 30, 20 29, 30 30, 30 20, 20 19, 10 20, 10 30)), ((20 19, 20 19, 20 19)))" ),
         5,
         readArray(
             "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 20, 10 30, 30 30, 30 20, 20 19, 10 20)), ((20 19, 20 19, 20 19)))" )
+    );
+  }
+
+  public void testRepeatedPointCollapseToPointDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(5.0);
+    checkResultDynamic(readArray(
+            "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 30, 20 29, 30 30, 30 20, 20 19, 10 20, 10 30)), ((20 19, 20 19, 20 19)))" ),
+            tolerance,
+            readArray(
+                    "MULTIPOLYGON (((10 10, 10 20, 20 19, 30 20, 30 10, 10 10)), ((10 20, 10 30, 30 30, 30 20, 20 19, 10 20)), ((20 19, 20 19, 20 19)))" )
     );
   }
   
@@ -91,7 +157,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "MULTIPOLYGON (((150 195, 200 200, 200 100, 100 100, 100 200, 150 195)), ((150 195, 150 195, 150 195, 150 195)))" )
     );
   }
-  
+
+  public void testRepeatedPointCollapseToPoint2Dynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(40.0);
+    checkResultDynamic(readArray(
+            "MULTIPOLYGON (((100 200, 150 195, 200 200, 200 100, 100 100, 100 200)), ((150 195, 150 195, 150 195, 150 195)))" ),
+            tolerance,
+            readArray(
+                    "MULTIPOLYGON (((150 195, 200 200, 200 100, 100 100, 100 200, 150 195)), ((150 195, 150 195, 150 195, 150 195)))" )
+    );
+  }
+
   //---------------------------------------------
   
   public void testSimple2() {
@@ -105,6 +182,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testSimple2Dynamic() {
+    List<Double> tolerances = Arrays.asList(1.0, 10.0);
+    checkResultDynamic(readArray(
+            "POLYGON ((100 100, 200 200, 300 100, 200 101, 100 100))",
+            "POLYGON ((150 0, 100 100, 200 101, 300 100, 250 0, 150 0))" ),
+            tolerances,
+            readArray(
+                "POLYGON ((100 100, 200 200, 300 100, 200 101, 100 100)),",
+                "POLYGON ((300 100, 200 101, 100 100, 150 0, 250 0, 300 100))")
+    );
+  }
+
   public void testMultiPolygons() {
     checkResult(readArray(
         "MULTIPOLYGON (((5 9, 2.5 7.5, 1 5, 5 5, 5 9)), ((5 5, 9 5, 7.5 2.5, 5 1, 5 5)))",
@@ -115,6 +204,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "MULTIPOLYGON (((1 5, 5 5, 5 1, 1 5)), ((5 5, 5 9, 9 5, 5 5)))" )
     );
   }
+
+  public void testMultiPolygonsDynamic() {
+    List<Double> tolerances = Arrays.asList(1.0, 3.0);
+    checkResultDynamic(readArray(
+            "MULTIPOLYGON (((5 9, 2.5 7.5, 1 5, 5 5, 5 9)), ((5 5, 9 5, 7.5 2.5, 5 1, 5 5)))",
+            "MULTIPOLYGON (((5 9, 6.5 6.5, 9 5, 5 5, 5 9)), ((1 5, 5 5, 5 1, 3.5 3.5, 1 5)))" ),
+            tolerances,
+            readArray(
+             "MULTIPOLYGON (((5 9, 2.5 7.5, 1 5, 5 5, 5 9)), ((5 5, 9 5, 7.5 2.5, 5 1, 5 5)))",
+             "MULTIPOLYGON (((5 9, 9 5, 5 5, 5 9)), ((1 5, 5 5, 5 1, 1 5)))")
+    );
+  }
   
   public void testSingleRingNoCollapse() {
     checkResult(readArray(
@@ -122,6 +223,17 @@ public class CoverageSimplifierTest extends GeometryTestCase {
         100000,
         readArray(
             "POLYGON ((10 50, 60 90, 60 10, 10 50))" )
+    );
+  }
+
+  public void testSingleRingNoCollapseDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(100000.0);
+    checkResultDynamic(readArray(
+            "POLYGON ((10 50, 60 90, 70 50, 60 10, 10 50))" ),
+            tolerance,
+            readArray(
+                    "POLYGON ((10 50, 60 90, 60 10, 10 50))" )
     );
   }
 
@@ -140,6 +252,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testMultiEdgeRingNoCollapseDynamic() {
+    List<Double> tolerances = Arrays.asList(40.0, 40.0);
+    checkResultDynamic(readArray(
+                    "POLYGON ((50 250, 200 200, 180 170, 200 150, 50 50, 50 250))",
+                    "POLYGON ((200 200, 180 170, 200 150, 200 200))"),
+            tolerances,
+            readArray(
+                    "POLYGON ((50 250, 200 200, 180 170, 200 150, 50 50, 50 250))",
+                    "POLYGON ((200 200, 180 170, 200 150, 200 200))")
+    );
+  }
+
   public void testFilledHole() {
     checkResult(readArray(
         "POLYGON ((20 30, 20 80, 60 50, 80 20, 50 20, 20 30))",
@@ -148,6 +272,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
         readArray(
             "POLYGON ((20 30, 20 80, 80 20, 20 30))",
             "POLYGON ((10 10, 10 90, 90 90, 90 10, 10 10), (20 30, 80 20, 20 80, 20 30))" )
+    );
+  }
+
+  public void testFilledHoleDynamic() {
+    List<Double> tolerances = Arrays.asList(17.0, 28.0);
+    checkResultDynamic(readArray(
+             "POLYGON ((20 30, 20 80, 60 50, 80 20, 50 20, 20 30))",
+             "POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (50 20, 20 30, 20 80, 60 50, 80 20, 50 20))" ),
+            tolerances,
+            readArray(
+                "POLYGON ((20 30, 20 80, 60 50, 80 20, 20 30))",
+                "POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (20 30, 20 80, 60 50, 80 20, 20 30))")
     );
   }
 
@@ -164,6 +300,20 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testTouchingHolesDynamic() {
+    List<Double> tolerances = Arrays.asList(1.0 ,1.0 ,0.5);
+    checkResultDynamic(readArray(
+            "POLYGON (( 0 0, 0 11, 19 11, 19 0, 0 0 ), ( 4 5, 12 5, 12 6, 10 6, 10 8, 9 8, 9 9, 7 9, 7 8, 6 8, 6 6, 4 6, 4 5 ), ( 12 6, 14 6, 14 9, 13 9, 13 7, 12 7, 12 6 ))",
+            "POLYGON (( 12 6, 12 5, 4 5, 4 6, 6 6, 6 8, 7 8, 7 9, 9 9, 9 8, 10 8, 10 6, 12 6 ))",
+            "POLYGON (( 12 6, 12 7, 13 7, 13 9, 14 9, 14 6, 12 6 ))"),
+            tolerances,
+            readArray(
+                    "POLYGON ((0 0, 0 11, 19 11, 19 0, 0 0), (12 6, 10 6, 9 9, 6 8, 6 6, 4 5, 12 5, 12 6), (12 6, 14 6, 14 9, 13 9, 13 7, 12 7, 12 6))",
+                    "POLYGON  ((12 6, 10 6, 9 9, 6 8, 6 6, 4 5, 12 5, 12 6))",
+                    "POLYGON ((12 6, 14 6, 14 9, 13 9, 13 7, 12 7, 12 6))" )
+    );
+  }
+
   public void testHoleTouchingShell() {
     checkResultInner(readArray(
             "POLYGON ((200 300, 300 300, 300 100, 100 100, 100 300, 200 300), (170 220, 170 160, 200 140, 200 250, 170 220), (170 250, 200 250, 200 300, 170 250))",
@@ -177,6 +327,20 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testHoleTouchingShellDynamic() {
+    List<Double> tolerances = Arrays.asList(100.0, 100.0, 100.0);
+    checkResultInnerDynamic(readArray(
+            "POLYGON ((200 300, 300 300, 300 100, 100 100, 100 300, 200 300), (170 220, 170 160, 200 140, 200 250, 170 220), (170 250, 200 250, 200 300, 170 250))",
+            "POLYGON ((170 220, 200 250, 200 140, 170 160, 170 220))",
+            "POLYGON ((170 250, 200 300, 200 250, 170 250))"),
+            tolerances,
+            readArray(
+                    "POLYGON ((100 100, 100 300, 200 300, 300 300, 300 100, 100 100), (170 160, 200 140, 200 250, 170 160), (170 250, 200 250, 200 300, 170 250))",
+                    "POLYGON ((170 160, 200 250, 200 140, 170 160))",
+                    "POLYGON ((200 250, 200 300, 170 250, 200 250))" )
+    );
+  }
+
   public void testHolesTouchingHolesAndShellInner() {
     checkResultInner(readArray(
             "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))"),
@@ -186,12 +350,34 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testHolesTouchingHolesAndShellInnerDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(4.0);
+    checkResultInnerDynamic(readArray(
+            "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))"),
+            tolerance,
+            readArray(
+                    "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))")
+    );
+  }
+
   public void testHolesTouchingHolesAndShell() {
     checkResult(readArray(
             "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))"),
         4.0,
         readArray(
             "POLYGON (( 1 2, 1 8, 9 8, 8 5, 9 2, 1 2 ), ( 5 4, 6 3, 6 4, 5 4 ), ( 5 6, 6 6, 6 7, 5 6 ), ( 6 4, 7 4, 8 5, 7 6, 6 6, 6 4 ), ( 7 3, 8 4, 7 4, 7 3 ), ( 7 6, 8 6, 7 7, 7 6 ))")
+    );
+  }
+
+  public void testHolesTouchingHolesAndShellDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(4.0);
+    checkResultDynamic(readArray(
+            "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))"),
+            tolerance,
+            readArray(
+                    "POLYGON (( 1 2, 1 8, 9 8, 8 5, 9 2, 1 2 ), ( 5 4, 6 3, 6 4, 5 4 ), ( 5 6, 6 6, 6 7, 5 6 ), ( 6 4, 7 4, 8 5, 7 6, 6 6, 6 4 ), ( 7 3, 8 4, 7 4, 7 3 ), ( 7 6, 8 6, 7 7, 7 6 ))")
     );
   }
 
@@ -205,11 +391,35 @@ public class CoverageSimplifierTest extends GeometryTestCase {
         );
   }
 
+  public void testMultiPolygonWithTouchingShellsInnerDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(4.0);
+    checkResultInnerDynamic(
+        readArray(
+        "MULTIPOLYGON ((( 2 7, 2 8, 3 8, 3 7, 2 7 )), (( 1 6, 1 7, 2 7, 2 6, 1 6 )), (( 0 7, 0 8, 1 8, 1 7, 0 7 )), (( 0 5, 0 6, 1 6, 1 5, 0 5 )), (( 2 5, 2 6, 3 6, 3 5, 2 5 )))"),
+        tolerance,
+        readArray(
+            "MULTIPOLYGON ((( 2 7, 2 8, 3 8, 3 7, 2 7 )), (( 1 6, 1 7, 2 7, 2 6, 1 6 )), (( 0 7, 0 8, 1 8, 1 7, 0 7 )), (( 0 5, 0 6, 1 6, 1 5, 0 5 )), (( 2 5, 2 6, 3 6, 3 5, 2 5 )))")
+    );
+  }
+
   public void testMultiPolygonWithTouchingShells() {
     checkResult(
         readArray(
             "MULTIPOLYGON ((( 2 7, 2 8, 3 8, 3 7, 2 7 )), (( 1 6, 1 7, 2 7, 2 6, 1 6 )), (( 0 7, 0 8, 1 8, 1 7, 0 7 )), (( 0 5, 0 6, 1 6, 1 5, 0 5 )), (( 2 5, 2 6, 3 6, 3 5, 2 5 )))"),
         1.0,
+        readArray(
+            "MULTIPOLYGON (((0 5, 0 6, 1 6, 0 5)), ((0 8, 1 8, 1 7, 0 8)), ((1 6, 1 7, 2 7, 2 6, 1 6)), ((2 5, 2 6, 3 5, 2 5)), ((2 7, 3 8, 3 7, 2 7)))")
+    );
+  }
+
+  public void testMultiPolygonWithTouchingShellsDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(4.0);
+    checkResultDynamic(
+        readArray(
+            "MULTIPOLYGON ((( 2 7, 2 8, 3 8, 3 7, 2 7 )), (( 1 6, 1 7, 2 7, 2 6, 1 6 )), (( 0 7, 0 8, 1 8, 1 7, 0 7 )), (( 0 5, 0 6, 1 6, 1 5, 0 5 )), (( 2 5, 2 6, 3 6, 3 5, 2 5 )))"),
+        tolerance,
         readArray(
             "MULTIPOLYGON (((0 5, 0 6, 1 6, 0 5)), ((0 8, 1 8, 1 7, 0 8)), ((1 6, 1 7, 2 7, 2 6, 1 6)), ((2 5, 2 6, 3 5, 2 5)), ((2 7, 3 8, 3 7, 2 7)))")
     );
@@ -226,12 +436,35 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testTouchingShellsInnerDynamic() {
+    List<Double> tolerances = Arrays.asList(4.0, 4.0);
+    checkResultInnerDynamic(readArray(
+            "POLYGON ((0 0, 0 5, 5 6, 10 5, 10 0, 0 0))",
+            "POLYGON ((0 10, 5 6, 10 10, 0 10))"),
+            tolerances,
+            readArray(
+                "POLYGON ((0 0, 0 5, 5 6, 10 5, 10 0, 0 0))",
+                "POLYGON ((0 10, 5 6, 10 10, 0 10))")
+    );
+  }
+
   public void testShellSimplificationAtStartingNode() {
     checkResult(readArray(
             "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
         1.5,
         readArray(
             "POLYGON ((1 7, 5 7, 5 3, 2 3, 1 7))")
+    );
+  }
+
+  public void testShellSimplificationAtStartingNodeDynamic() {
+    List<Double> tolerance = new ArrayList<Double>(1);
+    tolerance.add(1.5);
+    checkResultDynamic(readArray(
+                    "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
+            tolerance,
+            readArray(
+                    "POLYGON ((1 7, 5 7, 5 3, 2 3, 1 7))")
     );
   }
 
@@ -246,6 +479,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testSimplifyInnerAtStartingNodeDynamic() {
+    List<Double> tolerances = Arrays.asList(3.0, 2.0);
+    checkResultInnerDynamic(readArray(
+                    "POLYGON (( 0 5, 0 9, 6 9, 6 2, 1 2, 0 5 ), ( 1 5, 2 3, 5 3, 5 7, 1 7, 1 5 ))",
+                    "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
+            tolerances,
+            readArray(
+                    "POLYGON ((0 5, 0 9, 6 9, 6 2, 1 2, 0 5), (1 7, 2 3, 5 3, 5 7, 1 7))",
+                    "POLYGON ((1 7, 5 7, 5 3, 2 3, 1 7))")
+    );
+  }
+
   public void testSimplifyAllAtStartingNode() {
     checkResult(readArray(
             "POLYGON (( 0 5, 0 9, 6 9, 6 2, 1 2, 0 5 ), ( 1 5, 2 3, 5 3, 5 7, 1 7, 1 5 ))",
@@ -257,6 +502,17 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
+  public void testSimplifyAllAtStartingNodeDynamic() {
+    List<Double> tolerances = Arrays.asList(1.5, 3.0);
+    checkResultDynamic(readArray(
+                    "POLYGON (( 0 5, 0 9, 6 9, 6 2, 1 2, 0 5 ), ( 1 5, 2 3, 5 3, 5 7, 1 7, 1 5 ))",
+                    "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
+            tolerances,
+            readArray(
+                    "POLYGON ((0 9, 6 9, 6 2, 1 2, 0 9), (1 7, 2 3, 5 3, 5 7, 1 7))",
+                    "POLYGON ((1 7, 5 7, 5 3, 2 3, 1 7))")
+    );
+  }
   //---------------------------------
   
   public void testInnerSimple() {
@@ -268,7 +524,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "POLYGON ((50 50, 50 150, 100 190, 100 200, 200 200, 50 50))",
             "POLYGON ((200 200, 50 50, 100 0, 170 50, 250 100, 200 200))" )
     );
-    
+  }
+
+  public void testInnerSimpleDynamic() {
+    List<Double> tolerances = Arrays.asList(50.0, 100.0);
+    checkResultInnerDynamic(readArray(
+                    "POLYGON ((50 50, 50 150, 100 190, 100 200, 200 200, 160 150, 120 120, 90 80, 50 50))",
+                    "POLYGON ((100 0, 50 50, 90 80, 120 120, 160 150, 200 200, 250 100, 170 50, 100 0))" ),
+            tolerances,
+            readArray(
+                    "POLYGON ((50 50, 50 150, 100 190, 100 200, 200 200, 50 50))",
+                    "POLYGON ((200 200, 50 50, 100 0, 170 50, 250 100, 200 200)))")
+    );
   }
   
   //---------------------------------
@@ -283,6 +550,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "POLYGON EMPTY" )
     );
   }
+
+  public void testAllEmptyDynamic() {
+    List<Double> tolerances = Arrays.asList(1.0, 1.0);
+    checkResultDynamic(readArray(
+                    "POLYGON EMPTY",
+                    "POLYGON EMPTY" ),
+            tolerances,
+            readArray(
+                    "POLYGON EMPTY",
+                    "POLYGON EMPTY" )
+    );
+  }
   
   public void testOneEmpty() {
     checkResult(readArray(
@@ -292,6 +571,18 @@ public class CoverageSimplifierTest extends GeometryTestCase {
         readArray(
             "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
             "POLYGON EMPTY" )
+    );
+  }
+
+  public void testOneEmptyDynamic() {
+    List<Double> tolerances = Arrays.asList(1.0, 1.0);
+    checkResultDynamic(readArray(
+                    "POLYGON ((1 9, 5 9.1, 9 9, 9 1, 1 1, 1 9))",
+                    "POLYGON EMPTY" ),
+            tolerances,
+            readArray(
+                    "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))",
+                    "POLYGON EMPTY" )
     );
   }
   
@@ -305,12 +596,29 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "POLYGON EMPTY" )
     );
   }
+
+  public void testEmptyHoleDynamic() {
+    List<Double> tolerances = Arrays.asList(1.0, 1.0);
+    checkResultDynamic(readArray(
+                    "POLYGON ((1 9, 5 9.1, 9 9, 9 1, 1 1, 1 9), EMPTY)",
+                    "POLYGON EMPTY" ),
+            tolerances,
+            readArray(
+                    "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), EMPTY)",
+                    "POLYGON EMPTY" )
+    );
+  }
   
   //=================================
 
-
   private void checkNoop(Geometry[] input) {
     Geometry[] actual = CoverageSimplifier.simplify(input, 0);
+    checkEqual(input, actual);
+  }
+
+  private void checkNoopDynamic(Geometry[] input) {
+    List<Double> tolerance = Collections.nCopies(input.length, 0.0);
+    Geometry[] actual = CoverageSimplifier.simplify(input, tolerance);
     checkEqual(input, actual);
   }
   
@@ -318,9 +626,19 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     Geometry[] actual = CoverageSimplifier.simplify(input, tolerance);
     checkEqual(expected, actual);
   }
+
+  private void checkResultDynamic(Geometry[] input, List<Double> tolerances, Geometry[] expected) {
+    Geometry[] actual = CoverageSimplifier.simplify(input, tolerances);
+    checkEqual(expected, actual);
+  }
   
   private void checkResultInner(Geometry[] input, double tolerance, Geometry[] expected) {
     Geometry[] actual = CoverageSimplifier.simplifyInner(input, tolerance);
+    checkEqual(expected, actual);
+  }
+
+  private void checkResultInnerDynamic(Geometry[] input, List<Double> tolerances, Geometry[] expected) {
+    Geometry[] actual = CoverageSimplifier.simplifyInner(input, tolerances);
     checkEqual(expected, actual);
   }
 }


### PR DESCRIPTION
An enhancement has been made to the coverage simplification algorithm (simplify and simplifyInner). Currently, coverage simplification only allows one global tolerance value to be specified for the entire coverage. The proposed enhancement allows multiple tolerances to be passed in as a list, where each entry corresponds to a geometry. The geometries can thus be simplified with different tolerances while still ensuring topological correctness. At coinciding coverage edges the lowest available value is utilized.
 
This will be very useful for solving problems related to the boundary discretization of tessellated geometries.

The following figure shows an example where the boundary polygon is simplified with a tolerance of 1, and the other hole polygons with 1 and 0.5.

![coverage1](https://github.com/locationtech/jts/assets/55232428/01f816ed-6163-4cd1-8b38-db2ea6b94765)

Here is another one with tolerances of 50 and 10.

![coverage2](https://github.com/locationtech/jts/assets/55232428/32ff06a6-2caf-4f41-b9ba-7f20f5d9a255)

