### PR TITLE
Fix vertex-vertex intersection in OverlayArea

### DIFF
--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -268,17 +268,17 @@ public class OverlayArea {
      * For accuracy the full edge is used to provide the direction vector.
      */
     Coordinate intPt = li.getIntersection(0);
-    
-    boolean isAenteringB = Orientation.COUNTERCLOCKWISE == Orientation.index(a0, a1, b1);
-    
-    if ( isAenteringB ) {
+
+    if ( Orientation.CLOCKWISE == Orientation.index(a0, a1, b0) ) {
       return EdgeVector.area2Term(intPt, a0, a1, true)
         + EdgeVector.area2Term(intPt, b1, b0, false);
     }
-    else {
+    else if ( Orientation.CLOCKWISE == Orientation.index(a0, a1, b1) ) {
       return EdgeVector.area2Term(intPt, a1, a0, false)
        + EdgeVector.area2Term(intPt, b0, b1, true);
     }
+
+    return 0.0;
   }
     
   private double areaForInteriorVertices(LinearRing ring) {

--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/SimpleOverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/SimpleOverlayArea.java
@@ -116,14 +116,12 @@ public class SimpleOverlayArea {
            * Use full edge to compute direction, for accuracy.
            */
           Coordinate intPt = li.getIntersection(0);
-          
-          boolean isAenteringB = Orientation.COUNTERCLOCKWISE == Orientation.index(a0, a1, b1);
-          
-          if ( isAenteringB ) {
+
+          if ( Orientation.CLOCKWISE == Orientation.index(a0, a1, b0) ) {
             area += EdgeVector.area2Term(intPt, a0, a1, true);
             area += EdgeVector.area2Term(intPt, b1, b0, false);
           }
-          else {
+          else if ( Orientation.CLOCKWISE == Orientation.index(a0, a1, b1) ) {
             area += EdgeVector.area2Term(intPt, a1, a0, false);
             area += EdgeVector.area2Term(intPt, b0, b1, true);
           }

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/OverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/OverlayAreaTest.java
@@ -32,8 +32,7 @@ public class OverlayAreaTest extends GeometryTestCase {
         "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
   }
   
-  //TODO: fix this bug
-  public void xtestTouching() {
+  public void testTouching() {
     checkIntersectionArea(
         "POLYGON ((10 90, 50 90, 50 50, 10 50, 10 90))",
         "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/SimpleOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/SimpleOverlayAreaTest.java
@@ -32,8 +32,7 @@ public class SimpleOverlayAreaTest extends GeometryTestCase {
         "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
   }
 
-  //TODO: fix this bug
-  public void xtestTouching() {
+  public void testTouching() {
     checkIntersectionArea(
         "POLYGON ((10 90, 50 90, 50 50, 10 50, 10 90))",
         "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");


### PR DESCRIPTION
Fixes a known bug in  OverlayArea, where COLLINEAR intersections did not cancel out.