### PR TITLE
Fix BoundaryChainNoder to split chains at self-touch nodes

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/noding/BasicSegmentString.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/BasicSegmentString.java
@@ -29,6 +29,15 @@ import org.locationtech.jts.io.WKTWriter;
 public class BasicSegmentString
 	implements SegmentString 
 {
+  public static BasicSegmentString substring(SegmentString segString, int start, int end) {
+    Coordinate[] pts = new Coordinate[end - start + 1];
+    int ipts = 0;
+    for (int i = start; i < end + 1; i++) {
+      pts[ipts++] = segString.getCoordinate(i).copy();
+    }
+    return new BasicSegmentString(pts, segString.getData());
+  }
+  
   private Coordinate[] pts;
   private Object data;
 

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageUnionTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageUnionTest.java
@@ -40,6 +40,27 @@ public class CoverageUnionTest extends GeometryTestCase
             );
   }
 
+  public void testHoleTouchingSide() {
+    checkUnion(
+        "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 5 3, 9 6, 9 1, 1 1)))",
+        "POLYGON ((9 6, 9 1, 1 1, 1 9, 9 9, 9 6), (9 6, 2 6, 5 3, 9 6))"
+            );
+  }
+  
+  public void testHolesTouchingSide() {
+    checkUnion(
+        "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 9 6, 9 1, 1 1)))",
+        "POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 9 6, 5 7), (2 6, 4 3, 5 7, 2 6))"
+            );
+  }
+  
+  public void testHolesTouching() {
+    checkUnion(
+        "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 7 7, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 7 7, 9 6, 9 1, 1 1)))",
+        "POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 7 7, 5 7), (2 6, 4 3, 5 7, 2 6))"
+            );
+  }
+  
   private void checkUnion(String wktCoverage, String wktExpected) {
     Geometry covGeom = read(wktCoverage);
     Geometry[] coverage = toArray(covGeom);

--- a/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/CoverageUnionTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/CoverageUnionTest.java
@@ -30,9 +30,25 @@ public class CoverageUnionTest extends GeometryTestCase
         "MULTIPOLYGON (((1 9, 6 9, 9 9, 9 1, 6 1, 1 1, 1 9), (2 8, 2 2, 6 2, 8 2, 8 8, 6 8, 2 8)), ((5 3, 3 3, 3 7, 5 7, 7 7, 7 3, 5 3), (5 4, 6 4, 6 6, 5 6, 4 6, 4 4, 5 4)))");
   }
 
-  public void testPolygonsNested( ) {
-    checkUnion("GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (3 7, 3 3, 7 3, 7 7, 3 7)), POLYGON ((3 7, 7 7, 7 3, 3 3, 3 7)))",
-        "POLYGON ((1 1, 1 9, 9 9, 9 1, 1 1))");
+  public void testHoleTouchingSide() {
+    checkUnion(
+        "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 5 3, 9 6, 9 1, 1 1)))",
+        "POLYGON ((9 6, 9 1, 1 1, 1 9, 9 9, 9 6), (9 6, 2 6, 5 3, 9 6))"
+            );
+  }
+  
+  public void testHolesTouchingSide() {
+    checkUnion(
+        "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 9 6, 9 1, 1 1)))",
+        "POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 9 6, 5 7), (2 6, 4 3, 5 7, 2 6))"
+            );
+  }
+  
+  public void testHolesTouching() {
+    checkUnion(
+        "GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 7 7, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 7 7, 9 6, 9 1, 1 1)))",
+        "POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 7 7, 5 7), (2 6, 4 3, 5 7, 2 6))"
+            );
   }
 
   public void testPolygonsFormingHole( ) {
@@ -45,6 +61,13 @@ public class CoverageUnionTest extends GeometryTestCase
         "POLYGON ((0 25, 0 50, 0 75, 0 100, 25 100, 50 100, 75 100, 100 100, 100 75, 100 50, 100 25, 100 0, 75 0, 50 0, 25 0, 0 0, 0 25))");
   }
 
+  public void testPolygonsNested( ) {
+    checkUnion("GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9), (3 7, 3 3, 7 3, 7 7, 3 7)), POLYGON ((3 7, 7 7, 7 3, 3 3, 3 7)))",
+        "POLYGON ((1 1, 1 9, 9 9, 9 1, 1 1))");
+  }
+
+  //------------------------------------------------------------
+  
   /**
    * Sequential lines are still noded
    */
@@ -69,6 +92,8 @@ public class CoverageUnionTest extends GeometryTestCase
         "MULTILINESTRING ((1 9, 3.1 8), (2 3, 4 3), (3.1 8, 5 7), (4 3, 5 3), (5 3, 5 7), (5 3, 7 4), (5 3, 8 1), (5 7, 7 8), (7 4, 9 5), (7 8, 9 9))");
   }
 
+  //=======================================================
+  
   private void checkUnion(String wkt, String wktExpected) {
     Geometry coverage = read(wkt);
     Geometry expected = read(wktExpected);


### PR DESCRIPTION
Fixes the `BoundaryChainNoder` to split chains at self-touch nodes.  This is required by `CoverageUnion` to produce correct OGC topology for inverted polygons and exverted holes.

For example, the coverage:
```
GEOMETRYCOLLECTION (POLYGON ((1 9, 9 9, 9 6, 5 7, 2 6, 1 9)), POLYGON ((1 1, 1 9, 2 6, 4 3, 5 7, 7 3, 9 6, 9 1, 1 1)))
```
produces a polygon with two holes:
```
POLYGON ((9 9, 9 6, 9 1, 1 1, 1 9, 9 9), (5 7, 7 3, 9 6, 5 7), (2 6, 4 3, 5 7, 2 6))
```
<img width="775" alt="image" src="https://github.com/user-attachments/assets/2d2b93f9-2f3a-46c8-b1c0-9239f955c031" />

Before this fix, the output would be an inverted polygon with a single self-touching ring.
