### PR TITLE
Add `WKTReader` support for `-Inf`

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTReader.java
@@ -80,7 +80,7 @@ import org.locationtech.jts.util.AssertionFailedException;
  * <li>The reader uses <tt>Double.parseDouble</tt> to perform the conversion of ASCII
  * numbers to floating point.  This means it supports the Java
  * syntax for floating point literals (including scientific notation).
- * <li><tt>NaN</tt> and <tt>Inf</tt> ordinate symbols are supported (case-insensitive), 
+ * <li><tt>NaN</tt>, <tt>Inf</tt> and <tt>-Inf</tt> ordinate symbols are supported (case-insensitive), 
  * which convert to the corresponding IEE-754 value
  * </ul>
  * <h3>Syntax</h3>
@@ -133,7 +133,7 @@ import org.locationtech.jts.util.AssertionFailedException;
  * <i>Coordinate:
  *         Number Number Number<sub>opt</sub> Number<sub>opt</sub></i>
  *
- * <i>Number:</i> A Java-style floating-point number (including <tt>NaN</tt> and <tt>Inf</tt>, with arbitrary case)
+ * <i>Number:</i> A Java-style floating-point number (including <tt>NaN</tt>, <tt>Inf</tt> and <tt>-Inf</tt>, case-independent)
  *
  * <i>Dimension:</i>
  *         <b>Z</b>|<b> Z</b>|<b>M</b>|<b> M</b>|<b>ZM</b>|<b> ZM</b>
@@ -163,6 +163,7 @@ import org.locationtech.jts.util.AssertionFailedException;
  * POINT ZM (0 0 0 0)
  * 
  * POINT (Inf Nan)
+ * POINT (Inf -Inf)
  * </pre>
  *
  *@version 1.7
@@ -175,6 +176,7 @@ public class WKTReader
   private static final String R_PAREN = ")";
   private static final String NAN_SYMBOL = "NaN";
   private static final String INF_SYMBOL = "Inf";
+  private static final String NEG_INF_SYMBOL = "-Inf";
 
   private GeometryFactory geometryFactory;
   private CoordinateSequenceFactory csFactory;
@@ -524,6 +526,9 @@ S  */
         }
         if (tokenizer.sval.equalsIgnoreCase(INF_SYMBOL)) {
           return Double.POSITIVE_INFINITY;
+        }
+        if (tokenizer.sval.equalsIgnoreCase(NEG_INF_SYMBOL)) {
+          return Double.NEGATIVE_INFINITY;
         }
         //TODO: handle -Inf ?
         else {

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReadWriteTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReadWriteTest.java
@@ -38,6 +38,11 @@ public class WKTReadWriteTest extends TestCase {
     assertEquals(pt, writer.write(reader.read("POINT (10 10 NAN)")));
   }
 
+  public void testReadInf() throws Exception {
+    final String pt = "POINT (Inf -Inf)";
+    assertEquals(pt, writer.write(reader.read("POINT (Inf -Inf)")));
+  }
+
   public void testReadPoint() throws Exception {
     assertEquals("POINT (10 10)", writer.write(reader.read("POINT (10 10)")));
     assertEquals("POINT EMPTY", writer.write(reader.read("POINT EMPTY")));

--- a/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/io/WKTReaderTest.java
@@ -465,10 +465,12 @@ public class WKTReaderTest extends GeometryTestCase {
   }
 
   public void testInf() throws ParseException {
-    Point pt = (Point) readerXY.read("POINT ( Inf INF )");
+    LineString pt = (LineString) readerXY.read("LINESTRING ( Inf -INF, -Inf inf )");
     CoordinateSequence cs = pt.getCoordinateSequence();
     assertEquals(Double.POSITIVE_INFINITY, cs.getOrdinate(0, Coordinate.X));
-    assertEquals(Double.POSITIVE_INFINITY, cs.getOrdinate(0, Coordinate.Y));
+    assertEquals(Double.NEGATIVE_INFINITY, cs.getOrdinate(0, Coordinate.Y));
+    assertEquals(Double.NEGATIVE_INFINITY, cs.getOrdinate(1, Coordinate.X));
+    assertEquals(Double.POSITIVE_INFINITY, cs.getOrdinate(1, Coordinate.Y));
   }
   
   public void testLargeNumbers() throws Exception {


### PR DESCRIPTION
Adds `WKTReader` support for `-Inf` ordinate values (case-insensitive).

A followup to #1166 

### Example
* `POINT (Inf -Inf)`