### PR TITLE
Add RelateNG envelope interaction/covers optimizations

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/SelectionFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/SelectionFunctions.java
@@ -70,6 +70,15 @@ public class SelectionFunctions
     });
   }
   
+  public static Geometry touches(Geometry a, final Geometry mask)
+  {
+    return select(a, new GeometryPredicate() {
+      public boolean isTrue(Geometry g) {
+        return mask.touches(g);
+      }
+    });
+  }
+  
   public static Geometry disjoint(Geometry a, Geometry mask)
   {
     List selected = new ArrayList();
@@ -81,6 +90,16 @@ public class SelectionFunctions
     }
     return a.getFactory().buildGeometry(selected);
   }
+  
+  public static Geometry relatePattern(Geometry a, final Geometry mask, String pattern)
+  {
+    return select(a, new GeometryPredicate() {
+      public boolean isTrue(Geometry g) {
+        return mask.relate(g, pattern);
+      }
+    });
+  }
+  
   public static Geometry valid(Geometry a)
   {
     List selected = new ArrayList();

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/SelectionNGFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/SelectionNGFunctions.java
@@ -73,6 +73,28 @@ public class SelectionNGFunctions
     });
   }
   
+  public static Geometry touches(Geometry a, final Geometry mask)
+  {
+    return SelectionFunctions.select(a, new GeometryPredicate() {
+      public boolean isTrue(Geometry g) {
+        return RelateNG.relate(mask, g, RelatePredicate.touches());
+      }
+    });
+  }
+  
+  public static Geometry touchesPrep(Geometry a, final Geometry mask)
+  {
+    RelateNG relateNG = RelateNG.prepare(mask);
+    Envelope maskEnv = mask.getEnvelopeInternal();
+    return SelectionFunctions.select(a, new GeometryPredicate() {
+      public boolean isTrue(Geometry g) {
+        if (maskEnv.disjoint(g.getEnvelopeInternal()))
+          return false;
+        return relateNG.evaluate(g, RelatePredicate.touches());
+      }
+    });
+  }
+  
   public static Geometry adjacent(Geometry a, final Geometry mask)
   {
     return SelectionFunctions.select(a, new GeometryPredicate() {
@@ -91,6 +113,26 @@ public class SelectionNGFunctions
       }
     });
   }
+  
+  public static Geometry relatePattern(Geometry a, final Geometry mask, String pattern)
+  {
+    return SelectionFunctions.select(a, new GeometryPredicate() {
+      public boolean isTrue(Geometry g) {
+        return RelateNG.relate(mask, g, RelatePredicate.matches(pattern));
+      }
+    });
+  }
+  
+  public static Geometry relatePatternPrep(Geometry a, final Geometry mask, String pattern)
+  {
+    RelateNG relateNG = RelateNG.prepare(mask);
+    return SelectionFunctions.select(a, new GeometryPredicate() {
+      public boolean isTrue(Geometry g) {
+        return relateNG.evaluate(g, RelatePredicate.matches(pattern));
+      }
+    });
+  }
+  
 }
   
 

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/SelectionNGFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/SelectionNGFunctions.java
@@ -12,6 +12,7 @@
 
 package org.locationtech.jtstest.function;
 
+import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.operation.relateng.IntersectionMatrixPattern;
 import org.locationtech.jts.operation.relateng.RelateNG;
@@ -31,9 +32,12 @@ public class SelectionNGFunctions
   public static Geometry intersectsPrep(Geometry a, final Geometry mask)
   {
     RelateNG relateNG = RelateNG.prepare(mask);
+    Envelope maskEnv = mask.getEnvelopeInternal();
     return SelectionFunctions.select(a, new GeometryPredicate() {
       public boolean isTrue(Geometry g) {
-        return relateNG.evaluate(g, RelatePredicate.intersects());
+        if (maskEnv.disjoint(g.getEnvelopeInternal()))
+          return false;
+       return relateNG.evaluate(g, RelatePredicate.intersects());
       }
     });
   }
