### PR TITLE
Fix RelateNG topology computation for Line Ends in mixed-dim GCs

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateGeometry.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateGeometry.java
@@ -213,11 +213,11 @@ class RelateGeometry {
     int loc = getLocator().locateNodeWithDim(nodePt, parentPolygonal);
     return loc == DimensionLocation.AREA_INTERIOR;  
   }
-  
-  public int locateLineEnd(Coordinate p) {
-    return getLocator().locateLineEnd(p);
-  }
 
+  public int locateLineEndWithDim(Coordinate p) {
+    return getLocator().locateLineEndWithDim(p);
+  }
+  
   /**
    * Locates a vertex of a polygon.
    * A vertex of a Polygon or MultiPolygon is on

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelatePointLocator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelatePointLocator.java
@@ -142,14 +142,33 @@ class RelatePointLocator {
   public int locate(Coordinate p) {
     return DimensionLocation.location(locateWithDim(p));
   }
-
-  public int locateLineEnd(Coordinate p) {
-    return lineBoundary.isBoundary(p) ? Location.BOUNDARY : Location.INTERIOR;
+  
+  /**
+   * Locates a point which is a line endpoint,
+   * as a {@link DimensionLocation}.
+   * For a mixed-dim GC, the line end point may also lie in an area,
+   * in which case this location is reported.
+   * Otherwise, the dimLoc will be either LINE_BOUNDARY 
+   * or LINE_INTERIOR, depending on the endpoint valence
+   * and the BoundaryNodeRule in place.
+   * 
+   * @param p the line end point to locate
+   * @return the dimension and location of the point
+   */
+  public int locateLineEndWithDim(Coordinate p) {
+    if (polygons != null) {
+      int locPoly = locateOnPolygons(p, false, null);
+      if (locPoly != Location.EXTERIOR)
+        return DimensionLocation.locationArea(locPoly);
+    }
+    return lineBoundary.isBoundary(p) 
+        ? DimensionLocation.LINE_BOUNDARY 
+        : DimensionLocation.LINE_INTERIOR;
   }
   
   /**
    * Locates a point which is known to be a node of the geometry
-   * (i.e. a point or on an edge).
+   * (i.e. a vertex or on an edge).
    * 
    * @param p the node point to locate
    * @param parentPolygonal the polygon the point is a node of

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGGCTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGGCTest.java
@@ -226,5 +226,11 @@ public class RelateNGGCTest extends RelateNGTestCase {
     checkEquals(a, b, true);
   }
 
+  public void testPolygonContainingLineInBoundaryAndInterior() {
+    String a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
+    String b = "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), LINESTRING (0 2, 0 5, 5 5))";
+    checkEquals(a, b, true);
+  }
+
 
 }

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelatePointLocatorTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelatePointLocatorTest.java
@@ -71,10 +71,24 @@ public class RelatePointLocatorTest extends GeometryTestCase {
     checkNodeLocation(gcPLA, 3, 1, Location.BOUNDARY);
   }
   
+  public void testLineEndInGCLA() {
+    String wkt = "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), LINESTRING (12 2, 0 2, 0 5, 5 5), LINESTRING (12 10, 12 2))";
+    checkLineEndDimLocation(wkt, 5, 5, DimensionLocation.AREA_INTERIOR);
+    checkLineEndDimLocation(wkt, 12, 2, DimensionLocation.LINE_INTERIOR);
+    checkLineEndDimLocation(wkt, 12, 10, DimensionLocation.LINE_BOUNDARY);
+  }
+  
   private void checkDimLocation(String wkt, double x, double y, int expectedDimLoc) {
     Geometry geom = read(wkt);
     RelatePointLocator locator = new RelatePointLocator(geom);
     int actual = locator.locateWithDim(new Coordinate(x, y));
+    assertEquals(expectedDimLoc, actual);
+  }
+  
+  private void checkLineEndDimLocation(String wkt, double x, double y, int expectedDimLoc) {
+    Geometry geom = read(wkt);
+    RelatePointLocator locator = new RelatePointLocator(geom);
+    int actual = locator.locateLineEndWithDim(new Coordinate(x, y));
     assertEquals(expectedDimLoc, actual);
   }
   

--- a/modules/tests/src/test/resources/testxml/misc/TestRelateGC.xml
+++ b/modules/tests/src/test/resources/testxml/misc/TestRelateGC.xml
@@ -85,7 +85,7 @@
 </case>
 
 <case>
-  <desc>GC:PL/mA</desc>
+  <desc>GC:PL/A</desc>
   <a>
     GEOMETRYCOLLECTION (POINT (7 1), LINESTRING (6 5, 6 4))
   </a>
@@ -554,5 +554,48 @@ GEOMETRYCOLLECTION (POLYGON ((1 9, 5 9, 6 6, 1 5, 1 9), (2 6, 4 8, 6 6, 2 6)), P
   <test><op name="within"     arg1="A" arg2="B"> true </op></test>
 </case>
 
+<case>
+  <desc>GC:AmP/A - polygon with overlapping points equal to polygon </desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)),
+      MULTIPOINT(0 2, 0 5))
+  </a>
+  <b>
+    POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+  </b>
+  <test><op name="relate" arg3="2FFF1FFF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> true </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>GC:AL/A - polygon with overlapping line equal to polygon </desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), 
+      LINESTRING (0 2, 0 5, 5 5))
+  </a>
+  <b>
+    POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+  </b>
+  <test><op name="relate" arg3="2FFF1FFF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> true </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
 
 </run>


### PR DESCRIPTION
Fixes RelateNG topology computation for Line Ends in mixed-dimension GeometryCollections.

Fixes the issue in https://github.com/libgeos/geos/issues/1148