### PR TITLE
Fix writing XYM geometries as WKB

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/CheckOrdinatesFilter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/CheckOrdinatesFilter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.io;
+
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFilter;
+
+import java.util.EnumSet;
+
+/**
+ * A filter implementation to test if a coordinate sequence actually has meaningful values for an
+ * ordinate bit-pattern
+ */
+class CheckOrdinatesFilter implements CoordinateSequenceFilter {
+
+  private final EnumSet<Ordinate> checkOrdinateFlags;
+  private final EnumSet<Ordinate> outputOrdinates;
+
+  /**
+   * Creates an instance of this class
+   *
+   * @param checkOrdinateFlags the index for the ordinates to test.
+   */
+  CheckOrdinatesFilter(EnumSet<Ordinate> checkOrdinateFlags) {
+
+    this.outputOrdinates = EnumSet.of(Ordinate.X, Ordinate.Y);
+    this.checkOrdinateFlags = checkOrdinateFlags;
+  }
+
+  /**
+   * @see CoordinateSequenceFilter#isGeometryChanged
+   */
+  public void filter(CoordinateSequence seq, int i) {
+
+    if (checkOrdinateFlags.contains(Ordinate.Z) && !outputOrdinates.contains(Ordinate.Z)) {
+        if (!Double.isNaN(seq.getZ(i))) {
+            outputOrdinates.add(Ordinate.Z);
+        }
+    }
+
+    if (checkOrdinateFlags.contains(Ordinate.M) && !outputOrdinates.contains(Ordinate.M)) {
+        if (!Double.isNaN(seq.getM(i))) {
+            outputOrdinates.add(Ordinate.M);
+        }
+    }
+  }
+
+  /**
+   * @see CoordinateSequenceFilter#isGeometryChanged
+   */
+  public boolean isGeometryChanged() {
+    return false;
+  }
+
+  /**
+   * @see CoordinateSequenceFilter#isDone
+   */
+  public boolean isDone() {
+    return outputOrdinates.equals(checkOrdinateFlags);
+  }
+
+  /**
+   * Gets the evaluated ordinate bit-pattern
+   *
+   * @return A bit-pattern of ordinates with valid values masked by {@link #checkOrdinateFlags}.
+   */
+  EnumSet<Ordinate> getOutputOrdinates() {
+    return outputOrdinates;
+  }
+}

--- a/modules/core/src/main/java/org/locationtech/jts/io/CheckOrdinatesFilter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/CheckOrdinatesFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Vivid Solutions.
+ * Copyright (c) 2024 Kristin Cowalcijk.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTWriter.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTWriter.java
@@ -19,7 +19,6 @@ import java.util.EnumSet;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
-import org.locationtech.jts.geom.CoordinateSequenceFilter;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.LineString;
@@ -173,60 +172,6 @@ public class WKTWriter
       buf.append(ch);
     }
     return buf.toString();
