### PR TITLE
Simplify FacetSequence implementation

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance/FacetSequence.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance/FacetSequence.java
@@ -16,12 +16,10 @@ import org.locationtech.jts.algorithm.Distance;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineSegment;
 
 /**
  * Represents a sequence of facets (points or line segments)
- * of a {@link Geometry}
  * specified by a subsequence of a {@link CoordinateSequence}.
  * 
  * @author Martin Davis
@@ -29,27 +27,9 @@ import org.locationtech.jts.geom.LineSegment;
  */
 public class FacetSequence
 {
-  private Geometry geom = null;
   private CoordinateSequence pts;
   private int start;
-  private int end;
-  
-  /**
-   * Creates a new sequence of facets based on a {@link CoordinateSequence}
-   * contained in the given {@link Geometry}.
-   * 
-   * @param geom the geometry containing the facets 
-   * @param pts the sequence containing the facet points
-   * @param start the index of the start point
-   * @param end the index of the end point + 1
-   */
-  public FacetSequence(Geometry geom, CoordinateSequence pts, int start, int end) 
-  {
-    this.geom = geom;
-    this.pts = pts;
-    this.start = start;
-    this.end = end;
-  } 
+  private int end; 
   
   /**
    * Creates a new sequence of facets based on a {@link CoordinateSequence}.
@@ -139,19 +119,19 @@ public class FacetSequence
    * and another sequence.
    * The locations are presented in the same order as the input sequences.
    *
-   * @return a pair of {@link GeometryLocation}s for the nearest points
+   * @return a pair of {@link Coordinate}s for the nearest points
    */
-  public GeometryLocation[] nearestLocations(FacetSequence facetSeq)
+  public Coordinate[] nearestLocations(FacetSequence facetSeq)
   {
     boolean isPoint = isPoint();
     boolean isPointOther = facetSeq.isPoint();
-    GeometryLocation[] locs = new GeometryLocation[2];
+    Coordinate[] locs = new Coordinate[2];
     
     if (isPoint && isPointOther) {
       Coordinate pt = pts.getCoordinate(start);
       Coordinate seqPt = facetSeq.pts.getCoordinate(facetSeq.start);
-      locs[0] = new  GeometryLocation(geom, start, new Coordinate(pt));
-      locs[1] = new  GeometryLocation(facetSeq.geom, facetSeq.start, new Coordinate(seqPt));
+      locs[0] = pt.copy();
+      locs[1] = seqPt.copy();
     }
     else if (isPoint) {
       Coordinate pt = pts.getCoordinate(start);      
@@ -161,7 +141,7 @@ public class FacetSequence
       Coordinate seqPt = facetSeq.pts.getCoordinate(facetSeq.start);
       computeDistancePointLine(seqPt, this, locs);
       // unflip the locations
-      GeometryLocation tmp = locs[0];
+      Coordinate tmp = locs[0];
       locs[0] = locs[1];
       locs[1] = tmp;
     }
@@ -171,7 +151,7 @@ public class FacetSequence
     return locs;    
   }
 
-  private double computeDistanceLineLine(FacetSequence facetSeq, GeometryLocation[] locs)
+  private double computeDistanceLineLine(FacetSequence facetSeq, Coordinate[] locs)
   {
     // both linear - compute minimum segment-segment distance
     double minDistance = Double.MAX_VALUE;
@@ -195,15 +175,15 @@ public class FacetSequence
   }
 
   private void updateNearestLocationsLineLine(int i, Coordinate p0, Coordinate p1, FacetSequence facetSeq, int j,
-      Coordinate q0, Coordinate q1, GeometryLocation[] locs) {
+      Coordinate q0, Coordinate q1, Coordinate[] locs) {
     LineSegment seg0 = new LineSegment(p0, p1);
     LineSegment seg1 = new LineSegment(q0, q1);
     Coordinate[] closestPt = seg0.closestPoints(seg1);
-    locs[0] = new GeometryLocation(geom, i, new Coordinate(closestPt[0]));
-    locs[1] = new GeometryLocation(facetSeq.geom, j, new Coordinate(closestPt[1]));    
+    locs[0] = closestPt[0].copy();
+    locs[1] = closestPt[1].copy();    
   }
   
-  private double computeDistancePointLine(Coordinate pt, FacetSequence facetSeq, GeometryLocation[] locs) 
+  private double computeDistancePointLine(Coordinate pt, FacetSequence facetSeq, Coordinate[] locs) 
   {
     double minDistance = Double.MAX_VALUE;
 
@@ -222,11 +202,11 @@ public class FacetSequence
   
   private void updateNearestLocationsPointLine(Coordinate pt, 
       FacetSequence facetSeq, int i, Coordinate q0, Coordinate q1, 
-      GeometryLocation[] locs) {
-    locs[0] = new GeometryLocation(geom, start, new Coordinate(pt));
+      Coordinate[] locs) {
+    locs[0] = pt.copy();
     LineSegment seg = new LineSegment(q0, q1);
     Coordinate segClosestPoint = seg.closestPoint(pt);
-    locs[1] = new  GeometryLocation(facetSeq.geom, i, new Coordinate(segClosestPoint));
+    locs[1] = segClosestPoint.copy();
   }
 
   public String toString()

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance/FacetSequenceTreeBuilder.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance/FacetSequenceTreeBuilder.java
@@ -57,18 +57,18 @@ public class FacetSequenceTreeBuilder {
         CoordinateSequence seq = null;
         if (geom instanceof LineString) {
           seq = ((LineString) geom).getCoordinateSequence();
-          addFacetSequences(geom, seq, sections);
+          addFacetSequences(seq, sections);
         }
         else if (geom instanceof Point) {
           seq = ((Point) geom).getCoordinateSequence();
-          addFacetSequences(geom, seq, sections);
+          addFacetSequences(seq, sections);
         }
       }
     });
     return sections;
   }
 
