### PR TITLE
Add faster MathUtil.hypot function

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/ui/style/AWTUtil.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/ui/style/AWTUtil.java
@@ -17,6 +17,8 @@ import java.awt.Graphics2D;
 import java.awt.Stroke;
 import java.awt.geom.Point2D;
 
+import org.locationtech.jts.math.MathUtil;
+
 public class AWTUtil 
 {
 
@@ -35,7 +37,7 @@ public class AWTUtil
   public static Point2D vector(Point2D a, Point2D b, double size) {
     double dx = b.getX() - a.getX();
     double dy = b.getY() - a.getY();
-    double len = Math.hypot(dx, dy);
+    double len = MathUtil.hypot(dx, dy);
     return new Point2D.Double(size * dx/len, size * dy/len);
   }
 

--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/ui/style/ArrowSegmentStyle.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/ui/style/ArrowSegmentStyle.java
@@ -20,6 +20,7 @@ import java.awt.geom.GeneralPath;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Point2D;
 
+import org.locationtech.jts.math.MathUtil;
 import org.locationtech.jtstest.testbuilder.ui.Viewport;
 
 
@@ -101,7 +102,7 @@ public class ArrowSegmentStyle
     double dx = p1.getX() - p0.getX();
     double dy = p1.getY() - p0.getY();
 
-    double len = Math.hypot(dx, dy);
+    double len = MathUtil.hypot(dx, dy);
     
     double vy = dy / len;
     double vx = dx / len;
@@ -162,7 +163,7 @@ public class ArrowSegmentStyle
     double dx = p1.getX() - origin.getX();
     double dy = p1.getY() - origin.getY();
     
-    double vlen = Math.hypot(dx, dy);
+    double vlen = MathUtil.hypot(dx, dy);
     
     if (vlen <= 0) return null;
     
@@ -206,7 +207,7 @@ public class ArrowSegmentStyle
     double dx = p1.getX() - p0.getX();
     double dy = p1.getY() - p0.getY();
     
-    double len = Math.hypot(dx, dy);
+    double len = MathUtil.hypot(dx, dy);
     
     return len < minLen;
   }

--- a/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/ui/style/DataLabelStyle.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/testbuilder/ui/style/DataLabelStyle.java
@@ -23,6 +23,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineSegment;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.math.MathUtil;
 import org.locationtech.jtstest.testbuilder.geom.ConstrainedInteriorPoint;
 import org.locationtech.jtstest.testbuilder.ui.GraphicsUtil;
 import org.locationtech.jtstest.testbuilder.ui.Viewport;
@@ -103,7 +104,7 @@ public class DataLabelStyle implements Style
     double offsetLen = 15;
     double nudgeX = 5;
     
-    double dirVecLen = Math.hypot(dx, dy);
+    double dirVecLen = MathUtil.hypot(dx, dy);
     
     double offsetX = offsetLen * dx / dirVecLen;
     double offsetY = offsetLen * dy / dirVecLen;

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/CGAlgorithms.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/CGAlgorithms.java
@@ -605,7 +605,7 @@ public class CGAlgorithms
       double dx = x1 - x0;
       double dy = y1 - y0;
 
