### PR TITLE
GeoJsonWriter: allow calling create() method from subclasses

### DIFF
--- a/modules/io/common/src/main/java/org/locationtech/jts/io/geojson/GeoJsonWriter.java
+++ b/modules/io/common/src/main/java/org/locationtech/jts/io/geojson/GeoJsonWriter.java
@@ -133,7 +133,7 @@ public class GeoJsonWriter {
     writer.flush();
   }
 
-  private Map<String, Object> create(Geometry geometry, boolean encodeCRS) {
+  protected Map<String, Object> create(Geometry geometry, boolean encodeCRS) {
 
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put(GeoJsonConstants.NAME_TYPE, geometry.getGeometryType());


### PR DESCRIPTION
Allow building a JSON map object for a geometry, before writing it as a String. This allows subclasses to include the geometry JSON into other JSON objects.
As GeoJsonWriter is not declared final, subclassing seems to be a viable option. 

Note: As this is a trivial change, I'll directly file a PR without much hassle.