### PR TITLE
Fix KMLReader to read coordinates with whitespace

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/kml/KMLReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/kml/KMLReader.java
@@ -34,6 +34,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Constructs a {@link Geometry} object from the OGC KML representation.
@@ -43,6 +45,8 @@ public class KMLReader {
     private final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
     private final GeometryFactory geometryFactory;
     private final Set<String> attributeNames;
+
+    private final Pattern whitespaceRegex = Pattern.compile("\\s+");
 
     private static final String POINT = "Point";
     private static final String LINESTRING = "LineString";
@@ -119,6 +123,8 @@ public class KMLReader {
         if (coordinates.isEmpty()) {
             raiseParseError("Empty coordinates");
         }
+        Matcher matcher= whitespaceRegex.matcher(coordinates.trim());
+        coordinates = matcher.replaceAll(" ");
 
         double[] parsedOrdinates = {Double.NaN, Double.NaN, Double.NaN};
         List<Coordinate> coordinateList = new ArrayList();

--- a/modules/core/src/test/java/org/locationtech/jts/io/kml/KMLReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/kml/KMLReaderTest.java
@@ -20,9 +20,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.io.ParseException;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
 
 public class KMLReaderTest extends TestCase {
     public static void main(String args[]) {
@@ -131,6 +129,17 @@ public class KMLReaderTest extends TestCase {
         );
     }
 
+    public void testCoordinatesWithWhitespace()
+    {
+        checkParsingResult(
+                "<LineString>" +
+                        "   <coordinates> 1.0,2.0" +
+                        "   -1.0,-2.0 </coordinates>" +
+                        "</LineString>",
+                "LINESTRING (1 2, -1 -2)",
+                new Map[]{null, null}
+        );
+    }
     public void testZ() {
         String kml = "<Point><coordinates>1.0,1.0,50.0</coordinates></Point>";
         KMLReader kmlReader = new KMLReader();
@@ -154,6 +163,7 @@ public class KMLReaderTest extends TestCase {
             throw new RuntimeException("ParseException: " + e.getMessage());
         }
     }
+
 
     public void testCoordinatesErrors() {
         checkExceptionThrown("<Point></Point>", "No element coordinates found in Point");


### PR DESCRIPTION
KMLReader will raise "Invalid coordinate format" error for coordinates with extra whitespace.
Example file: https://developers.google.com/kml/documentation/KML_Samples.kml

Added line to trim and replace whitespace in coordinates string before processing.