### PR TITLE
Improve CoverageSimplifier

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
@@ -72,7 +72,9 @@ public class CoverageFunctions {
       @Metadata(title="Weight")
       double weight) {
     Geometry[] cov = toGeometryArray(coverage);
-    Geometry[] result =  CoverageSimplifier.simplify(cov, tolerance, weight);
+    CoverageSimplifier simplifier = new CoverageSimplifier(cov);
+    simplifier.setSmoothWeight(weight);
+    Geometry[] result = simplifier.simplify(tolerance);
     return coverage.getFactory().createGeometryCollection(result);
   }
   
@@ -83,14 +85,35 @@ public class CoverageFunctions {
       @Metadata(title="Removal Size Factor")
       double factor) {
     Geometry[] cov = toGeometryArray(coverage);
-    Geometry[] result =  CoverageSimplifier.simplifyRemovalSize(cov, tolerance, factor);
+    CoverageSimplifier simplifier = new CoverageSimplifier(cov);
+    simplifier.setRemovableRingSizeFactor(factor);
+    Geometry[] result = simplifier.simplify(tolerance);
     return coverage.getFactory().createGeometryCollection(result);
   }
   
   @Metadata(description="Simplify inner edges of a coverage")
-  public static Geometry simplifyinner(Geometry coverage, double tolerance) {
+  public static Geometry simplifyInner(Geometry coverage, double tolerance) {
     Geometry[] cov = toGeometryArray(coverage);
     Geometry[] result =  CoverageSimplifier.simplifyInner(cov, tolerance);
+    return coverage.getFactory().createGeometryCollection(result);
+  }
+  
+  @Metadata(description="Simplify outer edges of a coverage")
+  public static Geometry simplifyOuter(Geometry coverage, double tolerance) {
+    Geometry[] cov = toGeometryArray(coverage);
+    Geometry[] result =  CoverageSimplifier.simplifyOuter(cov, tolerance);
+    return coverage.getFactory().createGeometryCollection(result);
+  }
+  
+  @Metadata(description="Simplify inner and outer edges of a coverage differently")
+  public static Geometry simplifyInOut(Geometry coverage, 
+      @Metadata(title="Inner Distance tol")
+      double toleranceInner, 
+      @Metadata(title="Outer Distance tol")
+      double toleranceOuter) {
+    Geometry[] cov = toGeometryArray(coverage);
+    CoverageSimplifier simplifier = new CoverageSimplifier(cov);
+    Geometry[] result = simplifier.simplify(toleranceInner, toleranceOuter);
     return coverage.getFactory().createGeometryCollection(result);
   }
   

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
@@ -62,14 +62,36 @@ public class CoverageFunctions {
   public static Geometry simplify(Geometry coverage, double tolerance) {
     Geometry[] cov = toGeometryArray(coverage);
     Geometry[] result =  CoverageSimplifier.simplify(cov, tolerance);
-    return FunctionsUtil.buildGeometry(result);
+    return coverage.getFactory().createGeometryCollection(result);
+  }
+  
+  @Metadata(description="Simplify a coverage with a smoothness weight")
+  public static Geometry simplifySharp(Geometry coverage, 
+      @Metadata(title="Distance tol")
+      double tolerance, 
+      @Metadata(title="Weight")
+      double weight) {
+    Geometry[] cov = toGeometryArray(coverage);
+    Geometry[] result =  CoverageSimplifier.simplify(cov, tolerance, weight);
+    return coverage.getFactory().createGeometryCollection(result);
+  }
+  
+  @Metadata(description="Simplify a coverage with a ring removal size factor")
+  public static Geometry simplifyRemoveRings(Geometry coverage, 
+      @Metadata(title="Distance tol")
+      double tolerance, 
+      @Metadata(title="Removal Size Factor")
+      double factor) {
+    Geometry[] cov = toGeometryArray(coverage);
+    Geometry[] result =  CoverageSimplifier.simplifyRemovalSize(cov, tolerance, factor);
+    return coverage.getFactory().createGeometryCollection(result);
   }
   
   @Metadata(description="Simplify inner edges of a coverage")
   public static Geometry simplifyinner(Geometry coverage, double tolerance) {
     Geometry[] cov = toGeometryArray(coverage);
     Geometry[] result =  CoverageSimplifier.simplifyInner(cov, tolerance);
-    return FunctionsUtil.buildGeometry(result);
+    return coverage.getFactory().createGeometryCollection(result);
   }
   
   static Geometry extractPolygons(Geometry geom) {

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
@@ -119,11 +119,12 @@ public class CoverageFunctions {
   }
   
   @Metadata(description="Simplify a coverage with per-geometry tolerances")
-  public static Geometry simplifyTolerances(Geometry coverage, String tolerances) {
+  public static Geometry simplifyTolerances(Geometry coverage, 
+      @Metadata(title="Tolerances (comma-sep)")
+      String tolerancesCSV) {
     Geometry[] cov = toGeometryArray(coverage);
-    double[] toleranceList = tolerances(tolerances, cov.length);
-    CoverageSimplifier simplifier = new CoverageSimplifier(cov);
-    Geometry[] result = simplifier.simplify(toleranceList);
+    double[] tolerances = tolerances(tolerancesCSV, cov.length);
+    Geometry[] result =  CoverageSimplifier.simplify(cov, tolerances);
     return FunctionsUtil.buildGeometry(result);
   }
   
@@ -138,12 +139,6 @@ public class CoverageFunctions {
   
   private static Double[] toDoubleArray(String csvList) {
     return Arrays.stream(csvList.split(",")).map(Double::parseDouble).toArray(Double[]::new);
-  }
-  
-  static Geometry extractPolygons(Geometry geom) {
-    List components = PolygonExtracter.getPolygons(geom);
-    Geometry result = geom.getFactory().buildGeometry(components);
-    return result;
   }
   
   private static Geometry[] toGeometryArray(Geometry geom) {

--- a/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/CoverageFunctions.java
@@ -11,6 +11,7 @@
  */
 package org.locationtech.jtstest.function;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.locationtech.jts.coverage.CoverageGapFinder;
@@ -115,6 +116,28 @@ public class CoverageFunctions {
     CoverageSimplifier simplifier = new CoverageSimplifier(cov);
     Geometry[] result = simplifier.simplify(toleranceInner, toleranceOuter);
     return coverage.getFactory().createGeometryCollection(result);
+  }
+  
+  @Metadata(description="Simplify a coverage with per-geometry tolerances")
+  public static Geometry simplifyTolerances(Geometry coverage, String tolerances) {
+    Geometry[] cov = toGeometryArray(coverage);
+    double[] toleranceList = tolerances(tolerances, cov.length);
+    CoverageSimplifier simplifier = new CoverageSimplifier(cov);
+    Geometry[] result = simplifier.simplify(toleranceList);
+    return FunctionsUtil.buildGeometry(result);
+  }
+  
+  private static double[] tolerances(String csvList, int len) {
+    Double[] tolsDouble = toDoubleArray(csvList);
+    double[] tols = new double[len];
+    for (int i = 0; i < tolsDouble.length; i++) {
+      tols[i] = tolsDouble[i];
+    }
+    return tols;
+  }  
+  
+  private static Double[] toDoubleArray(String csvList) {
+    return Arrays.stream(csvList.split(",")).map(Double::parseDouble).toArray(Double[]::new);
   }
   
   static Geometry extractPolygons(Geometry geom) {

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/Corner.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/Corner.java
@@ -25,12 +25,12 @@ class Corner implements Comparable<Corner> {
   private int next;
   private double area;
 
-  public Corner(LinkedLine edge, int i) {
+  public Corner(LinkedLine edge, int i, double area) {
     this.edge = edge;
     this.index = i; 
     this.prev = edge.prev(i);
     this.next = edge.next(i);
-    this.area = area(edge, i);
+    this.area = area;
   }
 
   public boolean isVertex(int index) {
@@ -57,13 +57,6 @@ class Corner implements Comparable<Corner> {
   
   public Coordinate next() {
     return edge.getCoordinate(next);  
-  }
-  
-  private static double area(LinkedLine edge, int index) {
-    Coordinate pp = edge.prevCoordinate(index);
-    Coordinate p = edge.getCoordinate(index);
-    Coordinate pn = edge.nextCoordinate(index);
-    return Triangle.area(pp, p, pn);
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CornerArea.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CornerArea.java
@@ -1,0 +1,35 @@
+package org.locationtech.jts.coverage;
+
+import org.locationtech.jts.algorithm.Angle;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Triangle;
+import org.locationtech.jts.math.MathUtil;
+
+class CornerArea {
+  public static final double DEFAULT_SMOOTH_WEIGHT = 0.0;
+  
+  private double weightSmooth = DEFAULT_SMOOTH_WEIGHT;
+  
+  public CornerArea() {
+  }
+
+  public CornerArea(double weightSmooth) {
+    this.weightSmooth = weightSmooth;
+  }
+
+  public double area(Coordinate pp, Coordinate p, Coordinate pn) {
+    
+    double area = Triangle.area(pp, p, pn);
+    double ang = angleNorm(pp, p, pn);
+    //-- rescale to [-1 .. 1], with 1 being narrow and -1 being flat
+    double angBias = 1.0 - 2.0 * ang;
+    //-- reduce area for narrower corners, to make them more likely to be removed
+    double areaWeighted = (1 - weightSmooth * angBias) * area;
+    return areaWeighted;
+  }
+  
+  private static double angleNorm(Coordinate pp, Coordinate p, Coordinate pn) {
+    double angNorm = Angle.angleBetween(pp, p, pn) / 2 / Math.PI;
+    return MathUtil.clamp(angNorm, 0, 1);
+  }
+}

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CornerArea.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CornerArea.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2022 Martin Davis.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
 package org.locationtech.jts.coverage;
 
 import org.locationtech.jts.algorithm.Angle;

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CornerArea.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CornerArea.java
@@ -16,16 +16,32 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Triangle;
 import org.locationtech.jts.math.MathUtil;
 
+/**
+ * Computes the effective area of corners, 
+ * taking into account the smoothing weight.
+ * 
+ * <h3>FUTURE WORK</h3>
+ * 
+ * Support computing geodetic area
+ * 
+ * @author Martin Davis
+ *
+ */
 class CornerArea {
   public static final double DEFAULT_SMOOTH_WEIGHT = 0.0;
   
-  private double weightSmooth = DEFAULT_SMOOTH_WEIGHT;
+  private double smoothWeight = DEFAULT_SMOOTH_WEIGHT;
   
   public CornerArea() {
   }
 
-  public CornerArea(double weightSmooth) {
-    this.weightSmooth = weightSmooth;
+  /**
+   * Creates a new corner area computer.
+   * 
+   * @param smoothWeight the weight for smoothing corners.  In range [0..1].
+   */
+  public CornerArea(double smoothWeight) {
+    this.smoothWeight = smoothWeight;
   }
 
   public double area(Coordinate pp, Coordinate p, Coordinate pn) {
@@ -35,7 +51,7 @@ class CornerArea {
     //-- rescale to [-1 .. 1], with 1 being narrow and -1 being flat
     double angBias = 1.0 - 2.0 * ang;
     //-- reduce area for narrower corners, to make them more likely to be removed
-    double areaWeighted = (1 - weightSmooth * angBias) * area;
+    double areaWeighted = (1 - smoothWeight * angBias) * area;
     return areaWeighted;
   }
   

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageEdge.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageEdge.java
@@ -11,8 +11,10 @@
  */
 package org.locationtech.jts.coverage;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.locationtech.jts.coverage.TPVWSimplifier.Edge;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateArrays;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -46,16 +48,6 @@ class CoverageEdge {
     return edge;
   }
 
-  static MultiLineString createLines(List<CoverageEdge> edges, GeometryFactory geomFactory) {
-    LineString lines[] = new LineString[edges.size()];
-    for (int i = 0; i < edges.size(); i++) {
-      CoverageEdge edge = edges.get(i);
-      lines[i] = edge.toLineString(geomFactory);
-    }
-    MultiLineString mls = geomFactory.createMultiLineString(lines);
-    return mls;
-  }
-  
   private static Coordinate[] extractEdgePoints(Coordinate[] ring, int start, int end) {
     int size = start < end 
                   ? end - start + 1 
@@ -156,6 +148,14 @@ class CoverageEdge {
     return ringCount;
   }
 
+  public boolean isInner() {
+    return ringCount == RING_COUNT_INNER;
+  }
+  
+  public boolean isOuter() {
+    return ringCount == RING_COUNT_OUTER;
+  }
+  
   public void setPrimary(boolean isPrimary) {
     this.isPrimary = isPrimary;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageEdge.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageEdge.java
@@ -11,16 +11,11 @@
  */
 package org.locationtech.jts.coverage;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.locationtech.jts.coverage.TPVWSimplifier.Edge;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateArrays;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineSegment;
 import org.locationtech.jts.geom.LineString;
-import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.io.WKTWriter;
 
 /**
@@ -221,6 +216,12 @@ class CoverageEdge {
     if (index == 0)
       return adjacentIndex0;
     return adjacentIndex1;
+  }
+
+  public boolean hasAdjacentIndex(int index) {
+    if (index == 0)
+      return adjacentIndex0 >= 0;
+    return adjacentIndex1 >= 0;
   }
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageEdge.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageEdge.java
@@ -133,6 +133,8 @@ class CoverageEdge {
   private int ringCount = 0;
   private boolean isFreeRing = true;
   private boolean isPrimary = true;
+  private int adjacentIndex0 = -1;
+  private int adjacentIndex1 = -1;
 
   public CoverageEdge(Coordinate[] pts, boolean isPrimary, boolean isFreeRing) {
     this.pts = pts;
@@ -157,6 +159,9 @@ class CoverageEdge {
   }
   
   public void setPrimary(boolean isPrimary) {
+    //-- preserve primary status if set
+    if (this.isPrimary)
+      return;
     this.isPrimary = isPrimary;
   }
   
@@ -200,8 +205,22 @@ class CoverageEdge {
     return WKTWriter.toLineString(pts);
   }
 
+  public void addIndex(int index) {
+    //TODO: keep information about which element is L and R?
+    
+    // assert: at least one elementIndex is unset (< 0)
+    if (adjacentIndex0 < 0) {
+      adjacentIndex0 = index;
+    }
+    else {
+      adjacentIndex1 = index;
+    }
+  }
 
-
-
+  public int getAdjacentIndex(int index) {
+    if (index == 0)
+      return adjacentIndex0;
+    return adjacentIndex1;
+  }
 
 }

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
@@ -224,10 +224,10 @@ public class CoverageSimplifier {
     // assert: index0 >= 0
     double tolerance = tolerances[index0];
     
-    int index1 = covEdge.getAdjacentIndex(0);
-    if (index1 >= 0) {
+    if (covEdge.hasAdjacentIndex(1)) {
+      int index1 = covEdge.getAdjacentIndex(1);
       double tol1 = tolerances[index1];
-      //-- minimum tolerance is used
+      //-- use lowest tolerance for edge
       if (tol1 < tolerance)
         tolerance = tol1;
     }

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/CoverageSimplifier.java
@@ -58,6 +58,10 @@ import org.locationtech.jts.geom.Geometry;
  * The input coverage should be valid according to {@link CoverageValidator}.
  * Invalid coverages may be simplified, but the result will likely still be invalid.
  * 
+ * <h3>FUTURE WORK</h3>
+ * 
+ * Support geodetic data by computing true geodetic area, and accepting tolerances in metres.
+ * 
  * @author Martin Davis
  */
 public class CoverageSimplifier {

--- a/modules/core/src/main/java/org/locationtech/jts/coverage/TPVWSimplifier.java
+++ b/modules/core/src/main/java/org/locationtech/jts/coverage/TPVWSimplifier.java
@@ -164,7 +164,7 @@ class TPVWSimplifier {
       LineString line = (LineString) lines.getGeometryN(i);
       boolean isFree = getValue(freeRings, i);
       boolean isRemovable = getValue(removableRings, i);
-      Edge edge = new Edge(line, distanceTolerance, isFree, isRemovable);
+      Edge edge = new Edge(line.getCoordinates(), distanceTolerance, isFree, isRemovable);
       edge.updateRemoved(removableSizeFactor);
       edges.add(edge);
     }
@@ -196,15 +196,15 @@ class TPVWSimplifier {
      * The endpoints of the edge are preserved during simplification,
      * unless it is a ring and the {@Link #isFreeRing} flag is set.
      * 
-     * @param inputLine the line or ring
+     * @param pts the line or ring
      * @param distanceTolerance 
      * @param isFreeRing whether a ring endpoint can be removed
      * @param isFreeRing 
      * @param isRemovable 
      */
-    Edge(LineString inputLine, double distanceTolerance, boolean isFreeRing, boolean isRemovable) {
-      this.envelope = inputLine.getEnvelopeInternal();
-      pts = inputLine.getCoordinates();
+    Edge(Coordinate[] pts, double distanceTolerance, boolean isFreeRing, boolean isRemovable) {
+      this.envelope = CoordinateArrays.envelope(pts);
+      this.pts = pts;
       this.nPts = pts.length;
       this.isFreeRing = isFreeRing;
       this.isRemovable = isRemovable;

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageRingEdgesTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageRingEdgesTest.java
@@ -45,22 +45,6 @@ public class CoverageRingEdgesTest  extends GeometryTestCase {
         "MULTILINESTRING ((0 10, 0 0, 10 0, 10 10, 0 10), (1 1, 1 9, 4 8, 9 9), (1 1, 9 1, 9 9), (1 1, 9 9))");
   }
 
-  public void testTouchingSquares() {
-    String wkt = "MULTIPOLYGON (((2 7, 2 8, 3 8, 3 7, 2 7)), ((1 6, 1 7, 2 7, 2 6, 1 6)), ((0 7, 0 8, 1 8, 1 7, 0 7)), ((0 5, 0 6, 1 6, 1 5, 0 5)), ((2 5, 2 6, 3 6, 3 5, 2 5)))";
-    checkEdgesSelected(wkt, 1,
-        "MULTILINESTRING ((1 6, 0 6, 0 5, 1 5, 1 6), (1 6, 1 7), (1 6, 2 6), (1 7, 0 7, 0 8, 1 8, 1 7), (1 7, 2 7), (2 6, 2 5, 3 5, 3 6, 2 6), (2 6, 2 7), (2 7, 2 8, 3 8, 3 7, 2 7))");
-    checkEdgesSelected(wkt, 2,
-        "MULTILINESTRING EMPTY");
-  }
-
-  public void testAdjacentSquares() {
-    String wkt = "GEOMETRYCOLLECTION (POLYGON ((1 3, 2 3, 2 2, 1 2, 1 3)), POLYGON ((3 3, 3 2, 2 2, 2 3, 3 3)), POLYGON ((3 1, 2 1, 2 2, 3 2, 3 1)), POLYGON ((1 1, 1 2, 2 2, 2 1, 1 1)))";
-    checkEdgesSelected(wkt, 1,
-        "MULTILINESTRING ((1 2, 1 1, 2 1), (1 2, 1 3, 2 3), (2 1, 3 1, 3 2), (2 3, 3 3, 3 2))");
-    checkEdgesSelected(wkt, 2,
-        "MULTILINESTRING ((1 2, 2 2), (2 1, 2 2), (2 2, 2 3), (2 2, 3 2))");
-  }
-
   public void testMultiPolygons() {
     checkEdges("GEOMETRYCOLLECTION (MULTIPOLYGON (((5 9, 2.5 7.5, 1 5, 5 5, 5 9)), ((5 5, 9 5, 7.5 2.5, 5 1, 5 5))), MULTIPOLYGON (((5 9, 6.5 6.5, 9 5, 5 5, 5 9)), ((1 5, 5 5, 5 1, 3.5 3.5, 1 5))))",
             "MULTILINESTRING ((1 5, 2.5 7.5, 5 9), (1 5, 3.5 3.5, 5 1), (1 5, 5 5), (5 1, 5 5), (5 1, 7.5 2.5, 9 5), (5 5, 5 9), (5 5, 9 5), (5 9, 6.5 6.5, 9 5))" 
@@ -71,16 +55,6 @@ public class CoverageRingEdgesTest  extends GeometryTestCase {
     Geometry geom = read(wkt);
     Geometry[] polygons = toArray(geom);
     List<CoverageEdge> edges = CoverageRingEdges.create(polygons).getEdges();
-    MultiLineString edgeLines = toArray(edges, geom.getFactory());
-    Geometry expected = read(wktExpected);
-    checkEqual(expected, edgeLines);
-  }
-
-  private void checkEdgesSelected(String wkt, int ringCount, String wktExpected) {
-    Geometry geom = read(wkt);
-    Geometry[] polygons = toArray(geom);
-    CoverageRingEdges covEdges = CoverageRingEdges.create(polygons);
-    List<CoverageEdge> edges = covEdges.selectEdges(ringCount);
     MultiLineString edgeLines = toArray(edges, geom.getFactory());
     Geometry expected = read(wktExpected);
     checkEqual(expected, edgeLines);

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
@@ -381,7 +381,9 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   }
   
   private void checkResultRemovalSize(Geometry[] input, double tolerance, double removalFactor, Geometry[] expected) {
-    Geometry[] actual = CoverageSimplifier.simplifyRemovalSize(input, tolerance, removalFactor);
+    CoverageSimplifier simplifier = new CoverageSimplifier(input);
+    simplifier.setRemovableRingSizeFactor(removalFactor);
+    Geometry[] actual = simplifier.simplify(tolerance);
     checkEqual(expected, actual);
   }
   

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
@@ -58,10 +58,10 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   
   public void testRepeatedPointRemoved() {
     checkResult(readArray(
-        "POLYGON ((5 9, 6.5 6.5, 9 5, 5 5, 5 5, 5 9))" ),
+        "POLYGON ((2 9, 7 6, 9 1, 2 1, 2 1, 3 6, 2 9))" ),
         2,
         readArray(
-            "POLYGON ((5 5, 5 9, 9 5, 5 5))" )
+            "POLYGON ((2 1, 2 9, 7 6, 9 1, 2 1))" )
     );
   }
   
@@ -118,10 +118,10 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   
   public void testSingleRingNoCollapse() {
     checkResult(readArray(
-        "POLYGON ((10 50, 60 90, 70 50, 60 10, 10 50))" ),
+        "POLYGON ((10 50, 50 90, 60 90, 70 50, 60 10, 10 50))" ),
         100000,
         readArray(
-            "POLYGON ((10 50, 60 90, 60 10, 10 50))" )
+            "POLYGON ((10 50, 60 90, 70 50, 60 10, 10 50))" )
     );
   }
 
@@ -146,8 +146,8 @@ public class CoverageSimplifierTest extends GeometryTestCase {
         "POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (50 20, 20 30, 20 80, 60 50, 80 20, 50 20))" ),
         28,
         readArray(
-            "POLYGON ((20 30, 20 80, 80 20, 20 30))",
-            "POLYGON ((10 10, 10 90, 90 90, 90 10, 10 10), (20 30, 80 20, 20 80, 20 30))" )
+            "POLYGON ((20 30, 20 80, 60 50, 80 20, 20 30))",
+            "POLYGON ((10 90, 90 90, 90 10, 10 10, 10 90), (20 30, 20 80, 60 50, 80 20, 20 30))" )
     );
   }
 
@@ -158,26 +158,26 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "POLYGON (( 12 6, 12 7, 13 7, 13 9, 14 9, 14 6, 12 6 ))"),
         1.0,
         readArray(
-            "POLYGON ((0 0, 0 11, 19 11, 19 0, 0 0), (4 5, 12 5, 12 6, 10 6, 9 9, 6 8, 6 6, 4 5), (12 6, 14 6, 14 9, 12 6))",
+            "POLYGON ((0 0, 0 11, 19 11, 19 0, 0 0), (4 5, 12 5, 12 6, 10 6, 9 9, 6 8, 6 6, 4 5), (12 6, 14 6, 14 9, 13 7, 12 6))",
             "POLYGON ((4 5, 6 6, 6 8, 9 9, 10 6, 12 6, 12 5, 4 5))",
-            "POLYGON ((12 6, 14 9, 14 6, 12 6))" )
+            " POLYGON ((12 6, 14 6, 14 9, 13 7, 12 6))" )
     );
   }
 
-  public void testHoleTouchingShell() {
+  public void testInnerHoleTouchingShell() {
     checkResultInner(readArray(
-            "POLYGON ((200 300, 300 300, 300 100, 100 100, 100 300, 200 300), (170 220, 170 160, 200 140, 200 250, 170 220), (170 250, 200 250, 200 300, 170 250))",
-            "POLYGON ((170 220, 200 250, 200 140, 170 160, 170 220))",
-            "POLYGON ((170 250, 200 300, 200 250, 170 250))"),
-        100.0,
+            "POLYGON ((200 300, 300 300, 300 100, 100 100, 100 300, 200 300), (170 220, 170 160, 200 140, 210 200, 200 250, 170 220), (170 250, 200 250, 200 300, 180 280, 170 250))",
+            "POLYGON ((170 220, 200 250, 210 200, 200 140, 170 160, 170 220))",
+            "POLYGON ((170 250, 180 280, 200 300, 200 250, 170 250))" ),
+        70.0,
         readArray(
-            "POLYGON ((100 100, 100 300, 200 300, 300 300, 300 100, 100 100), (170 160, 200 140, 200 250, 170 160), (170 250, 200 250, 200 300, 170 250))",
-            "POLYGON ((170 160, 200 250, 200 140, 170 160))",
-            "POLYGON ((200 250, 200 300, 170 250, 200 250))" )
+            "POLYGON ((100 100, 100 300, 200 300, 300 300, 300 100, 100 100), (170 160, 200 140, 200 250, 170 220, 170 160), (170 250, 200 250, 200 300, 170 250))",
+            "POLYGON ((170 160, 170 220, 200 250, 200 140, 170 160))",
+            "POLYGON ((170 250, 200 300, 200 250, 170 250))" )
     );
   }
 
-  public void testHolesTouchingHolesAndShellInner() {
+  public void testInnerHolesTouchingHolesAndShell() {
     checkResultInner(readArray(
             "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))"),
         4.0,
@@ -191,11 +191,11 @@ public class CoverageSimplifierTest extends GeometryTestCase {
             "POLYGON (( 8 5, 9 4, 9 2, 1 2, 1 4, 2 4, 2 5, 1 5, 1 8, 9 8, 9 6, 8 5 ), ( 8 5, 7 6, 6 6, 6 4, 7 4, 8 5 ), ( 7 6, 8 6, 7 7, 7 6 ), ( 6 6, 6 7, 5 6, 6 6 ), ( 6 4, 5 4, 6 3, 6 4 ), ( 7 4, 7 3, 8 4, 7 4 ))"),
         4.0,
         readArray(
-            "POLYGON (( 1 2, 1 8, 9 8, 8 5, 9 2, 1 2 ), ( 5 4, 6 3, 6 4, 5 4 ), ( 5 6, 6 6, 6 7, 5 6 ), ( 6 4, 7 4, 8 5, 7 6, 6 6, 6 4 ), ( 7 3, 8 4, 7 4, 7 3 ), ( 7 6, 8 6, 7 7, 7 6 ))")
+            "POLYGON ((8 5, 9 2, 1 2, 1 8, 9 8, 8 5), (8 5, 7 6, 6 6, 6 4, 7 4, 8 5))")
     );
   }
 
-  public void testMultiPolygonWithTouchingShellsInner() {
+  public void testInnerMultiPolygonWithTouchingShells() {
     checkResultInner(
         readArray(
         "MULTIPOLYGON ((( 2 7, 2 8, 3 8, 3 7, 2 7 )), (( 1 6, 1 7, 2 7, 2 6, 1 6 )), (( 0 7, 0 8, 1 8, 1 7, 0 7 )), (( 0 5, 0 6, 1 6, 1 5, 0 5 )), (( 2 5, 2 6, 3 6, 3 5, 2 5 )))"),
@@ -208,14 +208,14 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   public void testMultiPolygonWithTouchingShells() {
     checkResult(
         readArray(
-            "MULTIPOLYGON ((( 2 7, 2 8, 3 8, 3 7, 2 7 )), (( 1 6, 1 7, 2 7, 2 6, 1 6 )), (( 0 7, 0 8, 1 8, 1 7, 0 7 )), (( 0 5, 0 6, 1 6, 1 5, 0 5 )), (( 2 5, 2 6, 3 6, 3 5, 2 5 )))"),
+            "MULTIPOLYGON (((1 6, 1 7, 2 7, 2 6, 1 6)), ((0 7, 0 8, 1 8, 1.2 7.5, 1 7, 0 7)), ((0 5, 0 6, 1 6, 1.2 5.5, 1 5, 0 5)))"),
         1.0,
         readArray(
-            "MULTIPOLYGON (((0 5, 0 6, 1 6, 0 5)), ((0 8, 1 8, 1 7, 0 8)), ((1 6, 1 7, 2 7, 2 6, 1 6)), ((2 5, 2 6, 3 5, 2 5)), ((2 7, 3 8, 3 7, 2 7)))")
+            "MULTIPOLYGON (((0 5, 0 6, 1 6, 1 5, 0 5)), ((0 7, 0 8, 1 8, 1 7, 0 7)), ((1 6, 1 7, 2 6, 1 6)))")
     );
   }
 
-  public void testTouchingShellsInner() {
+  public void testInnerTouchingShells() {
     checkResultInner(readArray(
             "POLYGON ((0 0, 0 5, 5 6, 10 5, 10 0, 0 0))",
             "POLYGON ((0 10, 5 6, 10 10, 0 10))"),
@@ -235,7 +235,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
-  public void testSimplifyInnerAtStartingNode() {
+  public void testInnerAtStartingNode() {
     checkResultInner(readArray(
         "POLYGON (( 0 5, 0 9, 6 9, 6 2, 1 2, 0 5 ), ( 1 5, 2 3, 5 3, 5 7, 1 7, 1 5 ))",
             "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
@@ -246,7 +246,7 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
 
-  public void testSimplifyAllAtStartingNode() {
+  public void testAtStartingNode() {
     checkResult(readArray(
             "POLYGON (( 0 5, 0 9, 6 9, 6 2, 1 2, 0 5 ), ( 1 5, 2 3, 5 3, 5 7, 1 7, 1 5 ))",
             "POLYGON (( 1 5, 1 7, 5 7, 5 3, 2 3, 1 5 ))"),
@@ -306,6 +306,67 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
   
+  //==============  Test with removed rings  =======================
+  
+  // A Polygon with a small hole containing another Polygon - small Polygon is primary so is not removed
+  public void testPolygonInHoleNotRemoved() {
+    checkResult(readArray(
+        "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (2 2, 2 3, 3 3, 2 2))",
+        "POLYGON ((2 2, 2 3, 3 3, 2 2))"
+          ),
+        1,
+        readArray(
+            "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (2 2, 2 3, 3 3, 2 2))",
+            "POLYGON ((2 2, 2 3, 3 3, 2 2))" )
+    );
+  }
+  
+  public void testMultiPolygonWithSmallPartRemoved() {
+    checkResult(readArray(
+        "MULTIPOLYGON (((11 9, 15 9, 15 5, 11 5, 11 9)), ((11 2, 12 2, 11 1, 11 2)))",
+        "POLYGON ((15 9, 18 9, 19 4, 14 1, 15 5, 15 9))"
+          ),
+        1,
+        readArray(
+            "POLYGON ((11 5, 11 9, 15 9, 15 5, 11 5))",
+            "POLYGON ((15 9, 18 9, 19 4, 14 1, 15 5, 15 9))" )
+    );
+  }
+  
+  public void testMultiPolygonWithTouchingSmallPartsRemoved() {
+    checkResult(readArray(
+        "MULTIPOLYGON (((1 5, 5 5, 5 1, 1 1, 1 5)), ((6 3, 7 2, 6 2, 6 3)), ((8 2, 7 2, 8 3, 8 2)))"
+          ),
+        1,
+        readArray(
+            "POLYGON ((1 5, 5 5, 5 1, 1 1, 1 5)))" )
+    );
+  }
+  
+  public void testMultiPolygonHolesSmallPartRemoved() {
+    checkResult(readArray(
+        "POLYGON ((0 9, 9 9, 9 0, 0 0, 0 9), (2 5, 2 4, 3 5, 2 5), (4 5, 4 3, 6 3, 6 5, 4 5))",
+        "MULTIPOLYGON (((2 5, 3 5, 2 4, 2 5)), ((4 5, 6 5, 6 3, 4 3, 4 5)))"
+          ),
+        1,
+        readArray(
+            "POLYGON ((0 9, 9 9, 9 0, 0 0, 0 9), (4 5, 4 3, 6 3, 6 5, 4 5))",
+            "POLYGON ((4 5, 6 5, 6 3, 4 3, 4 5))" )
+    );
+  }
+  
+  public void testMultiPolygonHolesSmallPart() {
+    checkResultRemovalSize(readArray(
+        "POLYGON ((0 9, 9 9, 9 0, 0 0, 0 9), (2 5, 2 4, 3 5, 2 5), (4 5, 4 3, 6 3, 6 5, 4 5))",
+        "MULTIPOLYGON (((2 5, 3 5, 2 4, 2 5)), ((4 5, 6 5, 6 3, 4 3, 4 5)))"
+          ),
+        1, 0,
+        readArray(
+            "POLYGON ((0 9, 9 9, 9 0, 0 0, 0 9), (2 5, 2 4, 3 5, 2 5), (4 5, 4 3, 6 3, 6 5, 4 5))",
+            "MULTIPOLYGON (((2 5, 3 5, 2 4, 2 5)), ((4 5, 6 5, 6 3, 4 3, 4 5)))" )
+    );
+  }
+  
   //=================================
 
 
@@ -316,6 +377,11 @@ public class CoverageSimplifierTest extends GeometryTestCase {
   
   private void checkResult(Geometry[] input, double tolerance, Geometry[] expected) {
     Geometry[] actual = CoverageSimplifier.simplify(input, tolerance);
+    checkEqual(expected, actual);
+  }
+  
+  private void checkResultRemovalSize(Geometry[] input, double tolerance, double removalFactor, Geometry[] expected) {
+    Geometry[] actual = CoverageSimplifier.simplifyRemovalSize(input, tolerance, removalFactor);
     checkEqual(expected, actual);
   }
   

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageSimplifierTest.java
@@ -367,12 +367,31 @@ public class CoverageSimplifierTest extends GeometryTestCase {
     );
   }
   
+  public void testTolerances() {
+    checkResult(readArray(
+        "POLYGON ((1 19, 6 19, 7 11, 6 1, 1 1, 1 19))",
+        "POLYGON ((6 19, 12 19, 11 15, 12 1, 6 1, 7 11, 6 19))",
+        "POLYGON ((12 19, 19 19, 22 10, 19 1, 12 1, 11 15, 12 19))"
+          ),
+        new double[] { 0, 3, 6 },
+        readArray(
+            "POLYGON ((6 19, 7 11, 6 1, 1 1, 1 19, 6 19))",
+            "POLYGON  ((6 19, 12 19, 12 1, 6 1, 7 11, 6 19))",
+            "POLYGON  ((12 19, 19 19, 19 1, 12 1, 12 19))" )
+    );
+  }
+  
   //=================================
 
 
   private void checkNoop(Geometry[] input) {
     Geometry[] actual = CoverageSimplifier.simplify(input, 0);
     checkEqual(input, actual);
+  }
+  
+  private void checkResult(Geometry[] input, double[] tolerances, Geometry[] expected) {
+    Geometry[] actual = CoverageSimplifier.simplify(input, tolerances);
+    checkEqual(expected, actual);
   }
   
   private void checkResult(Geometry[] input, double tolerance, Geometry[] expected) {

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/TPVWSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/TPVWSimplifierTest.java
@@ -11,9 +11,14 @@
  */
 package org.locationtech.jts.coverage;
 
-import java.util.BitSet;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.locationtech.jts.coverage.TPVWSimplifier.Edge;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiLineString;
 
 import junit.textui.TestRunner;
@@ -47,10 +52,10 @@ public class TPVWSimplifierTest extends GeometryTestCase {
   }
     
   public void testNoFreeRing() {
-    checkSimplify("MULTILINESTRING ((1 9, 9 9, 9 1), (1 9, 1 1, 9 1), (5 5, 4 8, 2 8, 2 2, 4 2, 5 5), (5 5, 6 8, 8 8, 8 2, 6 2, 5 5))", 
+    checkSimplify("MULTILINESTRING ((1 19, 19 19, 19 1), (1 19, 1 1, 19 1), (10 10, 9 18, 2 18, 2 2, 7 6, 10 10), (10 10, 11 18, 18 18, 18 2, 13 6, 10 10))", 
         new int[] {  },
         2, 
-        "MULTILINESTRING ((1 9, 1 1, 9 1), (1 9, 9 9, 9 1), (5 5, 2 2, 2 8, 5 5), (5 5, 8 2, 8 8, 5 5))");
+        "MULTILINESTRING ((1 19, 1 1, 19 1), (1 19, 19 19, 19 1), (10 10, 2 2, 2 18, 9 18, 10 10), (10 10, 11 18, 18 18, 18 2, 10 10))");
   }
     
   public void testConstraint() {
@@ -58,20 +63,15 @@ public class TPVWSimplifierTest extends GeometryTestCase {
         new int[] {  },
         "MULTILINESTRING ((1 9, 9 9, 6 5, 9 1), (1 9, 1 1, 9 1))",
         1, 
-        "MULTILINESTRING ((6 8, 2 8, 2 2, 6 2, 5.9 5, 6 8))");
+        "MULTILINESTRING ((1 9, 1 1, 9 1), (1 9, 9 9, 6 5, 9 1), (6 8, 2 8, 2 2, 6 2, 5.9 5, 6 8))");
   }
     
   private void checkNoop(String wkt, double tolerance) {
-    MultiLineString geom = (MultiLineString) read(wkt);
-    Geometry actual = TPVWSimplifier.simplify(geom, tolerance);
-    checkEqual(geom, actual);
+    checkSimplify(wkt, null, null, tolerance, wkt);  
   }
   
   private void checkSimplify(String wkt, double tolerance, String wktExpected) {
-    MultiLineString geom = (MultiLineString) read(wkt);
-    Geometry actual = TPVWSimplifier.simplify(geom, tolerance);
-    Geometry expected = read(wktExpected);
-    checkEqual(expected, actual);
+    checkSimplify(wkt, null, null, tolerance, wktExpected);  
   }
   
   private void checkSimplify(String wkt, int[] freeRingIndex, 
@@ -82,17 +82,50 @@ public class TPVWSimplifierTest extends GeometryTestCase {
   private void checkSimplify(String wkt, int[] freeRingIndex, 
       String wktConstraints,
       double tolerance, String wktExpected) {
-    MultiLineString lines = (MultiLineString) read(wkt);
-    BitSet freeRings = new BitSet();
-    for (int index : freeRingIndex) {
-      freeRings.set(index);
-    }
-    MultiLineString constraints = wktConstraints == null ? null
-      : (MultiLineString) read(wktConstraints);
+    TPVWSimplifier.Edge[] edges = createEdges(wkt, freeRingIndex, wktConstraints, tolerance);
     CornerArea cornerArea = new CornerArea();
-    Geometry actual = TPVWSimplifier.simplify(lines, null, freeRings, constraints, tolerance, cornerArea, 1.0);
+    TPVWSimplifier.simplify(edges, cornerArea, 1.0);
+    
     Geometry expected = read(wktExpected);
+    MultiLineString actual = createResult(edges, expected.getFactory());
     checkEqual(expected, actual);
   }
   
+  private TPVWSimplifier.Edge[] createEdges(String wkt, int[] freeRingIndex, String wktConstraints, double tolerance) {
+    List<TPVWSimplifier.Edge> edgeList = new ArrayList<TPVWSimplifier.Edge>();
+    addEdges(wkt, freeRingIndex, tolerance, edgeList);
+    if (wktConstraints != null) {
+      addEdges(wktConstraints, null, 0.0, edgeList);
+    }
+    TPVWSimplifier.Edge[] edges = edgeList.toArray(new TPVWSimplifier.Edge[0]);
+    return edges;
+  }
+
+  private void addEdges(String wkt, int[] freeRings, double tolerance, List<Edge> edges) {
+    MultiLineString lines = (MultiLineString) read(wkt);
+    for (int i = 0; i < lines.getNumGeometries(); i++) {
+      LineString line = (LineString) lines.getGeometryN(i);
+      boolean isRemovable = false;
+      boolean isFreeRing = freeRings == null ? false : hasIndex(freeRings, i);
+      Edge edge = new Edge(line.getCoordinates(), tolerance, isFreeRing, isRemovable);
+      edges.add(edge);
+    }
+  }
+  
+  private boolean hasIndex(int[] freeRings, int i) {
+    for (int fr : freeRings) {
+      if (fr == i)
+        return true;
+    }
+    return false;
+  }
+
+  private static MultiLineString createResult(Edge[] edges, GeometryFactory geomFactory) {
+    LineString[] result = new LineString[edges.length];
+    for (int i = 0; i < edges.length; i++) {
+      Coordinate[] pts = edges[i].getCoordinates();
+      result[i] = geomFactory.createLineString(pts);
+    }
+    return geomFactory.createMultiLineString(result);
+  }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/TPVWSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/TPVWSimplifierTest.java
@@ -89,7 +89,8 @@ public class TPVWSimplifierTest extends GeometryTestCase {
     }
     MultiLineString constraints = wktConstraints == null ? null
       : (MultiLineString) read(wktConstraints);
-    Geometry actual = TPVWSimplifier.simplify(lines, freeRings, constraints, tolerance);
+    CornerArea cornerArea = new CornerArea();
+    Geometry actual = TPVWSimplifier.simplify(lines, null, freeRings, constraints, tolerance, cornerArea, 1.0);
     Geometry expected = read(wktExpected);
     checkEqual(expected, actual);
   }


### PR DESCRIPTION
Improves `CoverageSimplier`:

* Adds small ring removal, with configurable tolerance factor
* Adds smoothness weighting, to provide smoother results
* Adds ability to specify separate tolerances for inner and outer edges
* Adds support for a separate tolerance for each input coverage element

