### PR TITLE
Fix vertex intersection in `OverlayArea`

### DIFF
--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/IntersectionVisitor.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/IntersectionVisitor.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2022 Martin Davis, and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.operation.overlayarea;
+
+import org.locationtech.jts.algorithm.Angle;
+import org.locationtech.jts.algorithm.LineIntersector;
+import org.locationtech.jts.algorithm.Orientation;
+import org.locationtech.jts.algorithm.RobustLineIntersector;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.noding.SegmentIntersector;
+import org.locationtech.jts.noding.SegmentString;
+
+/**
+ * Computes the partial overlay area of two polygons by summing the contributions of
+ * the edge vectors created by the intersections between the edges of the two polygons.
+ */
+class IntersectionVisitor implements SegmentIntersector {
+
+    private static final LineIntersector li = new RobustLineIntersector();
+
+    private double area = 0.0;
+
+    double getArea() {
+        return area;
+    }
+
+    @Override
+    public void processIntersections(SegmentString a, int aIndex, SegmentString b, int bIndex) {
+        boolean isCCWA = (boolean) a.getData();
+        boolean isCCWB = (boolean) b.getData();
+
+        Coordinate a0 = a.getCoordinate(aIndex);
+        Coordinate a1 = a.getCoordinate(aIndex + 1);
+        Coordinate b0 = b.getCoordinate(bIndex);
+        Coordinate b1 = b.getCoordinate(bIndex + 1);
+
+        if (isCCWA) {
+            Coordinate tmp = a0;
+            a0 = a1;
+            a1 = tmp;
+        }
+        if (isCCWB) {
+            Coordinate tmp = b0;
+            b0 = b1;
+            b1 = tmp;
+        }
+
+        li.computeIntersection(a0, a1, b0, b1);
+        if (!li.hasIntersection()) return;
+
+        if (li.isProper() || li.isInteriorIntersection()) {
+            // Edge-edge intersection OR vertex-edge intersection
+
+            /**
+             * An intersection creates two edge vectors which contribute to the area.
+             *
+             * With both rings oriented CW (effectively)
+             * There are two situations for segment intersection:
+             *
+             * 1) A entering B, B exiting A => rays are IP->A1:R, IP->B0:L
+             * 2) A exiting B, B entering A => rays are IP->A0:L, IP->B1:R
+             * (where IP is the intersection point,
+             * and  :L/R indicates result polygon interior is to the Left or Right).
+             *
+             * For accuracy the full edge is used to provide the direction vector.
+             */
+
+            Coordinate intPt = li.getIntersection(0);
+
+            if (Orientation.CLOCKWISE == Orientation.index(a0, a1, b0)) {
+                if (intPt.equals2D(a1)) {
+                    // Intersection at vertex and A0 -> A1 is outside the intersection area.
+                    // Area will be computed by the segment A1 -> A2
+                    return;
+                }
+                area += EdgeVector.area2Term(intPt, a0, a1, true);
+                area += EdgeVector.area2Term(intPt, b1, b0, false);
+            } else if (Orientation.CLOCKWISE == Orientation.index(a0, a1, b1)) {
+                if (intPt.equals2D(a0)) {
+                    // Intersection at vertex and A0 -> A1 is outside the intersection area.
+                    // Area will be computed by the segment A(-1) -> A0
+                    return;
+                }
+                area += EdgeVector.area2Term(intPt, a1, a0, false);
+                area += EdgeVector.area2Term(intPt, b0, b1, true);
+            }
+
+        } else {
+            // vertex-vertex intersection
+            // This intersection is visited 4 times - include only once
+            if (!a1.equals2D(b1)) {
+                return;
+            }
+
+            // If A0->A1 is collinear with B0->B1, then the intersection point from LineIntersector might not be equal to A1 and B1
+            Coordinate intPt = a1;
+
+            Coordinate a2 = a.nextInRing(aIndex + 1);
+            Coordinate b2 = b.nextInRing(bIndex + 1);
+            if (isCCWA) {
+                a2 = a.prevInRing(aIndex);
+            }
+            if (isCCWB) {
+                b2 = b.prevInRing(bIndex);
+            }
+
+            double aAngle = Angle.interiorAngle(a0, intPt, a2);
+            double bAngle = Angle.interiorAngle(b0, intPt, b2);
+
+            // The LTE ja LT are chosen such that when A0->A1 is collinear with B0->B1,
+            // or when A1->A2 is collinear with B1->B2, then A is chosen.
+            // This avoids double counting in the case of collinear segments.
+            if (Angle.interiorAngle(a0, intPt, b2) <= bAngle) {
+                area += EdgeVector.area2Term(intPt, a1, a0, false);
+            }
+            if (Angle.interiorAngle(b0, intPt, a2) <= bAngle) {
+                area += EdgeVector.area2Term(intPt, a1, a2, true);
+            }
+            if (Angle.interiorAngle(b0, intPt, a2) < aAngle) {
+                area += EdgeVector.area2Term(intPt, b1, b0, false);
+            }
+            if (Angle.interiorAngle(a0, intPt, b2) < aAngle) {
+                area += EdgeVector.area2Term(intPt, b1, b2, true);
+            }
+        }
+    }
+
+    @Override
+    public boolean isDone() {
+        // Process all intersections
+        return false;
+    }
+}

