### PR TITLE
Make segintersector.isDone() default to false

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/noding/SegmentIntersector.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/SegmentIntersector.java
@@ -12,15 +12,27 @@
 package org.locationtech.jts.noding;
 
 /**
+ * <p>
  * Processes possible intersections detected by a {@link Noder}.
- * The {@link SegmentIntersector} is passed to a {@link Noder}.
- * The {@link SegmentIntersector#processIntersections(SegmentString, int, SegmentString, int)} method is called whenever the {@link Noder}
- * detects that two SegmentStrings <i>might</i> intersect.
- * This class may be used either to find all intersections, or
- * to detect the presence of an intersection.  In the latter case,
- * Noders may choose to short-circuit their computation by calling the
- * {@link #isDone()} method.
- * This class is an example of the <i>Strategy</i> pattern.
+ * </p>
+ * 
+ * <p>
+ * A {@code SegmentIntersector} is passed to a {@link Noder}, and its
+ * {@link #processIntersections(SegmentString, int, SegmentString, int)} method is called 
+ * whenever the {@code Noder} detects that two {@code SegmentString}s 
+ * <i>might</i> intersect.
+ * </p>
+ * 
+ * <p>
+ * This interface can be used either to find all intersections, or to 
+ * simply detect the presence of an intersection. If only detection is needed, 
+ * implementations may short-circuit further computation by returning {@code true} 
+ * from the {@link #isDone()} method.
+ * </p>
+ * 
+ * <p>
+ * This class is an example of the <i>Strategy</i> design pattern.
+ * </p>
  *
  * @version 1.7
  */
@@ -37,10 +49,19 @@ public interface SegmentIntersector
      );
   
   /**
-   * Reports whether the client of this class
-   * needs to continue testing all intersections in an arrangement.
-   * 
-   * @return true if there is no need to continue testing segments
+   * Reports whether the client of this class needs to continue 
+   * testing all intersections in an arrangement.
+   * <p>
+   * By default, this method returns {@code false}, indicating that 
+   * all possible intersections will be processed.
+   * Override this method to return {@code true} if you want
+   * to short-circuit further processing (for example, once an intersection is found).
+   * </p>
+   *
+   * @return {@code true} if there is no need to continue testing segments; 
+   *         {@code false} to continue finding all intersections
    */
-  boolean isDone();
+  default boolean isDone() {
+	  return false;
+  }
 }


### PR DESCRIPTION
Give the SegmentIntersector interface's `isDone()` method a default value of false.

This way one can process all intersections cleanly with a lambda (rather than inner class that must implement both processIntersections() and isDone().

```
mci.process(segmentStringsB, (e0, segIndex0, e1, segIndex1) -> {
    sid.processIntersections(e0, segIndex0, e1, segIndex1);
    if (sid.hasIntersection()) {
    	// do
    }
});
```