### PR TITLE
Fix CoordinateList.clone() to copy correctly

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateList.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateList.java
@@ -242,7 +242,7 @@ public class CoordinateList
   public Object clone() {
       CoordinateList clone = (CoordinateList) super.clone();
       for (int i = 0; i < this.size(); i++) {	  
-          clone.add(i, (Coordinate) this.get(i).clone());
+          clone.set(i, (Coordinate) this.get(i).clone());
       }
       return clone;
   }

--- a/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateListTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geom/CoordinateListTest.java
@@ -24,9 +24,16 @@ public class CoordinateListTest extends TestCase {
     checkValue(coordList().toCoordinateArray(false) );
   }
 
+  public void testClone() {
+    CoordinateList clone = (CoordinateList) coordList(0,0,1,1,2,2).clone();
+    checkValue(clone.toCoordinateArray(true), 0,0,1,1,2,2);    
+  }
+  
+  //======================================
+  
   private void checkValue(Coordinate[] coordArray, double ... ords) {
     
-    assertEquals( coordArray.length * 2, ords.length);
+    assertEquals( "list has wrong length", coordArray.length, ords.length / 2);
     
     for (int i = 0 ; i < coordArray.length; i += 2) {
       Coordinate pt = coordArray[i];


### PR DESCRIPTION
Fixes a bug in `CoordinateList.clone` which was duplicating the array instead of overwriting it.

Fixes #1163