-  private static void addFacetSequences(Geometry geom, CoordinateSequence pts, List sections) {
+  private static void addFacetSequences(CoordinateSequence pts, List sections) {
     int i = 0;
     int size = pts.size();
     while (i <= size - 1) {
@@ -77,7 +77,7 @@ public class FacetSequenceTreeBuilder {
       // section
       if (end >= size - 1)
         end = size;
-      FacetSequence sect = new FacetSequence(geom, pts, i, end);
+      FacetSequence sect = new FacetSequence(pts, i, end);
       sections.add(sect);
       i = i + FACET_SEQUENCE_SIZE;
     }

--- a/modules/core/src/main/java/org/locationtech/jts/operation/distance/IndexedFacetDistance.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/distance/IndexedFacetDistance.java
@@ -125,51 +125,32 @@ public class IndexedFacetDistance
    */
   public double distance(Geometry g)
   {
-    STRtree tree2 = FacetSequenceTreeBuilder.build(g);
-    Object[] obj = cachedTree.nearestNeighbour(tree2, 
-        FACET_SEQ_DIST);
+    Object[] obj = nearestFacets(g);
     FacetSequence fs1 = (FacetSequence) obj[0];
     FacetSequence fs2 = (FacetSequence) obj[1];
     return fs1.distance(fs2);
   }
-  
-  /**
-   * Computes the nearest locations on the base geometry
-   * and the given geometry.
-   * 
-   * @param g the geometry to compute the nearest location to
-   * @return the nearest locations
-   */
-  public GeometryLocation[] nearestLocations(Geometry g)
-  {
+
+  private Object[] nearestFacets(Geometry g) {
     STRtree tree2 = FacetSequenceTreeBuilder.build(g);
     Object[] obj = cachedTree.nearestNeighbour(tree2, 
         FACET_SEQ_DIST);
+    return obj;
+  }
+  
+  /**
+   * Computes the nearest points on the base geometry
+   * and the given geometry.
+   * 
+   * @param g the geometry to compute the nearest location to
+   * @return the nearest points
+   */
+  public Coordinate[] nearestPoints(Geometry g)
+  {
+    Object[] obj = nearestFacets(g);
     FacetSequence fs1 = (FacetSequence) obj[0];
     FacetSequence fs2 = (FacetSequence) obj[1];
     return fs1.nearestLocations(fs2);
-  }
-
-  /**
-   * Compute the nearest locations on the target geometry
-   * and the given geometry.
-   * 
-   * @param g the geometry to compute the nearest point to
-   * @return the nearest points
-   */
-  public Coordinate[] nearestPoints(Geometry g) {
-    GeometryLocation[] minDistanceLocation = nearestLocations(g);
-    Coordinate[] nearestPts = toPoints(minDistanceLocation);
-    return nearestPts;
-  }
-
-  private static Coordinate[] toPoints(GeometryLocation[] locations) {
-    if (locations == null) 
-      return null;
-    Coordinate[] nearestPts = new Coordinate[] {
-        locations[0].getCoordinate(),
-      locations[1].getCoordinate() };
-    return nearestPts;
   }
 
   /**
@@ -200,9 +181,6 @@ public class IndexedFacetDistance
       return fs1.distance(fs2);    
     }
   }
-
-
-
 }
 
 


### PR DESCRIPTION
Simplify the `FacetSequence` implementation by removing the unused link to the parent geometry.