### PR TITLE
RobustLineIntersector defensive copyWithZ check to avoid exception with CoordinateXY or CoordinateXYM

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java
@@ -15,6 +15,10 @@ package org.locationtech.jts.algorithm;
  *@version 1.7
  */
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateXY;
+import org.locationtech.jts.geom.CoordinateXYM;
+import org.locationtech.jts.geom.CoordinateXYZM;
+import org.locationtech.jts.geom.Coordinates;
 import org.locationtech.jts.geom.Envelope;
 
 /**
@@ -211,8 +215,8 @@ public class RobustLineIntersector
 
   private static Coordinate copyWithZ(Coordinate p, double z) {
     Coordinate pCopy = copy(p);
-    if (! Double.isNaN(z)) {
-      pCopy.setZ( z );
+    if (! Double.isNaN(z) && Coordinates.hasZ(pCopy)) {
+      pCopy.setZ(z);
     }
     return pCopy;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinates.java
@@ -68,6 +68,26 @@ public class Coordinates {
   }
 
   /**
+   * Check if coordinate can store Z valye, based on subclass of {@link Coordinate}.
+   *
+   * @param coordinate supplied coordinate
+   * @return true if setZ is available
+   */
+  public static boolean hasZ(Coordinate coordinate)
+  {
+    if (coordinate instanceof CoordinateXY) {
+      return false;
+    } else if (coordinate instanceof CoordinateXYM) {
+      return false;
+    } else if (coordinate instanceof CoordinateXYZM) {
+      return true;
+    } else if (coordinate instanceof Coordinate) {
+      return true;
+    }
+    return true;
+  }
+
+  /**
    * Determine number of measures based on subclass of {@link Coordinate}.
    * 
    * @param coordinate supplied coordinate

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/IntersectionTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/IntersectionTest.java
@@ -4,6 +4,14 @@ import org.locationtech.jts.geom.Coordinate;
 
 import junit.framework.TestCase;
 import junit.textui.TestRunner;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.impl.CoordinateArraySequenceFactory;
+import org.locationtech.jts.io.WKTReader;
 
 public class IntersectionTest extends TestCase {
   private static final double MAX_ABS_ERROR = 1e-5;
@@ -69,6 +77,41 @@ public class IntersectionTest extends TestCase {
     checkIntersectionLineSegmentNull( 0, 0, 0, 1,    2, 9,  1, 9 );
     checkIntersectionLineSegmentNull( 0, 0, 0, 1,   -2, 9, -1, 9 );
     checkIntersectionLineSegmentNull( 0, 0, 0, 1,    2, 9,  1, 9 );
+  }
+
+  public void testIntersectionXY() throws Exception {
+    // intersection with dim 3 x dim3
+    WKTReader reader = new WKTReader();
+    Geometry poly1 = reader.read("POLYGON((0 0 0, 0 10000 2, 10000 10000 2, 10000 0 0, 0 0 0))");
+    Geometry clipArea = reader.read("POLYGON((0 0, 0 2500, 2500 2500, 2500 0, 0 0))");
+    Geometry clipped1 = poly1.intersection(clipArea);
+
+    // intersection with dim 3 x dim 2
+    GeometryFactory gf = poly1.getFactory();
+    CoordinateSequenceFactory csf = gf.getCoordinateSequenceFactory();
+    double xmin = 0.0;
+    double xmax = 2500.0;
+    double ymin = 0.0;
+    double ymax = 2500.0;
+
+    CoordinateSequence cs = csf.create(5,2);
+    cs.setOrdinate(0, 0, xmin);
+    cs.setOrdinate(0, 1, ymin);
+    cs.setOrdinate(1, 0, xmin);
+    cs.setOrdinate(1, 1, ymax);
+    cs.setOrdinate(2, 0, xmax);
+    cs.setOrdinate(2, 1, ymax);
+    cs.setOrdinate(3, 0, xmax);
+    cs.setOrdinate(3, 1, ymin);
+    cs.setOrdinate(4, 0, xmin);
+    cs.setOrdinate(4, 1, ymin);
+
+    LinearRing bounds = gf.createLinearRing(cs);
+
+    Polygon fence = gf.createPolygon(bounds, null);
+    Geometry clipped2 = poly1.intersection(fence);
+
+    assertTrue(clipped1.equals(clipped2));
   }
 
   //==================================================


### PR DESCRIPTION
Defensive check prevents copyWithZ, copyWithZInterpolate methods from throwing an exception when the target coordinate is CoordinateXY or CoordinateXYM.

This is in addition to the existing defensive check to avoid doing anything if the z vale was Double.NaN.

This mitigates but does not solve https://github.com/locationtech/jts/issues/375 which is due to the intermixing of Coordinate and CoordinateXY values in GeoTools clipping code.