### PR TITLE
Fix OffsetCurve simplifyFactor parameter handling

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/buffer/OffsetCurve.java
@@ -182,6 +182,7 @@ public class OffsetCurve {
       bufferParams.setQuadrantSegments(quadSegs);
       bufferParams.setJoinStyle(bufParams.getJoinStyle());
       bufferParams.setMitreLimit(bufParams.getMitreLimit());
+      bufferParams.setSimplifyFactor(bufParams.getSimplifyFactor());
     }
   }
   

--- a/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/buffer/OffsetCurveTest.java
@@ -397,6 +397,18 @@ public class OffsetCurveTest extends GeometryTestCase {
     );
 
   }
+  
+  //---------------------------------------
+  
+  // see https://github.com/locationtech/jts/issues/1147
+  public void testSimplifyFactor() {
+    checkOffsetCurveSimplify("LINESTRING (-74.10825983114643 205.2512862651522, -61.59032155710979 183.66416102497575, -56.17516937041343 177.39645645603244, -45.87664216572637 163.28009296700202, -32.80606824944878 140.06145723770865)", 
+        -70, 0.0001,
+        "LINESTRING (-134.66360133032907 170.13646580544648, -122.14566305629245 148.54934056527003, -114.55900733787851 137.9004382015626, -111.02744383471095 133.81287132602836, -104.85483126202604 125.3519680316891, -93.80502418590495 105.72303306503763)",
+        0.00001);
+  }
+
+
   //=======================================
   
   private static final double EQUALS_TOL = 0.05;
@@ -450,4 +462,16 @@ public class OffsetCurveTest extends GeometryTestCase {
     checkEqual(expected, result, tolerance);
   }
 
+  private void checkOffsetCurveSimplify(String wkt, 
+      double distance, double simplifyFactor,
+      String wktExpected, double tolerance) {
+    Geometry geom = read(wkt);
+    BufferParameters params = new BufferParameters();
+    params.setSimplifyFactor(simplifyFactor);
+    OffsetCurve oc = new OffsetCurve(geom, distance, params);
+    Geometry result =  oc.getCurve();
+    
+    Geometry expected = read(wktExpected);
+    checkEqual(expected, result, tolerance);
+  }
 }


### PR DESCRIPTION
Fixes `OffsetCurve` to read the `BufferParameters.simplifyFactor` value correctly.

Provides a solution for #1147.