### PR TITLE
Change RelateNG semantics so all EMPTY geometries are topologically equal

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateNG.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelateNG.java
@@ -227,10 +227,6 @@ public class RelateNG
         
     RelateGeometry geomB = new RelateGeometry(b, boundaryNodeRule);
     
-    if (geomA.isEmpty() && geomB.isEmpty()) {
-      //TODO: what if predicate is disjoint?  Perhaps use result on disjoint envs?
-      return finishValue(predicate);
-    }
     int dimA = geomA.getDimensionReal();
     int dimB = geomB.getDimensionReal();
     

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelatePredicate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelatePredicate.java
@@ -482,11 +482,20 @@ public interface RelatePredicate {
       @Override
       public void init(int dimA, int dimB) {
         super.init(dimA, dimB);
-        require(dimA == dimB);
+        //-- don't require equal dims, because EMPTY = EMPTY for all dims
       }
       
       @Override
+      public boolean requireInteraction() {
+        //-- allow EMPTY = EMPTY
+        return false;
+      };
+    
+      @Override
       public void init(Envelope envA, Envelope envB) {
+        //-- handle EMPTY = EMPTY cases
+        setValueIf(true, envA.isNull() && envB.isNull());
+        
         require(envA.equals(envB));
       }   
       

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGTest.java
@@ -614,7 +614,6 @@ public class RelateNGTest extends RelateNGTestCase {
       for (int j = 0; j < nempty; j++) {
         String a = empties[i];
         String b = empties[j];
-        checkRelate(a, b, "FFFFFFFF2");
         ///-- empty geometries are all topologically equal
         checkEquals(a, b, true);
       }

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGTest.java
@@ -597,7 +597,7 @@ public class RelateNGTest extends RelateNGTestCase {
     checkRelate(a, b, "212F01FF2");
   }
   
-  //================  Repeated Points  ==============
+  //================  EMPTY geometries  ==============
 
   public void testEmptyEquals() {
     String empties[] = {
@@ -615,8 +615,8 @@ public class RelateNGTest extends RelateNGTestCase {
         String a = empties[i];
         String b = empties[j];
         checkRelate(a, b, "FFFFFFFF2");
-        //-- currently in JTS empty geometries do NOT test equal
-         checkEquals(a, b, false);
+        ///-- empty geometries are all topologically equal
+        checkEquals(a, b, true);
       }
     }  
   }


### PR DESCRIPTION
This changes RelateNG semantics so that EMPTY geometries are always equal.  This makes sense from a topological perspective, since they all consist of the empty set of points.

The semantics now match GEOS.
