### PR TITLE
Fix OffsetCurve to support mitre joins for polygons

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
@@ -208,25 +208,35 @@ public class OffsetCurve {
       public Geometry map(Geometry geom) {
         if (geom instanceof Point) return null;
         if (geom instanceof Polygon ) {
-          return toLineString(geom.buffer(distance).getBoundary());
+          return computePolygonCurve((Polygon) geom, distance);
         } 
         return computeCurve((LineString) geom, distance);
       }
-
-      /**
-       * Force LinearRings to be LineStrings.
-       * 
-       * @param geom a geometry which may be a LinearRing
-       * @return a geometry which will be a LineString or MultiLineString
-       */
-      private Geometry toLineString(Geometry geom) {
-        if (geom instanceof LinearRing) {
-          LinearRing ring = (LinearRing) geom;
-          return geom.getFactory().createLineString(ring.getCoordinateSequence());
-        }
-        return geom;
-      }
     });
+  }
+  
+  private Geometry computePolygonCurve(Polygon poly, double distance) {
+    Geometry buffer;
+    if (bufferParams == null)
+      buffer = BufferOp.bufferOp(poly, distance);
+    else {
+      buffer = BufferOp.bufferOp(poly, distance, bufferParams);
+    }
+    return toLineString(buffer.getBoundary());
+  }
+  
+  /**
+   * Force LinearRings to be LineStrings.
+   * 
+   * @param geom a linear geometry which may be a LinearRing
+   * @return a geometry which if linear is a LineString or MultiLineString
+   */
+  private static Geometry toLineString(Geometry geom) {
+    if (geom instanceof LinearRing) {
+      LinearRing ring = (LinearRing) geom;
+      return geom.getFactory().createLineString(ring.getCoordinateSequence());
+    }
+    return geom;
   }
   
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -382,6 +382,21 @@ public class OffsetCurveTest extends GeometryTestCase {
     );
   }
   
+  public void testPolygonMitreJoin() {
+    checkOffsetCurve(
+        "POLYGON ((1 1, 1 7, 5 4, 8 8, 8 1, 1 1))", 
+        1, 0, BufferParameters.JOIN_MITRE, 5,
+        "LINESTRING (0 0, 0 9, 4.8 5.4, 9 11, 9 0, 0 0)",
+        0.0001
+    );
+    checkOffsetCurve(
+        "POLYGON ((1 1, 1 7, 5 4, 8 8, 8 1, 1 1))", 
+        -1, 0, BufferParameters.JOIN_MITRE, 5,
+        "LINESTRING (2 2, 2 5, 5.2 2.6, 7 5, 7 2, 2 2)",
+        0.0001
+    );
+
+  }
   //=======================================
   
   private static final double EQUALS_TOL = 0.05;


### PR DESCRIPTION
Fixes `OffsetCurve` to support mitre joins for polygons, when using `BufferParameters`.

<img width="372" alt="image" src="https://github.com/user-attachments/assets/b3227aee-6854-4a90-8550-2c9846a2d90f" />
 