### PR TITLE
Add auto-tolerance to MaximumInscribedCircle and LargestEmptyCircle

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircle.java
@@ -29,7 +29,8 @@ import org.locationtech.jts.operation.distance.IndexedFacetDistance;
 
 /**
  * Constructs the Maximum Inscribed Circle for a 
- * polygonal {@link Geometry}, up to a specified tolerance.
+ * polygonal {@link Geometry}, up to a specified tolerance
+ * (which can be specified or determined automatically).
  * The Maximum Inscribed Circle is determined by a point in the interior of the area 
  * which has the farthest distance from the area boundary,
  * along with a boundary point at that distance.
@@ -42,7 +43,6 @@ import org.locationtech.jts.operation.distance.IndexedFacetDistance;
  * The radius length of the Maximum Inscribed Circle is a 
  * measure of how "narrow" a polygon is. It is the 
  * distance at which the negative buffer becomes empty.
- * <p>
  * The class supports testing whether a polygon is "narrower"
  * than a specified distance via 
  * {@link #isRadiusWithin(Geometry, double)} or
@@ -53,7 +53,9 @@ import org.locationtech.jts.operation.distance.IndexedFacetDistance;
  * <p>
  * The class supports polygons with holes and multipolygons.
  * <p>
- * The implementation uses a successive-approximation technique
+ * For small polygons (currently triangles and convex quadrilaterals)
+ * the MIC is determined exactly.
+ * For other polygons the implementation uses a successive-approximation technique
  * over a grid of square cells covering the area geometry.
  * The grid is refined using a branch-and-bound algorithm. 
  * Point containment and distance are computed in a performant
@@ -77,6 +79,18 @@ public class MaximumInscribedCircle {
 
   /**
    * Computes the center point of the Maximum Inscribed Circle
+   * of a polygonal geometry.
+   * 
+   * @param polygonal a polygonal geometry
+   * @return the center point of the maximum inscribed circle
+   */
+  public static Point getCenter(Geometry polygonal) {
+    MaximumInscribedCircle mic = new MaximumInscribedCircle(polygonal);
+    return mic.getCenter();
+  }
+
+  /**
+   * Computes the center point of the Maximum Inscribed Circle
    * of a polygonal geometry, up to a given tolerance distance.
    * 
    * @param polygonal a polygonal geometry
@@ -88,6 +102,18 @@ public class MaximumInscribedCircle {
     return mic.getCenter();
   }
 
+  /**
+   * Computes a radius line of the Maximum Inscribed Circle
+   * of a polygonal geometry.
+   * 
+   * @param polygonal a polygonal geometry
+   * @return a 2-point line from the center to a point on the circle
+   */
+  public static LineString getRadiusLine(Geometry polygonal) {
+    MaximumInscribedCircle mic = new MaximumInscribedCircle(polygonal);
+    return mic.getRadiusLine();
+  }
+  
   /**
    * Computes a radius line of the Maximum Inscribed Circle
    * of a polygonal geometry, up to a given tolerance distance.
@@ -104,7 +130,7 @@ public class MaximumInscribedCircle {
   /**
    * Tests if the radius of the maximum inscribed circle 
    * is no longer than the specified distance.
-   * This method determines the distance tolerance automatically
+   * The approximation tolerance is determined automatically
    * as a fraction of the maxRadius value.
    * 
    * @param polygonal a polygonal geometry
@@ -114,27 +140,6 @@ public class MaximumInscribedCircle {
   public static boolean isRadiusWithin(Geometry polygonal, double maxRadius) {
     MaximumInscribedCircle mic = new MaximumInscribedCircle(polygonal, -1);
     return mic.isRadiusWithin(maxRadius);
-  }
-  
-  /**
-   * Computes the maximum number of iterations allowed.
-   * Uses a heuristic based on the size of the input geometry
-   * and the tolerance distance.
-   * A smaller tolerance distance allows more iterations.
-   * This is a rough heuristic, intended
-   * to prevent huge iterations for very thin geometries.
-   * 
-   * @param geom the input geometry
-   * @param toleranceDist the tolerance distance
-   * @return the maximum number of iterations allowed
-   */
-  static long computeMaximumIterations(Geometry geom, double toleranceDist) {
-    double diam = geom.getEnvelopeInternal().getDiameter();
-    double ncells = diam / toleranceDist;
-    //-- Using log of ncells allows control over number of iterations
-    int factor = (int) Math.log(ncells);
-    if (factor < 1) factor = 1;
-    return 2000 + 2000 * factor;
   }
   
   private Geometry inputGeom;
