### PR TITLE
OverlayEdge: Don't skip first point when adding coordinates

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayEdge.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/overlayng/OverlayEdge.java
@@ -147,7 +147,7 @@ class OverlayEdge extends HalfEdge {
    */
   public void addCoordinates(CoordinateList coords)
   {
-    boolean isFirstEdge = coords.size() > 0;
+    boolean isFirstEdge = coords.isEmpty();
     if (direction) {
       int startIndex = 1;
       if (isFirstEdge) startIndex = 0;

--- a/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/overlayng/OverlayNGTest.java
@@ -489,6 +489,15 @@ public class OverlayNGTest extends OverlayNGTestCase {
     Geometry actual = intersection(a, b);
     checkEqual(expected, actual);    
   }
- 
+
+  /**
+   * Tests that overlay produces stable (non-rotated) results.
+   * See https://github.com/locationtech/jts/issues/865
+   */
+  public void testRingsNonRotated() {
+    Geometry a = read("POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))");
+    Geometry actual = intersection(a, a);
+    checkEqualExact(a, actual);
+  }
   
 }


### PR DESCRIPTION
The `isFirstEdge` logic in `OverlayEdge::addCoordinates` appears to be backwards. It works out OK because it is only used to construct rings, and the dropped point ends up being added later on, with the ring being "rotated" by one vertex.

However, problems arise when extending this function to handle coordinates from `CircularString` because dropping the first point of the first arc causes a control point to be interpreted as an endpoint.

Fixes #865