@@ -59,8 +63,11 @@ public class SelectionNGFunctions
   public static Geometry coversPrep(Geometry a, final Geometry mask)
   {
     RelateNG relateNG = RelateNG.prepare(mask);
+    Envelope maskEnv = mask.getEnvelopeInternal();
     return SelectionFunctions.select(a, new GeometryPredicate() {
       public boolean isTrue(Geometry g) {
+        if (maskEnv.disjoint(g.getEnvelopeInternal()))
+          return false;
         return relateNG.evaluate(g, RelatePredicate.covers());
       }
     });

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/IMPatternMatcher.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/IMPatternMatcher.java
@@ -53,6 +53,11 @@ class IMPatternMatcher extends IMPredicate
     setValueIf(false, requiresInteraction && isDisjoint);
   }
 
+  @Override
+  public boolean requireInteraction() {
+    return requiresInteraction(patternMatrix);
+  }
+  
   private static boolean requiresInteraction(IntersectionMatrix im) {
     boolean requiresInteraction = 
         requiresInteraction(im.get(Location.INTERIOR, Location.INTERIOR))

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/IMPatternMatcher.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/IMPatternMatcher.java
@@ -48,26 +48,26 @@ class IMPatternMatcher extends IMPredicate
   public void init(Envelope envA, Envelope envB) {
     super.init(dimA, dimB);
     //-- if pattern specifies any non-E/non-E interaction, envelopes must not be disjoint
-    boolean requiresInteraction = requiresInteraction(patternMatrix);
+    boolean requiresInteraction = requireInteraction(patternMatrix);
     boolean isDisjoint = envA.disjoint(envB);
     setValueIf(false, requiresInteraction && isDisjoint);
   }
 
   @Override
   public boolean requireInteraction() {
-    return requiresInteraction(patternMatrix);
+    return requireInteraction(patternMatrix);
   }
   
-  private static boolean requiresInteraction(IntersectionMatrix im) {
+  private static boolean requireInteraction(IntersectionMatrix im) {
     boolean requiresInteraction = 
-        requiresInteraction(im.get(Location.INTERIOR, Location.INTERIOR))
-        || requiresInteraction(im.get(Location.INTERIOR, Location.BOUNDARY))
-        || requiresInteraction(im.get(Location.BOUNDARY, Location.INTERIOR))
-        || requiresInteraction(im.get(Location.BOUNDARY, Location.BOUNDARY));
+        isInteraction(im.get(Location.INTERIOR, Location.INTERIOR))
+        || isInteraction(im.get(Location.INTERIOR, Location.BOUNDARY))
+        || isInteraction(im.get(Location.BOUNDARY, Location.INTERIOR))
+        || isInteraction(im.get(Location.BOUNDARY, Location.BOUNDARY));
     return requiresInteraction;
   }
   
-  private static boolean requiresInteraction(int imDim) {
+  private static boolean isInteraction(int imDim) {
     return imDim == Dimension.TRUE || imDim >= Dimension.P;
   }
 

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/IMPredicate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/IMPredicate.java
@@ -77,6 +77,13 @@ abstract class IMPredicate extends BasicPredicate {
    */
   protected abstract boolean isDetermined();
   
+  /**
+   * Tests whether the exterior of the specified input geometry
+   * is intersected by any part of the other input.
+   * 
+   * @param isA the input geometry
+   * @return true if the input geometry exterior is intersected
+   */
   protected boolean intersectsExteriorOf(boolean isA) {
     if (isA) {
       return isIntersects(Location.EXTERIOR, Location.INTERIOR)
@@ -112,6 +119,12 @@ abstract class IMPredicate extends BasicPredicate {
     setValue(valueIM());
   }
   
+  /**
+   * Gets the value of the predicate according to the current
+   * intersection matrix state.
+   * 
+   * @return the current predicate value
+   */
   protected abstract boolean valueIM();
 
   public String toString() {

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateGeometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateGeometry.java
@@ -48,6 +48,7 @@ class RelateGeometry {
   private Geometry geom;
   private boolean isPrepared = false;
   
+  private Envelope geomEnv;
   private int geomDim = Dimension.FALSE;
   private Set<Coordinate> uniquePoints;
   private BoundaryNodeRule boundaryNodeRule;
@@ -69,6 +70,7 @@ class RelateGeometry {
   
   public RelateGeometry(Geometry input, boolean isPrepared, BoundaryNodeRule bnRule) {
     this.geom = input;
+    this.geomEnv = input.getEnvelopeInternal();
     this.isPrepared = isPrepared;
     this.boundaryNodeRule = bnRule;
     //-- cache geometry metadata
@@ -160,7 +162,7 @@ class RelateGeometry {
   }
 
   public Envelope getEnvelope() {
-    return geom.getEnvelopeInternal();
+    return geomEnv;
   }
   
   public int getDimension() {

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateMatrixPredicate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateMatrixPredicate.java
@@ -26,6 +26,12 @@ class RelateMatrixPredicate extends IMPredicate
   public String name() { return "relateMatrix"; }
   
   @Override
+  public boolean requireInteraction() {
+    //-- ensure entire matrix is computed
+    return false;
+  }
+  
+  @Override
   public boolean isDetermined() {
     //-- ensure entire matrix is computed
     return false;

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateNG.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateNG.java
@@ -220,7 +220,11 @@ public class RelateNG
    * @return true if the predicate is satisfied
    */
   public boolean evaluate(Geometry b, TopologyPredicate predicate) {
-
+    //-- fast envelope checks
+    if (! hasRequiredEnvelopeInteraction(b, predicate)) {
+      return false;
+    }
+        
     RelateGeometry geomB = new RelateGeometry(b, boundaryNodeRule);
     
     if (geomA.isEmpty() && geomB.isEmpty()) {
@@ -265,6 +269,29 @@ public class RelateNG
     //-- after all processing, set remaining unknown values in IM
     topoComputer.finish();
     return topoComputer.getResult();
+  }
+
+  private boolean hasRequiredEnvelopeInteraction(Geometry b, TopologyPredicate predicate) {
+    Envelope envB = b.getEnvelopeInternal();
+    boolean isInteracts = false;
+    if (predicate.requireCovers(GEOM_A)) {
+      if (! geomA.getEnvelope().covers(envB)) {
+        return false;
+      }
+      isInteracts = true;
+    }
+    else if (predicate.requireCovers(GEOM_B)) {
+      if (! envB.covers(geomA.getEnvelope())) {
+        return false;
+      }
+      isInteracts = true;
+    }
+    if (! isInteracts 
+        && predicate.requireInteraction()
+        && ! geomA.getEnvelope().intersects(envB)) {
+      return false;
+    }
+    return true;
   }
 
   private boolean finishValue(TopologyPredicate predicate) {

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateNG.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateNG.java
@@ -350,8 +350,8 @@ public class RelateNG
      * for the intersects predicate (since these are checked
      * during segment/segment intersection checking anyway). 
      * Checking points against areas is necessary, since the input
-     * linework may be entirely disjoint if one input lies wholly 
-     * inside an area.
+     * linework is disjoint if one input lies wholly inside an area,
+     * so segment intersection checking is not sufficient.
      */
     boolean checkDisjointPoints = geomTarget.hasDimension(Dimension.A) 
         || topoComputer.isExteriorCheckRequired(isA);

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelatePredicate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelatePredicate.java
@@ -52,13 +52,13 @@ public interface RelatePredicate {
       public String name() { return "intersects"; }
   
       @Override
-      public boolean requiresSelfNoding() {
+      public boolean requireSelfNoding() {
         //-- self-noding is not required to check for a simple interaction
         return false;
       }
       
       @Override
-      public boolean requiresExteriorCheck(boolean isSourceA) {
+      public boolean requireExteriorCheck(boolean isSourceA) {
         //-- intersects only requires testing interaction
         return false;
       }
@@ -104,13 +104,19 @@ public interface RelatePredicate {
       public String name() { return "disjoint"; }
       
       @Override
-      public boolean requiresSelfNoding() {
+      public boolean requireSelfNoding() {
         //-- self-noding is not required to check for a simple interaction
         return false;
       }
-
+      
       @Override
-      public boolean requiresExteriorCheck(boolean isSourceA) {
+      public boolean requireInteraction() {
+        //-- ensure entire matrix is computed
+        return false;
+      }
+      
+      @Override
+      public boolean requireExteriorCheck(boolean isSourceA) {
         //-- disjoint only requires testing interaction
         return false;
       }
@@ -164,7 +170,12 @@ public interface RelatePredicate {
     public String name() { return "contains"; }
       
     @Override
-    public boolean requiresExteriorCheck(boolean isSourceA) {
+    public boolean requireCovers(boolean isSourceA) {
+      return isSourceA == RelateGeometry.GEOM_A;
+    }
+    
+    @Override
+    public boolean requireExteriorCheck(boolean isSourceA) {
       //-- only need to check B against Exterior of A
       return isSourceA == RelateGeometry.GEOM_B;
     }
@@ -222,7 +233,12 @@ public interface RelatePredicate {
       public String name() { return "within"; }
       
       @Override
-      public boolean requiresExteriorCheck(boolean isSourceA) {
+      public boolean requireCovers(boolean isSourceA) {
+        return isSourceA == RelateGeometry.GEOM_B;
+      }
+      
+      @Override
+      public boolean requireExteriorCheck(boolean isSourceA) {
         //-- only need to check A against Exterior of B
         return isSourceA == RelateGeometry.GEOM_A;
       }
@@ -286,7 +302,12 @@ public interface RelatePredicate {
       public String name() { return "covers"; }
       
       @Override
-      public boolean requiresExteriorCheck(boolean isSourceA) {
+      public boolean requireCovers(boolean isSourceA) {
+        return isSourceA == RelateGeometry.GEOM_A;
+      }
+      
+      @Override
+      public boolean requireExteriorCheck(boolean isSourceA) {
         //-- only need to check B against Exterior of A
         return isSourceA == RelateGeometry.GEOM_B;
       }
@@ -345,7 +366,12 @@ public interface RelatePredicate {
       public String name() { return "coveredBy"; }
       
       @Override
-      public boolean requiresExteriorCheck(boolean isSourceA) {
+      public boolean requireCovers(boolean isSourceA) {
+        return isSourceA == RelateGeometry.GEOM_B;
+      }
+      
+      @Override
+      public boolean requireExteriorCheck(boolean isSourceA) {
         //-- only need to check A against Exterior of B
         return isSourceA == RelateGeometry.GEOM_A;
       }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyComputer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyComputer.java
@@ -133,11 +133,11 @@ class TopologyComputer {
     //TODO: change to testing for lines or GC with > 1 polygon
     if (geomA.isPointsOrPolygons()) return false;
     if (geomB.isPointsOrPolygons()) return false;
-    return predicate.requiresSelfNoding();
+    return predicate.requireSelfNoding();
   }
   
   public boolean isExteriorCheckRequired(boolean isA) {
-    return predicate.requiresExteriorCheck(isA);
+    return predicate.requireExteriorCheck(isA);
   }
   
   private void updateDim(int locA, int locB, int dimension) {

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyPredicate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyPredicate.java
@@ -72,7 +72,7 @@ public interface TopologyPredicate {
    * <pre>
    * IM[Ext(Src), Int(Tgt)] = F and IM[Ext(Src), Bdy(Tgt)] = F
    * </pre>
-   * This allows a fast result if 
+   * If true, this allows a fast result if 
    * the source envelope does not cover the target envelope.
    * 
    * @param isSourceA indicates the source input geometry
@@ -89,7 +89,7 @@ public interface TopologyPredicate {
    * <pre>
    * IM[Int(Src), Ext(Tgt)] >= 0 or IM[Bdy(Src), Ext(Tgt)] >= 0
    * </pre> 
-   * When not required to evaluate a predicate this permits performance optimization.
+   * If false, this may permit a faster result in some geometric situations.
    *  
    * @param isSourceA indicates the source input geometry
    * @return true if the predicate requires checking whether the source intersects the target exterior

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyPredicate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyPredicate.java
@@ -45,10 +45,43 @@ public interface TopologyPredicate {
    * 
    * @return true if self-noding is required.
    */
-  default boolean requiresSelfNoding() {
+  default boolean requireSelfNoding() {
     return true;
   }
 
+  /**
+   * Reports whether this predicate requires interaction between
+   * the input geometries.
+   * This is the case if 
+   * <pre>
+   * IM[I, I] >= 0 or IM[I, B] >= 0 or IM[B, I] >= 0 or IM[B, B] >= 0
+   * </pre>  
+   * This allows a fast result if 
+   * the envelopes of the geometries are disjoint.
+   * 
+   * @return true if the geometries must interact
+   */
+  default boolean requireInteraction() {
+    return true;
+  }
+  
+  /**
+   * Reports whether this predicate requires that the source
+   * cover the target.
+   * This is the case if 
+   * <pre>
+   * IM[Ext(Src), Int(Tgt)] = F and IM[Ext(Src), Bdy(Tgt)] = F
+   * </pre>
+   * This allows a fast result if 
+   * the source envelope does not cover the target envelope.
+   * 
+   * @param isSourceA indicates the source input geometry
+   * @return true if the predicate requires checking whether the source covers the target
+   */
+  default boolean requireCovers(boolean isSourceA) {
+    return false;
+  }
+  
   /**
    * Reports whether this predicate requires checking if the source input intersects
    * the Exterior of the target input.
@@ -58,10 +91,10 @@ public interface TopologyPredicate {
    * </pre> 
    * When not required to evaluate a predicate this permits performance optimization.
    *  
-   * @param isSourceA flag indicating which input geometry is the source
+   * @param isSourceA indicates the source input geometry
    * @return true if the predicate requires checking whether the source intersects the target exterior
    */
-  default boolean requiresExteriorCheck(boolean isSourceA) {
+  default boolean requireExteriorCheck(boolean isSourceA) {
     return true;
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyPredicateTracer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyPredicateTracer.java
@@ -47,13 +47,13 @@ public class TopologyPredicateTracer {
     public String name() { return pred.name(); }
     
     @Override
-    public boolean requiresSelfNoding() {
-      return pred.requiresSelfNoding();
+    public boolean requireSelfNoding() {
+      return pred.requireSelfNoding();
     }
     
     @Override
-    public boolean requiresExteriorCheck(boolean isSourceA) {
-      return pred.requiresExteriorCheck(isSourceA);
+    public boolean requireExteriorCheck(boolean isSourceA) {
+      return pred.requireExteriorCheck(isSourceA);
     }
     
     @Override

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyPredicateTracer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyPredicateTracer.java
@@ -52,6 +52,11 @@ public class TopologyPredicateTracer {
     }
     
     @Override
+    public boolean requireCovers(boolean isSourceA) {
+      return pred.requireCovers(isSourceA);
+    }
+    
+    @Override
     public boolean requireExteriorCheck(boolean isSourceA) {
       return pred.requireExteriorCheck(isSourceA);
     }

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGTest.java
@@ -23,7 +23,7 @@ public class RelateNGTest extends RelateNGTestCase {
     super(name);
   }
 
-  public void testDisjoint() {
+  public void testPointsDisjoint() {
     String a = "POINT (0 0)";
     String b = "POINT (1 1)";
     checkIntersectsDisjoint(a, b, false);


### PR DESCRIPTION
This PR adds an optimization to enable fast checking of whether envelopes interact or cover. This allows short-circuiting for some predicates.

It is an improvement to #1052.