--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -275,11 +275,14 @@ public class OverlayArea {
         }
 
       } else {
-        // vertex-vertex intersection
+        // vertex-vertex inteqrsection
         // This intersection is visited 4 times - include only once
-        if (!intPt.equals2D(a1) || !intPt.equals2D(b1)) {
+        if (!a1.equals2D(b1)) {
           return;
         }
+
+        // If A0->A1 is collinear with B0->B1, then the intersection point might not be equal to A1 and B1
+        intPt = a1;
 
         Coordinate a2 = a.nextInRing(aIndex + 1);
         Coordinate b2 = b.nextInRing(bIndex + 1);

--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -275,7 +275,7 @@ public class OverlayArea {
         }
 
       } else {
-        // vertex-vertex inteqrsection
+        // vertex-vertex intersection
         // This intersection is visited 4 times - include only once
         if (!a1.equals2D(b1)) {
           return;
@@ -296,8 +296,8 @@ public class OverlayArea {
         double aAngle = Angle.interiorAngle(a0, intPt, a2);
         double bAngle = Angle.interiorAngle(b0, intPt, b2);
 
-        // The LTE ja LT are chosen such that when A0->A1 is collinear with B0->B1, then A is chosen
-        // and when A1->A2 is collinear with B1->B2, then A is chosen.
+        // The LTE ja LT are chosen such that when A0->A1 is collinear with B0->B1,
+        // or when A1->A2 is collinear with B1->B2, then A is chosen.
         // This avoids double counting in the case of collinear segments.
         if (Angle.interiorAngle(a0, intPt, b2) <= bAngle) {
           area += EdgeVector.area2Term(intPt, a1, a0, false);

--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -320,22 +320,22 @@ public class OverlayArea {
         or when A1->A2 is collinear with B1->B2, then only the segment from polygon A
         is chosen to avoid double counting.
          */
-        double aaAngle = Angle.interiorAngle(a0, intPt, a2);
-        double bbAngle = Angle.interiorAngle(b0, intPt, b2);
+        double angleA0A2 = Angle.interiorAngle(a0, intPt, a2);
+        double angleB0B2 = Angle.interiorAngle(b0, intPt, b2);
 
-        double abAngle = Angle.interiorAngle(a0, intPt, b2);
-        double baAngle = Angle.interiorAngle(b0, intPt, a2);
+        double angleA0B2 = Angle.interiorAngle(a0, intPt, b2);
+        double angleB0A2 = Angle.interiorAngle(b0, intPt, a2);
 
-        if (abAngle <= bbAngle) {
+        if (angleA0B2 <= angleB0B2) {
           area += EdgeVector.area2Term(intPt, a1, a0, false);
         }
-        if (baAngle <= bbAngle) {
+        if (angleB0A2 <= angleB0B2) {
           area += EdgeVector.area2Term(intPt, a1, a2, true);
         }
-        if (baAngle < aaAngle) {
+        if (angleB0A2 < angleA0A2) {
           area += EdgeVector.area2Term(intPt, b1, b0, false);
         }
-        if (abAngle < aaAngle) {
+        if (angleA0B2 < angleA0A2) {
           area += EdgeVector.area2Term(intPt, b1, b2, true);
         }
       }

--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -291,9 +291,14 @@ public class OverlayArea {
           return;
         }
 
-        // If A0->A1 is collinear with B0->B1, then the intersection point might not be equal to A1 and B1
+        // If A0->A1 is collinear with B0->B1,
+        // then the intersection point from LineIntersector might not be equal to A1 and B1
         intPt = a1;
 
+        /* Get the next vertices in the CW direction.
+        Now we have four segments: A0->A1, A1->A2, B0->B1, B1->B2
+        and the intersection point is A1 == B1.
+         */
         Coordinate a2 = a.nextInRing(aIndex + 1);
         Coordinate b2 = b.nextInRing(bIndex + 1);
         if (isCCWA) {
@@ -303,12 +308,21 @@ public class OverlayArea {
           b2 = b.prevInRing(bIndex);
         }
 
+        /* The angles A0->A1->A2 and B0->B1->B2 determine
+         the maximum intersection area interior angle.
+         Edges from the other polygon that lie within this angle
+         are on the boundary of the intersection area.
+
+         Depending on the relative orientation of the polygons,
+         we could pick 0, 2 or 4 segments to contribute to the area.
+
+        The LTE ja LT are chosen such that when A0->A1 is collinear with B0->B1,
+        or when A1->A2 is collinear with B1->B2, then only the segment from polygon A
+        is chosen to avoid double counting.
+         */
         double aAngle = Angle.interiorAngle(a0, intPt, a2);
         double bAngle = Angle.interiorAngle(b0, intPt, b2);
 
-        // The LTE ja LT are chosen such that when A0->A1 is collinear with B0->B1,
-        // or when A1->A2 is collinear with B1->B2, then A is chosen.
-        // This avoids double counting in the case of collinear segments.
         if (Angle.interiorAngle(a0, intPt, b2) <= bAngle) {
           area += EdgeVector.area2Term(intPt, a1, a0, false);
         }

--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -267,9 +267,19 @@ public class OverlayArea {
          */
 
         if (Orientation.CLOCKWISE == Orientation.index(a0, a1, b0)) {
+          if (intPt.equals2D(a1)) {
+            // Intersection at vertex and A0 -> A1 is outside the intersection area.
+            // Area will be computed by the segment A1 -> A2
+            return;
+          }
           area += EdgeVector.area2Term(intPt, a0, a1, true);
           area += EdgeVector.area2Term(intPt, b1, b0, false);
         } else if (Orientation.CLOCKWISE == Orientation.index(a0, a1, b1)) {
+          if (intPt.equals2D(a0)) {
+            // Intersection at vertex and A0 -> A1 is outside the intersection area.
+            // Area will be computed by the segment A(-1) -> A0
+            return;
+          }
           area += EdgeVector.area2Term(intPt, a1, a0, false);
           area += EdgeVector.area2Term(intPt, b0, b1, true);
         }

--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -320,19 +320,22 @@ public class OverlayArea {
         or when A1->A2 is collinear with B1->B2, then only the segment from polygon A
         is chosen to avoid double counting.
          */
-        double aAngle = Angle.interiorAngle(a0, intPt, a2);
-        double bAngle = Angle.interiorAngle(b0, intPt, b2);
+        double aaAngle = Angle.interiorAngle(a0, intPt, a2);
+        double bbAngle = Angle.interiorAngle(b0, intPt, b2);
 
-        if (Angle.interiorAngle(a0, intPt, b2) <= bAngle) {
+        double abAngle = Angle.interiorAngle(a0, intPt, b2);
+        double baAngle = Angle.interiorAngle(b0, intPt, a2);
+
+        if (abAngle <= bbAngle) {
           area += EdgeVector.area2Term(intPt, a1, a0, false);
         }
-        if (Angle.interiorAngle(b0, intPt, a2) <= bAngle) {
+        if (baAngle <= bbAngle) {
           area += EdgeVector.area2Term(intPt, a1, a2, true);
         }
-        if (Angle.interiorAngle(b0, intPt, a2) < aAngle) {
+        if (baAngle < aaAngle) {
           area += EdgeVector.area2Term(intPt, b1, b0, false);
         }
-        if (Angle.interiorAngle(a0, intPt, b2) < aAngle) {
+        if (abAngle < aaAngle) {
           area += EdgeVector.area2Term(intPt, b1, b2, true);
         }
       }

--- a/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
+++ b/modules/lab/src/main/java/org/locationtech/jts/operation/overlayarea/OverlayArea.java
@@ -23,11 +23,9 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.GeometryFilter;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Location;
-import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.index.kdtree.KdNode;
 import org.locationtech.jts.index.kdtree.KdTree;
@@ -179,7 +177,7 @@ public class OverlayArea {
     if (area0 != 0.0) return area0;
     
     // only checking one point, so non-indexed is faster
-    SimplePointInAreaLocator locator = new SimplePointInAreaLocator(geom);
+    SimplePointInAreaLocator locator = new SimplePointInAreaLocator(geom.getFactory().createPolygon(geom));
     double area1 = areaForContainedGeom(geom0, geom.getEnvelopeInternal(), locator);
     // geom0 is either disjoint or contained - either way we are done
     return area1;

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
@@ -80,6 +80,24 @@ public abstract class BaseOverlayAreaTest extends GeometryTestCase {
             "POLYGON ((30 20, 40 50, 60 20, 30 20))");
   }
 
+  public void testVertexIntersectionContained2() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 10, 40 50, 90 10, 10 10))",
+            "POLYGON ((30 10, 40 50, 60 10, 30 10))");
+  }
+
+  public void testVertexIntersectionContained3() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 10, 40 50, 90 10, 10 10))",
+            "POLYGON ((10 10, 40 50, 60 20, 10 10))");
+  }
+
+  public void testVertexIntersectionContained4() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 10, 10 50, 50 50, 50 10, 10 10))",
+            "POLYGON ((10 10, 30 30, 50 10, 10 10))");
+  }
+
   public void testVertexIntersectionOverlapping() {
     checkIntersectionAreaSymmetric(
             "POLYGON ((10 10, 40 50, 90 10, 10 10))",
@@ -102,12 +120,12 @@ public abstract class BaseOverlayAreaTest extends GeometryTestCase {
     Geometry a = read(wktA);
     Geometry b = read(wktB);
     
-    double ovIntArea = computeOverlayArea(a, b);
-    
     double intAreaFull = a.intersection(b).getArea();
     
-    //System.out.printf("OverlayArea: %f   Full overlay: %f\n", ovIntArea, intAreaFull);
-    assertEquals(intAreaFull, ovIntArea, 0.0001);
+    assertEquals(intAreaFull, computeOverlayArea(a, b), 0.0001);
+    assertEquals(intAreaFull, computeOverlayArea(a.reverse(), b), 0.0001);
+    assertEquals(intAreaFull, computeOverlayArea(a, b.reverse()), 0.0001);
+    assertEquals(intAreaFull, computeOverlayArea(a.reverse(), b.reverse()), 0.0001);
   }
 
   protected final void checkIntersectionAreaSymmetric(String wktA, String wktB) {

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
@@ -128,6 +128,20 @@ public abstract class BaseOverlayAreaTest extends GeometryTestCase {
             "POLYGON ((40 10, 20 30, 40 50, 50 30, 40 10))");
   }
 
+  public void testCollinearOverlappingEdgesPartial() {
+    checkIntersectionAreaSymmetric(
+        "POLYGON ((10 30, 30 30, 30 10, 10 10, 10 30))",
+        "POLYGON ((20 30, 40 30, 40 10, 20 10, 20 30))"
+    );
+  }
+
+  public void testCollinearOverlappingEdgesFull() {
+    checkIntersectionAreaSymmetric(
+        "POLYGON ((10 30, 50 30, 50 10, 10 10, 10 30))",
+        "POLYGON ((20 30, 40 30, 40 10, 20 10, 20 30))"
+    );
+  }
+
   protected final void checkIntersectionArea(String wktA, String wktB) {
     Geometry a = read(wktA);
     Geometry b = read(wktB);

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
@@ -38,6 +38,12 @@ public abstract class BaseOverlayAreaTest extends GeometryTestCase {
         "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
   }
 
+  public void testTouchingNonPerpendicular() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 90, 49 90, 50 50, 10 53, 10 90))",
+            "POLYGON ((90 10, 47 10, 50 50, 90 54, 90 10))");
+  }
+
   public void testRectangleAContainsB() {
     checkIntersectionAreaSymmetric(
         "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))",
@@ -66,6 +72,30 @@ public abstract class BaseOverlayAreaTest extends GeometryTestCase {
     checkIntersectionAreaSymmetric(
         "POLYGON ((100 300, 305 299, 150 200, 300 150, 150 100, 300 50, 100 50, 100 300))",
         "POLYGON ((400 350, 150 250, 350 200, 200 150, 350 100, 180 50, 400 50, 400 350))");
+  }
+
+  public void testVertexIntersectionContained() {
+    checkIntersectionAreaSymmetric(
+        "POLYGON ((10 10, 40 50, 90 10, 10 10))",
+            "POLYGON ((30 20, 40 50, 60 20, 30 20))");
+  }
+
+  public void testVertexIntersectionOverlapping() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 10, 40 50, 90 10, 10 10))",
+            "POLYGON ((30 -20, 40 50, 60 -20, 30 -20))");
+  }
+
+  public void testVertexIntersectionOverlapping2() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 10, 40 50, 90 10, 10 10))",
+            "POLYGON ((30 20, 40 50, 90 20, 30 20))");
+  }
+
+  public void testVertexIntersectionTwoAreas() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 10, 30 50, 60 10, 10 10))",
+            "POLYGON ((20 60, 40 60, 40 20, 30 50, 20 20, 20 60))");
   }
 
   protected final void checkIntersectionArea(String wktA, String wktB) {

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
@@ -116,6 +116,18 @@ public abstract class BaseOverlayAreaTest extends GeometryTestCase {
             "POLYGON ((20 60, 40 60, 40 20, 30 50, 20 20, 20 60))");
   }
 
