### PR TITLE
Convert LinearRing to Polygon to use with SimplePointInAreaLocator

### DIFF
--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -173,7 +173,7 @@ public class OverlayArea {
     if (area0 != 0.0) return area0;
     
     // only checking one point, so non-indexed is faster
-    SimplePointInAreaLocator locator = new SimplePointInAreaLocator(geom);
+    SimplePointInAreaLocator locator = new SimplePointInAreaLocator(geom.getFactory().createPolygon(geom));
     double area1 = areaForContainedGeom(geom0, geom.getEnvelopeInternal(), locator);
     // geom0 is either disjoint or contained - either way we are done
     return area1;

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/OverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/OverlayAreaTest.java
@@ -40,15 +40,19 @@ public class OverlayAreaTest extends GeometryTestCase {
   }
   
   public void testRectangleAContainsB() {
-    checkIntersectionArea(
-        "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))",
-        "POLYGON ((150 250, 250 250, 250 150, 150 150, 150 250))");
+    String wktA = "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))";
+    String wktB = "POLYGON ((150 250, 250 250, 250 150, 150 150, 150 250))";
+
+    checkIntersectionArea(wktA, wktB);
+    checkIntersectionArea(wktB, wktA);
   }
 
   public void testTriangleAContainsB() {
-    checkIntersectionArea(
-        "POLYGON ((60 170, 270 370, 380 60, 60 170))",
-        "POLYGON ((200 250, 245 155, 291 195, 200 250))");
+    String wktA = "POLYGON ((60 170, 270 370, 380 60, 60 170))";
+    String wktB = "POLYGON ((200 250, 245 155, 291 195, 200 250))";
+
+    checkIntersectionArea(wktA, wktB);
+    checkIntersectionArea(wktB, wktA);
   }
 
   public void testRectangleOverlap() {

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/SimpleOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/SimpleOverlayAreaTest.java
@@ -40,15 +40,19 @@ public class SimpleOverlayAreaTest extends GeometryTestCase {
   }
 
   public void testRectangleAContainsB() {
-    checkIntersectionArea(
-        "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))",
-        "POLYGON ((150 250, 250 250, 250 150, 150 150, 150 250))");
+    String wktA = "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))";
+    String wktB = "POLYGON ((150 250, 250 250, 250 150, 150 150, 150 250))";
+
+    checkIntersectionArea(wktA, wktB);
+    checkIntersectionArea(wktB, wktA);
   }
 
   public void testTriangleAContainsB() {
-    checkIntersectionArea(
-        "POLYGON ((60 170, 270 370, 380 60, 60 170))",
-        "POLYGON ((200 250, 245 155, 291 195, 200 250))");
+    String wktA = "POLYGON ((60 170, 270 370, 380 60, 60 170))";
+    String wktB = "POLYGON ((200 250, 245 155, 291 195, 200 250))";
+
+    checkIntersectionArea(wktA, wktB);
+    checkIntersectionArea(wktB, wktA);
   }
 
   public void testRectangleOverlap() {


### PR DESCRIPTION
Improved test coverage for `OverlayArea` and `SimpleOverlayArea` - it revealed a bug in `OverlayArea`, where `LinearRing` was checked for point containment, but it does not include its interior