### PR TITLE
Change CoverageUnion failure exception message

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/CoverageUnion.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/CoverageUnion.java
@@ -77,7 +77,12 @@ public class CoverageUnion
     }
     
     // a precision model is not needed since no noding is done
-    return OverlayNG.union(coverage, null, noder );
+    try {
+      return OverlayNG.union(coverage, null, noder );
+    } 
+    catch (TopologyException ex) {
+      throw new TopologyException("Input coverage is invalid due to incorrect noding");
+    }
   }
 
   private CoverageUnion() {

--- a/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageUnionTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/coverage/CoverageUnionTest.java
@@ -12,6 +12,7 @@
 package org.locationtech.jts.coverage;
 
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.TopologyException;
 
 import junit.textui.TestRunner;
 import test.jts.GeometryTestCase;
@@ -61,6 +62,24 @@ public class CoverageUnionTest extends GeometryTestCase
             );
   }
   
+  public void testInvalidNodingError() {
+    checkError(
+        "GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0)), POLYGON ((1 0, 0.9 1, 2 1, 2 0, 1 0)))" );
+  }
+  
+  private void checkError(String wktCoverage) {
+    Geometry covGeom = read(wktCoverage);
+    Geometry[] coverage = toArray(covGeom);
+    try {
+      Geometry actual = CoverageUnion.union(coverage);
+    }
+    catch (TopologyException ex) {
+      // executes with no error
+      return;
+    }
+    fail("No error thrown for invalid input coverage");
+  }
+
   private void checkUnion(String wktCoverage, String wktExpected) {
     Geometry covGeom = read(wktCoverage);
     Geometry[] coverage = toArray(covGeom);


### PR DESCRIPTION
Change `CoverageUnion` exception message to clarify that error is due to an invalid input coverage.

See discussion in https://github.com/libgeos/geos/pull/1279#discussion_r2256157484.