+  public void testVertexIntersectionOnEdge() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 10, 10 40, 40 40, 40 10, 10 10))",
+            "POLYGON ((20 30, 20 40, 70 50, 20 30))");
+  }
+
+  public void testVertexIntersectionOnEdge2() {
+    checkIntersectionAreaSymmetric(
+            "POLYGON ((10 30, 10 60, 40 60, 40 30, 10 30))",
+            "POLYGON ((40 10, 20 30, 40 50, 50 30, 40 10))");
+  }
+
   protected final void checkIntersectionArea(String wktA, String wktB) {
     Geometry a = read(wktA);
     Geometry b = read(wktB);

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
@@ -27,48 +27,48 @@ public abstract class BaseOverlayAreaTest extends GeometryTestCase {
   }
 
   public void testDisjoint() {
-    checkIntersectionArea(
+    checkIntersectionAreaSymmetric(
         "POLYGON ((10 90, 40 90, 40 60, 10 60, 10 90))",
         "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
   }
 
   public void testTouching() {
-    checkIntersectionArea(
+    checkIntersectionAreaSymmetric(
         "POLYGON ((10 90, 50 90, 50 50, 10 50, 10 90))",
         "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
   }
 
   public void testRectangleAContainsB() {
-    checkIntersectionArea(
+    checkIntersectionAreaSymmetric(
         "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))",
         "POLYGON ((150 250, 250 250, 250 150, 150 150, 150 250))");
   }
 
   public void testTriangleAContainsB() {
-    checkIntersectionArea(
+    checkIntersectionAreaSymmetric(
         "POLYGON ((60 170, 270 370, 380 60, 60 170))",
         "POLYGON ((200 250, 245 155, 291 195, 200 250))");
   }
 
   public void testRectangleOverlap() {
-    checkIntersectionArea(
+    checkIntersectionAreaSymmetric(
         "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
         "POLYGON ((250 250, 250 150, 150 150, 150 250, 250 250))");
   }
 
   public void testRectangleTriangleOverlap() {
-    checkIntersectionArea(
+    checkIntersectionAreaSymmetric(
         "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
         "POLYGON ((300 200, 150 150, 300 100, 300 200))");
   }
 
   public void testSawOverlap() {
-    checkIntersectionArea(
+    checkIntersectionAreaSymmetric(
         "POLYGON ((100 300, 305 299, 150 200, 300 150, 150 100, 300 50, 100 50, 100 300))",
         "POLYGON ((400 350, 150 250, 350 200, 200 150, 350 100, 180 50, 400 50, 400 350))");
   }
 
-  protected void checkIntersectionArea(String wktA, String wktB) {
+  protected final void checkIntersectionArea(String wktA, String wktB) {
     Geometry a = read(wktA);
     Geometry b = read(wktB);
     
@@ -78,6 +78,11 @@ public abstract class BaseOverlayAreaTest extends GeometryTestCase {
     
     //System.out.printf("OverlayArea: %f   Full overlay: %f\n", ovIntArea, intAreaFull);
     assertEquals(intAreaFull, ovIntArea, 0.0001);
+  }
+
+  protected final void checkIntersectionAreaSymmetric(String wktA, String wktB) {
+    checkIntersectionArea(wktA, wktB);
+    checkIntersectionArea(wktB, wktA);
   }
 
   abstract protected double computeOverlayArea(Geometry a, Geometry b);

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/BaseOverlayAreaTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022 Martin Davis
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.operation.overlayarea;
+
+import org.locationtech.jts.geom.Geometry;
+import test.jts.GeometryTestCase;
+
+/**
+ * Base class for testing overlay area algorithms
+ * by comparing them to the standard overlay intersection area.
+ * This is a parameterized test class.
+ * Subclasses provide the overlay area algorithm to test.
+ */
+public abstract class BaseOverlayAreaTest extends GeometryTestCase {
+
+  public BaseOverlayAreaTest(String name) {
+    super(name);
+  }
+
+  public void testDisjoint() {
+    checkIntersectionArea(
+        "POLYGON ((10 90, 40 90, 40 60, 10 60, 10 90))",
+        "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
+  }
+
+  public void testTouching() {
+    checkIntersectionArea(
+        "POLYGON ((10 90, 50 90, 50 50, 10 50, 10 90))",
+        "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
+  }
+
+  public void testRectangleAContainsB() {
+    checkIntersectionArea(
+        "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))",
+        "POLYGON ((150 250, 250 250, 250 150, 150 150, 150 250))");
+  }
+
+  public void testTriangleAContainsB() {
+    checkIntersectionArea(
+        "POLYGON ((60 170, 270 370, 380 60, 60 170))",
+        "POLYGON ((200 250, 245 155, 291 195, 200 250))");
+  }
+
+  public void testRectangleOverlap() {
+    checkIntersectionArea(
+        "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
+        "POLYGON ((250 250, 250 150, 150 150, 150 250, 250 250))");
+  }
+
+  public void testRectangleTriangleOverlap() {
+    checkIntersectionArea(
+        "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
+        "POLYGON ((300 200, 150 150, 300 100, 300 200))");
+  }
+
+  public void testSawOverlap() {
+    checkIntersectionArea(
+        "POLYGON ((100 300, 305 299, 150 200, 300 150, 150 100, 300 50, 100 50, 100 300))",
+        "POLYGON ((400 350, 150 250, 350 200, 200 150, 350 100, 180 50, 400 50, 400 350))");
+  }
+
+  protected void checkIntersectionArea(String wktA, String wktB) {
+    Geometry a = read(wktA);
+    Geometry b = read(wktB);
+    
+    double ovIntArea = computeOverlayArea(a, b);
+    
+    double intAreaFull = a.intersection(b).getArea();
+    
+    //System.out.printf("OverlayArea: %f   Full overlay: %f\n", ovIntArea, intAreaFull);
+    assertEquals(intAreaFull, ovIntArea, 0.0001);
+  }
+
+  abstract protected double computeOverlayArea(Geometry a, Geometry b);
+}

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/OverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/OverlayAreaTest.java
@@ -14,9 +14,10 @@ package org.locationtech.jts.operation.overlayarea;
 import org.locationtech.jts.geom.Geometry;
 
 import junit.textui.TestRunner;
+import org.locationtech.jts.geom.Polygon;
 import test.jts.GeometryTestCase;
 
-public class OverlayAreaTest extends GeometryTestCase {
+public class OverlayAreaTest extends BaseOverlayAreaTest {
 
   public static void main(String args[]) {
     TestRunner.run(OverlayAreaTest.class);
@@ -24,49 +25,6 @@ public class OverlayAreaTest extends GeometryTestCase {
   
   public OverlayAreaTest(String name) {
     super(name);
-  }
-
-  public void testDisjoint() {
-    checkIntersectionArea(
-        "POLYGON ((10 90, 40 90, 40 60, 10 60, 10 90))",
-        "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
-  }
-  
-  //TODO: fix this bug
-  public void xtestTouching() {
-    checkIntersectionArea(
-        "POLYGON ((10 90, 50 90, 50 50, 10 50, 10 90))",
-        "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
-  }
-  
-  public void testRectangleAContainsB() {
-    checkIntersectionArea(
-        "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))",
-        "POLYGON ((150 250, 250 250, 250 150, 150 150, 150 250))");
-  }
-
-  public void testTriangleAContainsB() {
-    checkIntersectionArea(
-        "POLYGON ((60 170, 270 370, 380 60, 60 170))",
-        "POLYGON ((200 250, 245 155, 291 195, 200 250))");
-  }
-
-  public void testRectangleOverlap() {
-    checkIntersectionArea(
-        "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
-        "POLYGON ((250 250, 250 150, 150 150, 150 250, 250 250))");
-  }
-
-  public void testRectangleTriangleOverlap() {
-    checkIntersectionArea(
-        "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
-        "POLYGON ((300 200, 150 150, 300 100, 300 200))");
-  }
-
-  public void testSawOverlap() {
-    checkIntersectionArea(
-        "POLYGON ((100 300, 305 299, 150 200, 300 150, 150 100, 300 50, 100 50, 100 300))",
-        "POLYGON ((400 350, 150 250, 350 200, 200 150, 350 100, 180 50, 400 50, 400 350))");
   }
 
   public void testAOverlapBWithHole() {
@@ -87,16 +45,8 @@ public class OverlayAreaTest extends GeometryTestCase {
         "MULTIPOLYGON (((55 266, 150 150, 170 290, 55 266)), ((100 0, 70 130, 260 160, 291 45, 100 0), (150 40, 125 98, 220 110, 150 40)))");
   }
 
-  private void checkIntersectionArea(String wktA, String wktB) {
-    Geometry a = read(wktA);
-    Geometry b = read(wktB);
-    
-    OverlayArea ova = new OverlayArea(a);
-    double ovIntArea = ova.intersectionArea(b);
-    
-    double intAreaFull = a.intersection(b).getArea();
-    
-    //System.out.printf("OverlayArea: %f   Full overlay: %f\n", ovIntArea, intAreaFull);
-    assertEquals(intAreaFull, ovIntArea, 0.0001);
+  @Override
+  protected double computeOverlayArea(Geometry a, Geometry b) {
+    return new OverlayArea(a).intersectionArea(b);
   }
 }

--- a/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/SimpleOverlayAreaTest.java
+++ b/modules/lab/src/test/java/org/locationtech/jts/operation/overlayarea/SimpleOverlayAreaTest.java
@@ -11,12 +11,11 @@
  */
 package org.locationtech.jts.operation.overlayarea;
 
+import junit.textui.TestRunner;
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
 
-import junit.textui.TestRunner;
-import test.jts.GeometryTestCase;
-
-public class SimpleOverlayAreaTest extends GeometryTestCase {
+public class SimpleOverlayAreaTest extends BaseOverlayAreaTest {
 
   public static void main(String args[]) {
     TestRunner.run(SimpleOverlayAreaTest.class);
@@ -26,58 +25,8 @@ public class SimpleOverlayAreaTest extends GeometryTestCase {
     super(name);
   }
 
-  public void testDisjoint() {
-    checkIntersectionArea(
-        "POLYGON ((10 90, 40 90, 40 60, 10 60, 10 90))",
-        "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
-  }
-
-  //TODO: fix this bug
-  public void xtestTouching() {
-    checkIntersectionArea(
-        "POLYGON ((10 90, 50 90, 50 50, 10 50, 10 90))",
-        "POLYGON ((90 10, 50 10, 50 50, 90 50, 90 10))");
-  }
-
-  public void testRectangleAContainsB() {
-    checkIntersectionArea(
-        "POLYGON ((100 300, 300 300, 300 100, 100 100, 100 300))",
-        "POLYGON ((150 250, 250 250, 250 150, 150 150, 150 250))");
-  }
-
-  public void testTriangleAContainsB() {
-    checkIntersectionArea(
-        "POLYGON ((60 170, 270 370, 380 60, 60 170))",
-        "POLYGON ((200 250, 245 155, 291 195, 200 250))");
-  }
-
-  public void testRectangleOverlap() {
-    checkIntersectionArea(
-        "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
-        "POLYGON ((250 250, 250 150, 150 150, 150 250, 250 250))");
-  }
-
-  public void testRectangleTriangleOverlap() {
-    checkIntersectionArea(
-        "POLYGON ((100 200, 200 200, 200 100, 100 100, 100 200))",
-        "POLYGON ((300 200, 150 150, 300 100, 300 200))");
-  }
-
-  public void testSawOverlap() {
-    checkIntersectionArea(
-        "POLYGON ((100 300, 305 299, 150 200, 300 150, 150 100, 300 50, 100 50, 100 300))",
-        "POLYGON ((400 350, 150 250, 350 200, 200 150, 350 100, 180 50, 400 50, 400 350))");
-  }
-
-  private void checkIntersectionArea(String wktA, String wktB) {
-    Polygon a = (Polygon) read(wktA);
-    Polygon b = (Polygon) read(wktB);
-    
-    double ovIntArea = SimpleOverlayArea.intersectionArea(a, b);
-    
-    double intAreaFull = a.intersection(b).getArea();
-    
-    //System.out.printf("OverlayArea: %f   Full overlay: %f\n", ovIntArea, intAreaFull);
-    assertEquals(intAreaFull, ovIntArea, 0.0001);
+  @Override
+  protected double computeOverlayArea(Geometry a, Geometry b) {
+    return SimpleOverlayArea.intersectionArea((Polygon) a, (Polygon) b);
   }
 }


### PR DESCRIPTION
Second try at fixing `OverlayArea`.
It seems to me, that vertex-vertex intersection could not be done, when only looking at pairs of edges. Instead all four have to be looked at together.  

For this I replaced `STRtree` with `SegmentSetMutualIntersector`, because it has access to previous and next segments on both lines.

Added several new test cases and moved common ones into a shared base for simple and regular overlay area tests.

Covers #1040 and #1042