-  }
-
-  /**
-   * A filter implementation to test if a coordinate sequence actually has
-   * meaningful values for an ordinate bit-pattern
-   */
-  private class CheckOrdinatesFilter implements CoordinateSequenceFilter {
-
-    private final EnumSet<Ordinate> checkOrdinateFlags;
-    private final EnumSet<Ordinate> outputOrdinates;
-
-    /**
-     * Creates an instance of this class
-
-     * @param checkOrdinateFlags the index for the ordinates to test.
-     */
-    private CheckOrdinatesFilter(EnumSet<Ordinate> checkOrdinateFlags) {
-
-      this.outputOrdinates = EnumSet.of(Ordinate.X, Ordinate.Y);
-      this.checkOrdinateFlags = checkOrdinateFlags;
-    }
-
-    /** @see org.locationtech.jts.geom.CoordinateSequenceFilter#isGeometryChanged */
-    public void filter(CoordinateSequence seq, int i) {
-
-      if (checkOrdinateFlags.contains(Ordinate.Z) && !outputOrdinates.contains(Ordinate.Z)) {
-        if (!Double.isNaN(seq.getZ(i)))
-          outputOrdinates.add(Ordinate.Z);
-      }
-
-      if (checkOrdinateFlags.contains(Ordinate.M) && !outputOrdinates.contains(Ordinate.M)) {
-        if (!Double.isNaN(seq.getM(i)))
-          outputOrdinates.add(Ordinate.M);
-      }
-    }
-
-    /** @see org.locationtech.jts.geom.CoordinateSequenceFilter#isGeometryChanged */
-    public boolean isGeometryChanged() {
-      return false;
-    }
-
-    /** @see org.locationtech.jts.geom.CoordinateSequenceFilter#isDone */
-    public boolean isDone() {
-      return outputOrdinates.equals(checkOrdinateFlags);
-    }
-
-    /**
-     * Gets the evaluated ordinate bit-pattern
-     *
-     * @return A bit-pattern of ordinates with valid values masked by {@link #checkOrdinateFlags}.
-     */
-    EnumSet<Ordinate> getOutputOrdinates() {
-      return outputOrdinates;
-    }
   }
 
   private EnumSet<Ordinate> outputOrdinates;

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKBWriterTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKBWriterTest.java
@@ -127,24 +127,33 @@ public class WKBWriterTest extends GeometryTestCase {
         4326,
         "0107000020E61000000900000001010000000000000000000000000000000000F03F01010000000000000000000000000000000000F03F01010000000000000000000040000000000000084001020000000200000000000000000000400000000000000840000000000000104000000000000014400102000000020000000000000000000000000000000000F03F000000000000004000000000000008400102000000020000000000000000001040000000000000144000000000000018400000000000001C4001030000000200000005000000000000000000000000000000000000000000000000000000000000000000244000000000000024400000000000002440000000000000244000000000000000000000000000000000000000000000000005000000000000000000F03F000000000000F03F000000000000F03F0000000000002240000000000000224000000000000022400000000000002240000000000000F03F000000000000F03F000000000000F03F01030000000200000005000000000000000000000000000000000000000000000000000000000000000000244000000000000024400000000000002440000000000000244000000000000000000000000000000000000000000000000005000000000000000000F03F000000000000F03F000000000000F03F0000000000002240000000000000224000000000000022400000000000002240000000000000F03F000000000000F03F000000000000F03F0103000000010000000500000000000000000022C0000000000000000000000000000022C00000000000002440000000000000F0BF0000000000002440000000000000F0BF000000000000000000000000000022C00000000000000000");
   }
+
+  public void testWkbLineStringM() {
+    checkWKB(
+        "LINESTRING M(1 2 3, 5 6 7)",
+        4,
+        ByteOrderValues.LITTLE_ENDIAN,
+        -1,
+        "010200004002000000000000000000F03F00000000000000400000000000000840000000000000144000000000000018400000000000001C40");
+  }
   
   public void testWkbLineStringZM() throws ParseException {
       LineString lineZM = new GeometryFactory().createLineString(new Coordinate[]{new CoordinateXYZM(1,2,3,4), new CoordinateXYZM(5,6,7,8)});
       byte[] write = new WKBWriter(4).write(lineZM);
 
-      LineString deserialisiert = (LineString) new WKBReader().read(write);
+      LineString lineZMRead = (LineString) new WKBReader().read(write);
 
-      assertEquals(lineZM, deserialisiert);
-      
-      assertEquals(1.0, lineZM.getPointN(0).getCoordinate().getX());
-      assertEquals(2.0, lineZM.getPointN(0).getCoordinate().getY());
-      assertEquals(3.0, lineZM.getPointN(0).getCoordinate().getZ());
-      assertEquals(4.0, lineZM.getPointN(0).getCoordinate().getM());
-      
-      assertEquals(5.0, lineZM.getPointN(1).getCoordinate().getX());
-      assertEquals(6.0, lineZM.getPointN(1).getCoordinate().getY());
-      assertEquals(7.0, lineZM.getPointN(1).getCoordinate().getZ());
-      assertEquals(8.0, lineZM.getPointN(1).getCoordinate().getM());
+      assertEquals(lineZM, lineZMRead);
+
+      assertEquals(1.0, lineZMRead.getPointN(0).getCoordinate().getX());
+      assertEquals(2.0, lineZMRead.getPointN(0).getCoordinate().getY());
+      assertEquals(3.0, lineZMRead.getPointN(0).getCoordinate().getZ());
+      assertEquals(4.0, lineZMRead.getPointN(0).getCoordinate().getM());
+
+      assertEquals(5.0, lineZMRead.getPointN(1).getCoordinate().getX());
+      assertEquals(6.0, lineZMRead.getPointN(1).getCoordinate().getY());
+      assertEquals(7.0, lineZMRead.getPointN(1).getCoordinate().getZ());
+      assertEquals(8.0, lineZMRead.getPointN(1).getCoordinate().getM());
   }
 
   void checkWKB(String wkt, int dimension, String expectedWKBHex) {


### PR DESCRIPTION
Fixes https://github.com/locationtech/jts/issues/733

Please note that we must specify `outputDimension = 4` when writing geometries with M dimension, even when the geometry is XYM instead of XYZM. This behavior is the same as WKTWriter.