### PR TITLE
Fix RelateNG IM calculation for EMPTY-nonEMPTY

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyComputer.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/TopologyComputer.java
@@ -247,8 +247,14 @@ class TopologyComputer {
     updateDim(isGeomA, Location.INTERIOR, Location.EXTERIOR, Dimension.P); 
   }
   
-  public void addPointOnGeometry(boolean isA, int locTarget, int dimTarget, Coordinate pt) {
-    updateDim(isA, Location.INTERIOR, locTarget, Dimension.P); 
+  public void addPointOnGeometry(boolean isPointA, int locTarget, int dimTarget, Coordinate pt) {
+    //-- update entry for Point interior
+    updateDim(isPointA, Location.INTERIOR, locTarget, Dimension.P);
+    
+    //-- an empty geometry has no points to infer entries from
+    if (getGeometry(! isPointA).isEmpty())
+      return;
+    
     switch (dimTarget) {
     case Dimension.P:
       return;
@@ -266,8 +272,8 @@ class TopologyComputer {
        * If a point intersects an area target, then the area interior and boundary
        * must extend beyond the point and thus interact with its exterior.
        */
-      updateDim(isA, Location.EXTERIOR, Location.INTERIOR, Dimension.A);      
-      updateDim(isA, Location.EXTERIOR, Location.BOUNDARY, Dimension.L);      
+      updateDim(isPointA, Location.EXTERIOR, Location.INTERIOR, Dimension.A);      
+      updateDim(isPointA, Location.EXTERIOR, Location.BOUNDARY, Dimension.L);      
       return;
     }
     throw new IllegalStateException("Unknown target dimension: " + dimTarget);
@@ -289,6 +295,10 @@ class TopologyComputer {
     //-- record topology at line end point
     updateDim(isLineA, locLineEnd, locTarget, Dimension.P);
     
+    //-- an empty geometry has no points to infer entries from
+    if (getGeometry(! isLineA).isEmpty())
+      return;
+
     //-- Line and Area targets may have additional topology
     switch (dimTarget) {
     case Dimension.P:

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relateng/RelateNGTest.java
@@ -599,24 +599,64 @@ public class RelateNGTest extends RelateNGTestCase {
   
   //================  EMPTY geometries  ==============
 
-  public void testEmptyEquals() {
-    String empties[] = {
-        "POINT EMPTY",
-        "LINESTRING EMPTY",
-        "POLYGON EMPTY",
-        "MULTIPOINT EMPTY",
-        "MULTILINESTRING EMPTY",
-        "MULTIPOLYGON EMPTY",
-        "GEOMETRYCOLLECTION EMPTY"
-    };
-    int nempty = 7;
-    for (int i = 0; i < nempty; i++) {
-      for (int j = 0; j < nempty; j++) {
-        String a = empties[i];
+  String empties[] = {
+      "POINT EMPTY",
+      "LINESTRING EMPTY",
+      "POLYGON EMPTY",
+      "MULTIPOINT EMPTY",
+      "MULTILINESTRING EMPTY",
+      "MULTIPOLYGON EMPTY",
+      "GEOMETRYCOLLECTION EMPTY"
+  };
+  
+  public void testEmptyEmpty() {
+    for (int i = 0; i < empties.length; i++) {
+      String a = empties[i];
+      
+      for (int j = 0; j < empties.length; j++) {
         String b = empties[j];
-        ///-- empty geometries are all topologically equal
+        checkRelate(a, b, "FFFFFFFF2");
+        //-- empty geometries are all topologically equal
         checkEquals(a, b, true);
+        
+        checkIntersectsDisjoint(a, b, false);
+        checkContainsWithin(a, b, false);
       }
+    }  
+  }
+  
+  public void testEmptyNonEmpty() {
+    String nonEmptyPoint = "POINT (1 1)";
+    String nonEmptyLine = "LINESTRING (1 1, 2 2)";
+    String nonEmptyPolygon = "POLYGON ((1 1, 1 2, 2 1, 1 1))";
+    
+    for (int i = 0; i < empties.length; i++) {
+      String empty = empties[i];
+      
+      checkRelate(empty, nonEmptyPoint, "FFFFFF0F2");
+      checkRelate(nonEmptyPoint, empty, "FF0FFFFF2");
+      
+      checkRelate(empty, nonEmptyLine, "FFFFFF102");
+      checkRelate(nonEmptyLine, empty, "FF1FF0FF2");
+      
+      checkRelate(empty, nonEmptyPolygon, "FFFFFF212");
+      checkRelate(nonEmptyPolygon, empty, "FF2FF1FF2");
+      
+      checkEquals(empty, nonEmptyPoint, false);
+      checkEquals(empty, nonEmptyLine, false);
+      checkEquals(empty, nonEmptyPolygon, false);
+      
+      checkIntersectsDisjoint(empty, nonEmptyPoint, false);
+      checkIntersectsDisjoint(empty, nonEmptyLine, false);
+      checkIntersectsDisjoint(empty, nonEmptyPolygon, false);
+      
+      checkContainsWithin(empty, nonEmptyPoint, false);
+      checkContainsWithin(empty, nonEmptyLine, false);
+      checkContainsWithin(empty, nonEmptyPolygon, false);
+      
+      checkContainsWithin(nonEmptyPoint, empty, false);
+      checkContainsWithin(nonEmptyLine, empty, false);
+      checkContainsWithin(nonEmptyPolygon, empty, false);
     }  
   }
   


### PR DESCRIPTION
Fixes RelateNG to correctly compute the DE-9IM matrix for cases with both EMPTY and non-EMPTY geometries.