### PR TITLE
Fix LineSegment.project to handle segments projecting onto a single endpoint

### DIFF
--- a/modules/app/src/main/java/org/locationtech/jtstest/function/LineSegmentFunctions.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/function/LineSegmentFunctions.java
@@ -116,4 +116,25 @@ public class LineSegmentFunctions
     return g1.getFactory().createPoint(reflectPt);
   }
 
+  public static Geometry project(Geometry g1, Geometry g2)
+  {
+    LineSegment seg1 = toLineSegment(g1);
+    Coordinate[] line2 = g2.getCoordinates();
+    if (line2.length == 1) {
+      Coordinate pt = line2[0];
+      Coordinate result = seg1.project(pt); 
+      return g1.getFactory().createPoint(result);
+    }
+    LineSegment seg2 = new LineSegment(line2[0], line2[1]);
+    LineSegment result = seg1.project(seg2);
+    if (result == null)
+      return g1.getFactory().createLineString();
+    return result.toGeometry(g1.getFactory());
+  }
+
+  private static LineSegment toLineSegment(Geometry g) {
+    Coordinate[] line = g.getCoordinates();
+    return new LineSegment(line[0], line[1]);
+  }
+
 }

--- a/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geom/LineSegment.java
@@ -468,16 +468,30 @@ public class LineSegment
     double pf0 = projectionFactor(seg.p0);
     double pf1 = projectionFactor(seg.p1);
     // check if segment projects at all
-    if (pf0 >= 1.0 && pf1 >= 1.0) return null;
-    if (pf0 <= 0.0 && pf1 <= 0.0) return null;
+    if (pf0 > 1.0 && pf1 > 1.0) return null;
+    if (pf0 < 0.0 && pf1 < 0.0) return null;
 
-    Coordinate newp0 = project(seg.p0, pf0);
-    if (pf0 < 0.0) newp0 = p0;
-    if (pf0 > 1.0) newp0 = p1;
+    Coordinate newp0;
+    if (pf0 < 0.0) {
+      newp0 = p0;
+    }
+    else if (pf0 > 1.0) {
+      newp0 = p1;
+    }
+    else {
+      newp0 = project(seg.p0, pf0);
+    }
 
-    Coordinate newp1 = project(seg.p1, pf1);
-    if (pf1 < 0.0) newp1 = p0;
-    if (pf1 > 1.0) newp1 = p1;
+    Coordinate newp1;
+    if (pf1 < 0.0) {
+      newp1 = p0;
+    }
+    else if (pf1 > 1.0) {
+      newp1 = p1;
+    }
+    else {
+      newp1 = project(seg.p1, pf1);
+    }
 
     return new LineSegment(newp0, newp1);
   }

--- a/modules/core/src/test/java/test/jts/GeometryTestCase.java
+++ b/modules/core/src/test/java/test/jts/GeometryTestCase.java
@@ -233,7 +233,27 @@ public abstract class GeometryTestCase extends TestCase{
     assertEquals(message + " X", expected.getX(), actual.getX(), tolerance);
     assertEquals(message + " Y", expected.getY(), actual.getY(), tolerance);
   }
- 
+  
+  protected void checkEqual(LineSegment expected, LineSegment actual, double tolerance) {
+    boolean equal;
+    if (actual == null || expected == null) {
+      equal = actual == null && expected == null;
+    }
+    else {
+      equal = isEqual(actual, expected, tolerance);
+    }
+    if (! equal) {
+      System.out.format(CHECK_EQUAL_FAIL_MSG, expected, actual );
+    }
+    assertTrue(equal);
+  }
+  
+  private boolean isEqual(LineSegment actual, LineSegment expected, double tolerance) {
+    return expected.getCoordinate(0).equals2D(actual.getCoordinate(0), tolerance)
+        && expected.getCoordinate(1).equals2D(actual.getCoordinate(1), tolerance);
+    
+  }
+
   protected void checkNoAlias(Geometry geom, Geometry geom2) {
     Geometry geom2Copy = geom2.copy();
     geom.apply(new CoordinateFilter() {


### PR DESCRIPTION
Fix `LineSegment.project(LineSegment)` to correctly return a segment projecting onto a single endpoint.  This should return a zero-length segment at the endpoint, but was returning null.

Also adds a slight improvement to project the segment endpoints only if not equal to an endpoint (when projection factor is between 0 and 1). 

Fixes #1178