@@ -154,8 +159,20 @@ public class MaximumInscribedCircle {
    * Creates a new instance of a Maximum Inscribed Circle computation.
    * 
    * @param polygonal an areal geometry
-   * @param tolerance the distance tolerance for computing the centre point (must be positive)
-   * @throws IllegalArgumentException if the tolerance is non-positive, or the input geometry is non-polygonal or empty.
+   * @throws IllegalArgumentException if the tolerance is negative, or the input geometry is non-polygonal or empty.
+   */
+  public MaximumInscribedCircle(Geometry polygonal) {
+    this(polygonal, 0.0);
+  }
+
+  /**
+   * Creates a new instance of a Maximum Inscribed Circle computation,
+   * with an approximation tolerance distance.
+   * A zero tolerance aut0matically determines an approximation tolerance.
+   * 
+   * @param polygonal an areal geometry
+   * @param tolerance the distance tolerance for computing the centre point (must be non-negative)
+   * @throws IllegalArgumentException if the tolerance is negative, or the input geometry is non-polygonal or empty.
    */
   public MaximumInscribedCircle(Geometry polygonal, double tolerance) {
     if (! (polygonal instanceof Polygon || polygonal instanceof MultiPolygon)) {
@@ -170,8 +187,9 @@ public class MaximumInscribedCircle {
     this.tolerance = tolerance;
   }
 
+  //-- used for isRadiusWithin
   private static final double MAX_RADIUS_FRACTION = 0.0001;
-
+  
   /**
    * Tests if the radius of the maximum inscribed circle 
    * is no longer than the specified distance.
@@ -291,10 +309,6 @@ public class MaximumInscribedCircle {
       return;
     }
     
-    //-- only needed for approximation
-    if (tolerance <= 0) {
-      throw new IllegalArgumentException("Tolerance must be positive");
-    }
     computeApproximation();
   }
 
@@ -305,7 +319,14 @@ public class MaximumInscribedCircle {
     radiusPoint = factory.createPoint(radiusPt);
   }
 
+  //-- empirically determined to balance accuracy and speed
+  private static final double AUTO_TOLERANCE_FRACTION = 0.001;
+  
   private void computeApproximation() {  
+    if (tolerance < 0) {
+      throw new IllegalArgumentException("Tolerance must be non-negative");
+    }
+    
     ptLocater = new IndexedPointInAreaLocator(inputGeom);
     indexedDistance = new IndexedFacetDistance( inputGeom.getBoundary() );
     
@@ -333,16 +354,12 @@ public class MaximumInscribedCircle {
       //System.out.println(iter + "] Dist: " + cell.getDistance() + " Max D: " + cell.getMaxDistance() + " size: " + cell.getHSide());
       //TestBuilderProxy.showIndicator(inputGeom.getFactory().toGeometry(cell.getEnvelope()));
       
-      //-- if cell must be closer than farthest, terminate since all remaining cells in queue are even closer. 
-      if (cell.getMaxDistance() < farthestCell.getDistance())
-        break;
-      
       // update the circle center cell if the candidate is further from the boundary
       if (cell.getDistance() > farthestCell.getDistance()) {
         farthestCell = cell;
       }
       
-      //-- search termination when checking max radius predicate
+      //-- search termination when checking isRadiusWithin predicate
       if (maximumRadius >= 0) {
         //-- found a inside point further than max radius
         if (farthestCell.getDistance() > maximumRadius)
@@ -356,21 +373,33 @@ public class MaximumInscribedCircle {
        * Refine this cell if the potential distance improvement
        * is greater than the required tolerance.
        * Otherwise the cell is pruned (not investigated further),
-       * since no point in it is further than
-       * the current farthest distance.
+       * since no point in it is further than 
+       * the current farthest distance (up to tolerance).
+       * 
+       * The tolerance can be automatically determined 
+       * as a fraction of the current farthest distance.
+       * For a very small actual MIC distance this may cause many iterations, 
+       * but the iter limit prevents an infinite loop
        */
+      double requiredTol = tolerance > 0 
+          ? tolerance
+          : farthestCell.getDistance() * AUTO_TOLERANCE_FRACTION;
+
       double potentialIncrease = cell.getMaxDistance() - farthestCell.getDistance();
-      if (potentialIncrease > tolerance) {
-        // split the cell into four sub-cells
-        double h2 = cell.getHSide() / 2;
-        cellQueue.add( createCell( cell.getX() - h2, cell.getY() - h2, h2));
-        cellQueue.add( createCell( cell.getX() + h2, cell.getY() - h2, h2));
-        cellQueue.add( createCell( cell.getX() - h2, cell.getY() + h2, h2));
-        cellQueue.add( createCell( cell.getX() + h2, cell.getY() + h2, h2));
-        //totalCells += 4;
-      }
+      if (potentialIncrease < requiredTol)
+        break;
+      
+      // refine the cell into four sub-cells
+      double h2 = cell.getHSide() / 2;
+      cellQueue.add( createCell( cell.getX() - h2, cell.getY() - h2, h2));
+      cellQueue.add( createCell( cell.getX() + h2, cell.getY() - h2, h2));
+      cellQueue.add( createCell( cell.getX() - h2, cell.getY() + h2, h2));
+      cellQueue.add( createCell( cell.getX() + h2, cell.getY() + h2, h2));
+      //totalCells += 4;
     }
-    // the farthest cell is the best approximation to the MIC center
+    //System.out.println("Iter: " + iter);
+    
+    //-- the farthest cell is the best approximation to the MIC center
     centerCell = farthestCell;
     centerPt = new Coordinate(centerCell.getX(), centerCell.getY());
     centerPoint = factory.createPoint(centerPt);
@@ -380,6 +409,28 @@ public class MaximumInscribedCircle {
     radiusPoint = factory.createPoint(radiusPt);
   }
 
+  /**
+   * Computes the maximum number of iterations allowed.
+   * Uses a heuristic based on the size of the input geometry
+   * and the tolerance distance.
+   * A smaller tolerance distance allows more iterations.
+   * This is a rough heuristic, intended
+   * to prevent huge iterations for very thin geometries.
+   * 
+   * @param geom the input geometry
+   * @param toleranceDist the tolerance distance
+   * @return the maximum number of iterations allowed
+   */
+  static long computeMaximumIterations(Geometry geom, double toleranceDist) {
+    double diam = geom.getEnvelopeInternal().getDiameter();
+    double tolDist = toleranceDist <= 0 ? 0.5 * diam * AUTO_TOLERANCE_FRACTION : toleranceDist;
+    double ncells = diam / tolDist;
+    //-- Using log of ncells allows control over number of iterations
+    int factor = (int) Math.log(ncells);
+    if (factor < 1) factor = 1;
+    return 2000 + 2000 * factor;
+  }
+  
   /**
    * Initializes the queue with a cell covering 
    * the extent of the area.
@@ -406,7 +457,8 @@ public class MaximumInscribedCircle {
   // create a cell at an interior point
   private Cell createInterorPointCell(Geometry geom) {
     Point p = geom.getInteriorPoint();
-    return new Cell(p.getX(), p.getY(), 0, distanceToBoundary(p));
+    double hSide = geom.getEnvelopeInternal().getDiameter();
+    return new Cell(p.getX(), p.getY(), hSide, distanceToBoundary(p));
   }
 
   /**

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/LargestEmptyCircleTest.java
@@ -50,13 +50,15 @@ public class LargestEmptyCircleTest extends GeometryTestCase {
   }
 
   public void testLinesZigzag() {
-    checkCircle("MULTILINESTRING ((100 100, 200 150, 100 200, 250 250, 100 300, 300 350, 100 400), (70 380, 0 350, 50 300, 0 250, 50 200, 0 150, 50 120))", 
-       0.01, 77.52, 249.99, 54.81 );
+    String wkt = "MULTILINESTRING ((100 100, 200 150, 100 200, 250 250, 100 300, 300 350, 100 400), (70 380, 0 350, 50 300, 0 250, 50 200, 0 150, 50 120))";
+    checkCircle(wkt, 0.01, 77.52, 249.99, 54.81 );
+    checkCircleAutoTol(wkt, 0.1, 77.5255128974095, 250, 54.81881578 );
   }
 
   public void testLinePointTriangle() {
-    checkCircle("GEOMETRYCOLLECTION (LINESTRING (100 100, 300 100), POINT (250 200))", 
-       0.01, 196.49, 164.31, 64.31 );
+    String wkt = "GEOMETRYCOLLECTION (LINESTRING (100 100, 300 100), POINT (250 200))";
+    checkCircle(wkt, 0.01, 196.49, 164.31, 64.31 );
+    checkCircleAutoTol(wkt, 0.1, 196.49, 164.31, 64.31 );
   }
 
   public void testLineFlat() {
@@ -146,17 +148,28 @@ public class LargestEmptyCircleTest extends GeometryTestCase {
   
   private void checkCircle(String wktObstacles, double tolerance, 
       double x, double y, double expectedRadius) {
-    checkCircle(read(wktObstacles), null, tolerance, x, y, expectedRadius);
+    Geometry obstacles = read(wktObstacles);
+    LargestEmptyCircle lec = new LargestEmptyCircle(obstacles, null, tolerance); 
+    checkCircle(lec, tolerance, x, y, expectedRadius);
+  }
+  
+  private void checkCircleAutoTol(String wktObstacles, double tolerance, 
+      double x, double y, double expectedRadius) {
+    Geometry obstacles = read(wktObstacles);
+    LargestEmptyCircle lec = new LargestEmptyCircle(obstacles, null); 
+    checkCircle(lec, tolerance, x, y, expectedRadius);
   }
   
   private void checkCircle(String wktObstacles, String wktBoundary, double tolerance, 
       double x, double y, double expectedRadius) {
-    checkCircle(read(wktObstacles), read(wktBoundary), tolerance, x, y, expectedRadius);
+    Geometry obstacles = read(wktObstacles);
+    Geometry boundary = read(wktBoundary);
+    LargestEmptyCircle lec = new LargestEmptyCircle(obstacles, boundary, tolerance); 
+    checkCircle(lec, tolerance, x, y, expectedRadius);
   }
   
-  private void checkCircle(Geometry obstacles, Geometry boundary, double tolerance, 
+  private void checkCircle(LargestEmptyCircle lec, double tolerance, 
       double x, double y, double expectedRadius) {
-    LargestEmptyCircle lec = new LargestEmptyCircle(obstacles, boundary, tolerance); 
     Geometry centerPoint = lec.getCenter();
     Coordinate centerPt = centerPoint.getCoordinate();
     Coordinate expectedCenter = new Coordinate(x, y);

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircleTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/construct/MaximumInscribedCircleTest.java
@@ -63,13 +63,15 @@ public class MaximumInscribedCircleTest extends GeometryTestCase {
   }
 
   public void testKiteWithHole() {
-    checkCircle("POLYGON ((100 0, 200 200, 300 200, 300 100, 100 0), (200 150, 200 100, 260 100, 200 150))", 
-       0.01, 257.47, 157.47, 42.52 );
+    String wkt = "POLYGON ((100 0, 200 200, 300 200, 300 100, 100 0), (200 150, 200 100, 260 100, 200 150))";
+    checkCircle(wkt, 0.01, 257.47, 157.47, 42.529 );
+    checkCircleAutoTol(wkt, 0.001, 257.47, 157.47, 42.529 );
   }
 
   public void testDoubleKite() {
-    checkCircle("MULTIPOLYGON (((150 200, 100 150, 150 100, 250 150, 150 200)), ((400 250, 300 150, 400 50, 560 150, 400 250)))", 
-       0.01, 411.38, 149.99, 78.75 );
+    String wkt = "MULTIPOLYGON (((150 200, 100 150, 150 100, 250 150, 150 200)), ((400 250, 300 150, 400 50, 560 150, 400 250)))";
+    checkCircle(wkt, 0.01, 411.38, 149.99, 78.75 );
+    checkCircleAutoTol(wkt, 0.001, 411.392, 149.971, 78.7378 );
   }
 
   /**
@@ -138,21 +140,36 @@ public class MaximumInscribedCircleTest extends GeometryTestCase {
     checkCircle(read(wkt), tolerance, x, y, expectedRadius);
   }
   
+  private void checkCircleAutoTol(String wkt, double tolerance, 
+      double x, double y, double expectedRadius) {
+    checkCircleAutoTol(read(wkt), tolerance, x, y, expectedRadius);
+  }
+  
   private void checkCircle(Geometry geom, double tolerance, 
       double x, double y, double expectedRadius) {
     MaximumInscribedCircle mic = new MaximumInscribedCircle(geom, tolerance); 
+    checkMIC(mic, tolerance, x, y, expectedRadius);
+  }
+
+  private void checkCircleAutoTol(Geometry geom, double tolerance, 
+      double x, double y, double expectedRadius) {
+    MaximumInscribedCircle mic = new MaximumInscribedCircle(geom); 
+    checkMIC(mic, tolerance, x, y, expectedRadius);
+  }
+
+  private void checkMIC(MaximumInscribedCircle mic, double tolerance, double x, double y, double expectedRadius) {
     Geometry centerPoint = mic.getCenter();
+    LineString radiusLine = mic.getRadiusLine();
+    Coordinate radiusPt = mic.getRadiusPoint().getCoordinate();
+    
     Coordinate centerPt = centerPoint.getCoordinate();
     Coordinate expectedCenter = new Coordinate(x, y);
     checkEqualXY(expectedCenter, centerPt, 2 * tolerance);
     
-    LineString radiusLine = mic.getRadiusLine();
     double actualRadius = radiusLine.getLength();
     assertEquals("Radius: ", expectedRadius, actualRadius, 2 * tolerance);
     
     checkEqualXY("Radius line center point: ", centerPt, radiusLine.getCoordinateN(0));
-    Coordinate radiusPt = mic.getRadiusPoint().getCoordinate();
     checkEqualXY("Radius line endpoint point: ", radiusPt, radiusLine.getCoordinateN(1));
-
   }
 }


### PR DESCRIPTION
This PR enhances `MaximumInscribedCircle` and `LargestEmptyCircle` to support automatically determining a reasonable tolerance value for computing the circle centre.  

In order to accommodate widely-varying shapes the tolerance is refined as the radius approximation is determined.  This is more likely to be accurate than a manually-provided accuracy tolerance distance, especially if the same tolerance is used for geometries of varying extent and shape.

<img width="389" alt="image" src="https://github.com/user-attachments/assets/d9723353-3812-4570-b47f-c668ba344484" />
<img width="379" alt="image" src="https://github.com/user-attachments/assets/aa09c759-9e7e-49d2-ab2a-772db2d73c22" />

