### PR TITLE
Fix TopologyPreservingSimplifier to avoid jumping components

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/simplify/TaggedLineString.java
@@ -60,7 +60,21 @@ class TaggedLineString
     return parentLine.getNumPoints();
   }
   
+  /**
+   * Returns a vertex of the component,
+   * in either simplified or original form.
+   * Once the component is simplified a vertex of the simplified linework
+   * must be returned. 
+   * Otherwise the simplified linework could be jumped by a flattened line
+   * which does not cross an original vertex, and so is reported as valid.
+   * 
+   * @return a component vertex
+   */
   public Coordinate getComponentPoint() {
+    //-- simplified vertex
+    if (resultSegs.size() > 0) 
+      return resultSegs.get(0).p0;
+    //-- original vertex
     return getParentCoordinates()[1];
   }
   

--- a/modules/core/src/test/java/org/locationtech/jts/simplify/TopologyPreservingSimplifierTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/simplify/TopologyPreservingSimplifierTest.java
@@ -249,8 +249,7 @@ public class TopologyPreservingSimplifierTest
     Geometry geom = read(wkt);
     Geometry actual = TopologyPreservingSimplifier.simplify(geom, tolerance);
     Geometry expected = read(wktExpected);
-    //TODO: add this once the "skipping over rings" problem is fixed
-    //checkValid(actual);
+    checkValid(actual);
     checkEqual(expected, actual);
   }
   


### PR DESCRIPTION
Fix `TaggedLineString` to return a valid component point for simplified lines. This fixes some cases which can cause `TopologyPreservingSimplifier` to "jump" components and create invalid geometry.

No unit tests are provided, since it has not been possible to create a simple reproducer.  The issue was seen in test case 19 from https://github.com/libgeos/geos/issues/1180.  If this is simplified with tolerance 0.01 a hole is left outside the simplified shell.

[network-as-polygon-edgecase-19.txt](https://github.com/user-attachments/files/17639094/network-as-polygon-edgecase-19.txt)
<img width="606" alt="image" src="https://github.com/user-attachments/assets/e6fe27bd-f2ca-4c18-b437-a4db898cebdd">

One thing preventing creating a simple test case is that `TopologyPreservingSimplifier` is non-deterministic in the order of simplifying rings.  It would be good to change to a deterministic evaluation order, to allow simpler test cases and provide consistency across JTS derivatives such as GEOS.