-      len += Math.hypot(dx, dy);
+      len += MathUtil.hypot(dx, dy);
 
       x0 = x1;
       y0 = y1;

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/Length.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/Length.java
@@ -13,6 +13,7 @@ package org.locationtech.jts.algorithm;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.math.MathUtil;
 
 /**
  * Functions for computing length.
@@ -49,7 +50,7 @@ public class Length {
       double dx = x1 - x0;
       double dy = y1 - y0;
   
-      len += Math.hypot(dx, dy);
+      len += MathUtil.hypot(dx, dy);
   
       x0 = x1;
       y0 = y1;

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/LineIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/LineIntersector.java
@@ -17,6 +17,7 @@ package org.locationtech.jts.algorithm;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.io.WKTWriter;
+import org.locationtech.jts.math.MathUtil;
 import org.locationtech.jts.util.Assert;
 
 /**
@@ -131,7 +132,7 @@ public abstract class LineIntersector
   {
     double dx = p.x - p1.x;
     double dy = p.y - p1.y;
-    double dist = Math.hypot(dx, dy);   // dummy value
+    double dist = MathUtil.hypot(dx, dy);   // dummy value
     Assert.isTrue(! (dist == 0.0 && ! p.equals(p1)), "Invalid distance calculation");
     return dist;
   }

--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumBoundingCircle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumBoundingCircle.java
@@ -17,6 +17,7 @@ import org.locationtech.jts.geom.CoordinateArrays;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Triangle;
+import org.locationtech.jts.math.MathUtil;
 import org.locationtech.jts.util.Assert;
 
 /**
@@ -367,7 +368,7 @@ public class MinimumBoundingCircle
 			double dx = p.x - P.x;
 			double dy = p.y - P.y;
 			if (dy < 0) dy = -dy;
-			double len = Math.hypot(dx, dy);
+			double len = MathUtil.hypot(dx, dy);
 			double sin = dy / len;
 			
 			if (sin < minSin) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Coordinate.java
@@ -14,6 +14,7 @@ package org.locationtech.jts.geom;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.locationtech.jts.math.MathUtil;
 import org.locationtech.jts.util.Assert;
 import org.locationtech.jts.util.NumberUtil;
 
@@ -435,7 +436,7 @@ public class Coordinate implements Comparable<Coordinate>, Cloneable, Serializab
   public double distance(Coordinate c) {
     double dx = x - c.x;
     double dy = y - c.y;
-    return Math.hypot(dx, dy);
+    return MathUtil.hypot(dx, dy);
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/geom/Envelope.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/Envelope.java
@@ -13,6 +13,8 @@ package org.locationtech.jts.geom;
 
 import java.io.Serializable;
 
+import org.locationtech.jts.math.MathUtil;
+
 /**
  *  Defines a rectangular region of the 2D coordinate plane.
  *  It is often used to represent the bounding box of a {@link Geometry},
@@ -303,7 +305,7 @@ public class Envelope
     }
     double w = getWidth();
     double h = getHeight();
-    return Math.hypot(w, h);
+    return MathUtil.hypot(w, h);
   }
   /**
    *  Returns the <code>Envelope</code>s minimum x-value. min x &gt; max x
@@ -780,7 +782,7 @@ public class Envelope
     // if either is zero, the envelopes overlap either vertically or horizontally
     if (dx == 0.0) return dy;
     if (dy == 0.0) return dx;
-    return Math.hypot(dx, dy);
+    return MathUtil.hypot(dx, dy);
   }
 
   public boolean equals(Object other) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -19,6 +19,7 @@ import org.locationtech.jts.algorithm.LineIntersector;
 import org.locationtech.jts.algorithm.Orientation;
 import org.locationtech.jts.algorithm.RobustLineIntersector;
 import org.locationtech.jts.io.WKTConstants;
+import org.locationtech.jts.math.MathUtil;
 
 
 /**
@@ -337,7 +338,7 @@ public class LineSegment
     
     double dx = p1.x - p0.x;
     double dy = p1.y - p0.y;
-    double len = Math.hypot(dx, dy);
+    double len = MathUtil.hypot(dx, dy);
     double ux = 0.0;
     double uy = 0.0;
     if (offsetDistance != 0.0) {

--- a/modules/core/src/main/java/org/locationtech/jts/geom/util/AffineTransformation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/util/AffineTransformation.java
@@ -16,6 +16,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFilter;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.math.MathUtil;
 import org.locationtech.jts.util.Assert;
 /**
  * Represents an affine transformation on the 2D Cartesian plane. 
@@ -494,7 +495,7 @@ public class AffineTransformation
     }
     double dx = x1 - x0;
     double dy = y1 - y0;
-    double d = Math.hypot(dx, dy);
+    double d = MathUtil.hypot(dx, dy);
     double sin = dy / d;
     double cos = dx / d;
     double cs2 = 2 * sin * cos;
@@ -525,7 +526,7 @@ public class AffineTransformation
     // rotate vector to positive x axis direction
     double dx = x1 - x0;
     double dy = y1 - y0;
-    double d = Math.hypot(dx, dy);
+    double d = MathUtil.hypot(dx, dy);
     double sin = dy / d;
     double cos = dx / d;
     rotate(-sin, cos);
@@ -576,7 +577,7 @@ public class AffineTransformation
     }
     
     // rotate vector to positive x axis direction
-    double d = Math.hypot(x, y);
+    double d = MathUtil.hypot(x, y);
     double sin = y / d;
     double cos = x / d;
     rotate(-sin, cos);

--- a/modules/core/src/main/java/org/locationtech/jts/index/strtree/EnvelopeDistance.java
+++ b/modules/core/src/main/java/org/locationtech/jts/index/strtree/EnvelopeDistance.java
@@ -12,6 +12,7 @@
 package org.locationtech.jts.index.strtree;
 
 import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.math.MathUtil;
 
 /**
  * Functions for computing distances between {@link Envelope}s.
@@ -44,7 +45,7 @@ public class EnvelopeDistance
   private static double distance(double x1, double y1, double x2, double y2) {
     double dx = x2 - x1;
     double dy = y2 - y1;
-    return Math.hypot(dx, dy);    
+    return MathUtil.hypot(dx, dy);    
   }
   
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/math/MathUtil.java
+++ b/modules/core/src/main/java/org/locationtech/jts/math/MathUtil.java
@@ -74,6 +74,21 @@ public class MathUtil
     return div * denom >= num ? div : div + 1;
   }
   
+  /**
+   * Computes the length of the vector (x,y).
+   * This is the length of the hypotenuse of 
+   * a right triangle with sides of length x and y.
+   * 
+   * This function is faster than the standard {@link Math.hypot} function.
+   * 
+   * @param x the x ordinate
+   * @param y the y ordinate
+   * @return the length of vector (x,y)
+   */
+  public static double hypot(double x, double y) {
+    return Math.sqrt(x * x +  y * y);
+  }
+  
   private static final double LOG_10 = Math.log(10);
   
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/math/Vector2D.java
+++ b/modules/core/src/main/java/org/locationtech/jts/math/Vector2D.java
@@ -148,7 +148,7 @@ public class Vector2D {
 	}
 
 	public double length() {
-		return Math.hypot(x, y);
+		return MathUtil.hypot(x, y);
 	}
 
 	public double lengthSquared() {
@@ -196,7 +196,7 @@ public class Vector2D {
   {
     double delx = v.x - x;
     double dely = v.y - y;
-    return Math.hypot(delx, dely);
+    return MathUtil.hypot(delx, dely);
   }
   
 	/**

--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetSegmentGenerator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetSegmentGenerator.java
@@ -21,6 +21,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineSegment;
 import org.locationtech.jts.geom.Position;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.math.MathUtil;
 
 /**
  * Generates segments which form an offset curve.
@@ -398,7 +399,7 @@ class OffsetSegmentGenerator
     int sideSign = side == Position.LEFT ? 1 : -1;
     double dx = seg.p1.x - seg.p0.x;
     double dy = seg.p1.y - seg.p0.y;
-    double len = Math.hypot(dx, dy);
+    double len = MathUtil.hypot(dx, dy);
     // u is the vector that is the length of the offset, in the direction of the segment
     double ux = sideSign * distance * dx / len;
     double uy = sideSign * distance * dy / len;

--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlay/validate/OffsetPointGenerator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlay/validate/OffsetPointGenerator.java
@@ -20,6 +20,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.util.LinearComponentExtracter;
+import org.locationtech.jts.math.MathUtil;
 
 /**
  * Generates points offset by a given distance 
@@ -95,7 +96,7 @@ public class OffsetPointGenerator
   {
     double dx = p1.x - p0.x;
     double dy = p1.y - p0.y;
-    double len = Math.hypot(dx, dy);
+    double len = MathUtil.hypot(dx, dy);
     // u is the vector that is the length of the offset, in the direction of the segment
     double ux = offsetDistance * dx / len;
     double uy = offsetDistance * dy / len;

--- a/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/Vertex.java
+++ b/modules/core/src/main/java/org/locationtech/jts/triangulate/quadedge/Vertex.java
@@ -16,6 +16,7 @@ package org.locationtech.jts.triangulate.quadedge;
 import org.locationtech.jts.algorithm.HCoordinate;
 import org.locationtech.jts.algorithm.NotRepresentableException;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.math.MathUtil;
 
 /**
  * Models a site (node) in a {@link QuadEdgeSubdivision}. 
@@ -161,7 +162,7 @@ public class Vertex
 
     /* magnitude of vector */
     double magn() {
-        return (Math.hypot(p.x, p.y));
+        return (MathUtil.hypot(p.x, p.y));
     }
 
     /* returns k X v (cross product). this is a vector perpendicular to v */

--- a/modules/lab/src/main/java/org/locationtech/jtslab/edgeray/EdgeRay.java
+++ b/modules/lab/src/main/java/org/locationtech/jtslab/edgeray/EdgeRay.java
@@ -12,6 +12,7 @@
 package org.locationtech.jtslab.edgeray;
 
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.math.MathUtil;
 
 class EdgeRay {
 
@@ -28,7 +29,7 @@ class EdgeRay {
 
     double dx = x1 - x0;
     double dy = y1 - y0;
-    double len = Math.hypot(dx, dy);
+    double len = MathUtil.hypot(dx, dy);
     
     double u0x = dx / len;
     double u0y = dy / len;
@@ -59,7 +60,7 @@ class EdgeRay {
 
     double dx = x1 - x0;
     double dy = y1 - y0;
-    double len = Math.hypot(dx, dy);
+    double len = MathUtil.hypot(dx, dy);
     
     if (len <= 0) return 0;
     


### PR DESCRIPTION
This PR adds a function `MathUtil.hypot` which is faster than the standard `Math.hypot` function.

This is a replacement for #923, since that change caused performance problems.

Fixes #1110

