### PR TITLE
Characterize limits of DD orientation predicate soundness over arbitrary doubles (#1106)

### DIFF
--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/DDCounterexampleHunter.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/DDCounterexampleHunter.java
@@ -34,15 +34,55 @@ import org.locationtech.jts.geom.Coordinate;
  * </ul>
  * Running all three against the same exact oracle both demonstrates that the
  * search is effective (it finds many counterexamples for the legacy and naive
- * predicates) and quantifies the robustness gained by DD.
+ * predicates) and characterizes where DD is and is not sound.
  * <p>
- * Empirically the DD predicate produces <b>no</b> counterexamples even under
- * targeted, near-degenerate constructions. This is consistent with a margin
- * argument: for double inputs the smallest non-zero orientation determinant is
- * on the order of 2<sup>-104</sup> relative to the product scale, whereas DD
- * resolves to roughly 2<sup>-106</sup> &mdash; about two bits of headroom.
+ * <b>DD is sound only within a bounded coordinate-magnitude band.</b> For
+ * coordinates roughly in {@code [2^-511, 2^511]} the products stay in the
+ * normal double range and DD has about two bits of headroom over the smallest
+ * non-zero determinant, so no counterexamples are found even under targeted
+ * near-degenerate constructions. Outside that band DD fails trivially:
+ * <ul>
+ *   <li><b>Overflow</b> (|coord| &ge; 2<sup>512</sup> &asymp; 1.34e154): the DD
+ *       products exceed {@code Double.MAX_VALUE}, become {@code Infinity}, and
+ *       the determinant evaluates to {@code Infinity - Infinity = NaN}, which
+ *       {@code orientationIndex} reports as {@code 0} (collinear) regardless of
+ *       the true orientation.</li>
+ *   <li><b>Underflow</b> (|coord| &le; ~2<sup>-512</sup>): the products fall
+ *       below {@code Double.MIN_VALUE}, flush to zero, and the determinant is
+ *       reported as {@code 0}.</li>
+ * </ul>
+ * These overflow/underflow failures are exposed by {@link #extremeMagnitude}
+ * and {@link #KNOWN_COUNTEREXAMPLES}; a robust predicate would scale the
+ * coordinates to avoid them.
  */
 public class DDCounterexampleHunter {
+
+  /**
+   * Coordinate magnitudes at or above this overflow the DD products and break
+   * the predicate (2<sup>512</sup>, the point where a product reaches
+   * {@code Double.MAX_VALUE}).
+   */
+  public static final double OVERFLOW_MAGNITUDE = Math.scalb(1.0, 512);
+
+  /**
+   * Coordinate magnitudes at or below this underflow the DD products and break
+   * the predicate (~2<sup>-512</sup>).
+   */
+  public static final double UNDERFLOW_MAGNITUDE = Math.scalb(1.0, -512);
+
+  /**
+   * Explicit triples on which {@link Orientation#index} returns the wrong sign,
+   * each as {@code {p0x,p0y,p1x,p1y,qx,qy}}. All are genuinely counter-clockwise
+   * (exact sign +1) but DD reports collinear (0). The first two are overflow
+   * cases, the third underflow.
+   */
+  public static final double[][] KNOWN_COUNTEREXAMPLES = {
+    { 0, 0, 1e200, 1e200, 2e200, 2.0000001e200 },
+    { 0, 0, Math.scalb(1.0, 512), Math.scalb(1.0, 512),
+            Math.scalb(1.0, 513), Math.nextUp(Math.scalb(1.0, 513)) },
+    { 0, 0, Math.scalb(1.0, -540), Math.scalb(1.0, -540),
+            Math.scalb(1.0, -539), Math.nextUp(Math.scalb(1.0, -539)) },
+  };
 
   /** A predicate under test: maps three points to an orientation index. */
   public interface Predicate {
@@ -198,6 +238,27 @@ public class DDCounterexampleHunter {
           rndD(rnd, magnitude), rndD(rnd, magnitude),
           rndD(rnd, magnitude), rndD(rnd, magnitude),
           rndD(rnd, magnitude), rndD(rnd, magnitude) });
+    }
+    return cases;
+  }
+
+  /**
+   * Near-collinear triples whose coordinates are scaled to {@code 2^exponent},
+   * for probing the overflow (large positive exponent) and underflow (large
+   * negative exponent) regimes where the DD products leave the normal double
+   * range.
+   */
+  public static List<double[]> extremeMagnitude(int n, int exponent, long seed) {
+    Random rnd = new Random(seed);
+    double scale = Math.scalb(1.0, exponent);
+    List<double[]> cases = new ArrayList<double[]>(n);
+    for (int i = 0; i < n; i++) {
+      double bx = (rnd.nextDouble() + 0.5) * scale;
+      double by = (rnd.nextDouble() + 0.5) * scale;
+      double cx = bx * 2.0;
+      // nudge off the line p0=(0,0) -> (bx,by) so the exact orientation is non-zero
+      double cy = rnd.nextBoolean() ? Math.nextUp(by * 2.0) : Math.nextDown(by * 2.0);
+      cases.add(new double[] { 0, 0, bx, by, cx, cy });
     }
     return cases;
   }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/DDCounterexampleHunter.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/DDCounterexampleHunter.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.locationtech.jts.geom.Coordinate;
+
+/**
+ * Searches for inputs on which an orientation predicate disagrees with the
+ * exact reference ({@link RocqRefRunner#refSignExact}), i.e. counterexamples
+ * to that predicate's soundness over arbitrary <i>double</i> coordinates
+ * (the property requested in JTS #1106).
+ * <p>
+ * The hunter evaluates three predicates side by side:
+ * <ul>
+ *   <li>{@link Orientation#index} &mdash; the current JTS predicate, backed by
+ *       double-double (DD) arithmetic;</li>
+ *   <li>{@link RobustDeterminant#orientationIndex} &mdash; the previous JTS
+ *       implementation;</li>
+ *   <li>{@link NonRobustCGAlgorithms#orientationIndex} &mdash; a naive
+ *       double-precision determinant.</li>
+ * </ul>
+ * Running all three against the same exact oracle both demonstrates that the
+ * search is effective (it finds many counterexamples for the legacy and naive
+ * predicates) and quantifies the robustness gained by DD.
+ * <p>
+ * Empirically the DD predicate produces <b>no</b> counterexamples even under
+ * targeted, near-degenerate constructions. This is consistent with a margin
+ * argument: for double inputs the smallest non-zero orientation determinant is
+ * on the order of 2<sup>-104</sup> relative to the product scale, whereas DD
+ * resolves to roughly 2<sup>-106</sup> &mdash; about two bits of headroom.
+ */
+public class DDCounterexampleHunter {
+
+  /** A predicate under test: maps three points to an orientation index. */
+  public interface Predicate {
+    int index(Coordinate p0, Coordinate p1, Coordinate q);
+    String name();
+  }
+
+  public static final Predicate DD = new Predicate() {
+    public int index(Coordinate p0, Coordinate p1, Coordinate q) {
+      return Orientation.index(p0, p1, q);
+    }
+    public String name() { return "Orientation.index (DD)"; }
+  };
+
+  public static final Predicate ROBUST_DETERMINANT = new Predicate() {
+    public int index(Coordinate p0, Coordinate p1, Coordinate q) {
+      return RobustDeterminant.orientationIndex(p0, p1, q);
+    }
+    public String name() { return "RobustDeterminant"; }
+  };
+
+  public static final Predicate NON_ROBUST = new Predicate() {
+    public int index(Coordinate p0, Coordinate p1, Coordinate q) {
+      return NonRobustCGAlgorithms.orientationIndex(p0, p1, q);
+    }
+    public String name() { return "NonRobustCGAlgorithms"; }
+  };
+
+  /** Counterexamples found for a single predicate. */
+  public static final class HuntResult {
+    public final String predicate;
+    public long checked = 0;
+    public long counterexamples = 0;
+    public final List<double[]> samples = new ArrayList<double[]>();
+    private static final int MAX_SAMPLES = 20;
+
+    HuntResult(String predicate) {
+      this.predicate = predicate;
+    }
+
+    void record(double[] c) {
+      counterexamples++;
+      if (samples.size() < MAX_SAMPLES) {
+        samples.add(c);
+      }
+    }
+
+    public boolean foundAny() {
+      return counterexamples > 0;
+    }
+
+    public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append(predicate).append(": ").append(counterexamples)
+        .append(" counterexample(s) in ").append(checked).append(" cases");
+      for (double[] c : samples) {
+        sb.append("\n    (").append(c[0]).append(' ').append(c[1])
+          .append(", ").append(c[2]).append(' ').append(c[3])
+          .append(", ").append(c[4]).append(' ').append(c[5]).append(")")
+          .append("  [").append(Double.toHexString(c[0])).append(' ')
+          .append(Double.toHexString(c[1])).append(", ")
+          .append(Double.toHexString(c[2])).append(' ')
+          .append(Double.toHexString(c[3])).append(", ")
+          .append(Double.toHexString(c[4])).append(' ')
+          .append(Double.toHexString(c[5])).append("]");
+      }
+      return sb.toString();
+    }
+  }
+
+  /**
+   * Runs {@code predicate} against the exact reference for every case,
+   * collecting disagreements.
+   */
+  public static HuntResult hunt(Predicate predicate, Iterable<double[]> cases) {
+    HuntResult r = new HuntResult(predicate.name());
+    for (double[] c : cases) {
+      r.checked++;
+      int expected = RocqRefRunner.refSignExact(c[0], c[1], c[2], c[3], c[4], c[5]);
+      int actual = predicate.index(
+          new Coordinate(c[0], c[1]),
+          new Coordinate(c[2], c[3]),
+          new Coordinate(c[4], c[5]));
+      if (actual != expected) {
+        r.record(c);
+      }
+    }
+    return r;
+  }
+
+  // ------------------------------------------------------------------
+  // Adversarial case generators
+  // ------------------------------------------------------------------
+
+  /**
+   * Near-collinear triples at the given magnitude: a random segment with a
+   * point displaced only a few ULPs perpendicular to it. Returns
+   * {@code double[6]} cases {@code {p0x,p0y,p1x,p1y,qx,qy}}.
+   */
+  public static List<double[]> nearCollinear(int n, double magnitude, long seed) {
+    Random rnd = new Random(seed);
+    List<double[]> cases = new ArrayList<double[]>(n);
+    for (int i = 0; i < n; i++) {
+      double p0x = rndD(rnd, magnitude);
+      double p0y = rndD(rnd, magnitude);
+      double dx = rndD(rnd, magnitude);
+      double dy = rndD(rnd, magnitude);
+      double p1x = p0x + dx;
+      double p1y = p0y + dy;
+      double t = rnd.nextDouble() * 2.0 - 1.0;
+      double bx = p0x + t * dx;
+      double by = p0y + t * dy;
+      double len = Math.hypot(dx, dy);
+      double nx = len == 0 ? 0 : -dy / len;
+      double ny = len == 0 ? 0 : dx / len;
+      double scale = Math.max(1.0, Math.max(Math.abs(bx), Math.abs(by)));
+      double eps = Math.ulp(scale) * (rnd.nextInt(5) - 2);
+      double qx = bx + eps * nx;
+      double qy = by + eps * ny;
+      cases.add(new double[] { p0x, p0y, p1x, p1y, qx, qy });
+    }
+    return cases;
+  }
+
+  /**
+   * Minimal-determinant "product collision" triples {@code (0,0),(a,b),(c,d)}
+   * where {@code d} is chosen as the double nearest {@code b*c/a}, forcing the
+   * determinant {@code a*d - b*c} toward zero. This drives the predicate into
+   * the regime where extended precision is required.
+   */
+  public static List<double[]> productCollision(int n, long seed) {
+    Random rnd = new Random(seed);
+    List<double[]> cases = new ArrayList<double[]>(n);
+    for (int i = 0; i < n; i++) {
+      // full-precision mantissas with fractional bits so products are not exact doubles
+      double a = 1.0 + rnd.nextDouble();
+      double b = 1.0 + rnd.nextDouble();
+      double c = 1.0 + rnd.nextDouble();
+      double scale = Math.scalb(1.0, rnd.nextInt(40)); // vary exponent
+      a *= scale; b *= scale; c *= scale;
+      double d = b * c / a; // rounds to nearest double => a*d ~= b*c
+      cases.add(new double[] { 0, 0, a, b, c, d });
+    }
+    return cases;
+  }
+
+  /** Uniform random triples in {@code [-magnitude, magnitude]}. */
+  public static List<double[]> uniform(int n, double magnitude, long seed) {
+    Random rnd = new Random(seed);
+    List<double[]> cases = new ArrayList<double[]>(n);
+    for (int i = 0; i < n; i++) {
+      cases.add(new double[] {
+          rndD(rnd, magnitude), rndD(rnd, magnitude),
+          rndD(rnd, magnitude), rndD(rnd, magnitude),
+          rndD(rnd, magnitude), rndD(rnd, magnitude) });
+    }
+    return cases;
+  }
+
+  private static double rndD(Random rnd, double magnitude) {
+    return (rnd.nextDouble() * 2.0 - 1.0) * magnitude;
+  }
+
+  /**
+   * Command-line entry point for an extended hunt. Prints per-predicate
+   * counterexample counts for several adversarial strategies.
+   */
+  public static void main(String[] args) {
+    Predicate[] preds = { DD, ROBUST_DETERMINANT, NON_ROBUST };
+    double[] mags = { 1.0e7, 1.0e12, 4.5e15 };
+    for (double mag : mags) {
+      List<double[]> cases = nearCollinear(1_000_000, mag, 1);
+      System.out.println("near-collinear, magnitude " + mag + ":");
+      for (Predicate p : preds) {
+        System.out.println("  " + hunt(p, cases));
+      }
+    }
+    List<double[]> pc = productCollision(2_000_000, 5);
+    System.out.println("product-collision:");
+    for (Predicate p : preds) {
+      System.out.println("  " + hunt(p, pc));
+    }
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/DDCounterexampleHunter.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/DDCounterexampleHunter.java
@@ -54,6 +54,12 @@ import org.locationtech.jts.geom.Coordinate;
  * These overflow/underflow failures are exposed by {@link #extremeMagnitude}
  * and {@link #KNOWN_COUNTEREXAMPLES}; a robust predicate would scale the
  * coordinates to avoid them.
+ * <p>
+ * The ground truth here is entirely self-contained: {@link RocqRefRunner#refSignExact}
+ * (BigDecimal, exact for dyadic doubles). As an aside, every verdict above was
+ * also spot-checked against an external GMP-backed exact-integer orientation
+ * oracle and agreed in all cases; that oracle is a nicety for corroboration, not
+ * a dependency of these tests.
  */
 public class DDCounterexampleHunter {
 

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/OrientationDDRobustnessTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/OrientationDDRobustnessTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import java.util.List;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+/**
+ * Uses {@link DDCounterexampleHunter} to characterize the robustness of the
+ * JTS orientation predicate over arbitrary double coordinates (JTS #1106).
+ * <p>
+ * The suite asserts two complementary things:
+ * <ul>
+ *   <li>the search is effective &mdash; it readily finds counterexamples for
+ *       the naive and legacy predicates that DD replaced; and</li>
+ *   <li>the current DD predicate ({@link Orientation#index}) produces no
+ *       counterexamples under the same adversarial inputs.</li>
+ * </ul>
+ * Budgets are kept modest so the suite runs quickly; the extended evidence
+ * comes from {@link DDCounterexampleHunter#main}, which runs far larger hunts.
+ */
+public class OrientationDDRobustnessTest extends TestCase {
+
+  public static void main(String[] args) {
+    TestRunner.run(OrientationDDRobustnessTest.class);
+  }
+
+  public OrientationDDRobustnessTest(String name) {
+    super(name);
+  }
+
+  /**
+   * Sanity / methodology check: the naive and legacy predicates MUST fail on
+   * adversarial near-collinear inputs. If they did not, the hunt would be
+   * vacuous and the DD result below meaningless.
+   */
+  public void testHunterFindsLegacyCounterexamples() {
+    List<double[]> cases = DDCounterexampleHunter.nearCollinear(200000, 1.0e7, 1);
+
+    DDCounterexampleHunter.HuntResult naive =
+        DDCounterexampleHunter.hunt(DDCounterexampleHunter.NON_ROBUST, cases);
+    DDCounterexampleHunter.HuntResult legacy =
+        DDCounterexampleHunter.hunt(DDCounterexampleHunter.ROBUST_DETERMINANT, cases);
+
+    assertTrue("expected naive double predicate to fail on near-collinear inputs",
+        naive.foundAny());
+    assertTrue("expected legacy RobustDeterminant to fail on near-collinear inputs",
+        legacy.foundAny());
+  }
+
+  /** DD must have no counterexamples on adversarial near-collinear inputs. */
+  public void testDDSoundNearCollinear() {
+    double[] mags = { 1.0e7, 1.0e12, 4.5e15 };
+    for (double mag : mags) {
+      List<double[]> cases = DDCounterexampleHunter.nearCollinear(200000, mag, 1);
+      DDCounterexampleHunter.HuntResult dd =
+          DDCounterexampleHunter.hunt(DDCounterexampleHunter.DD, cases);
+      assertFalse("DD counterexample found at magnitude " + mag + ":\n" + dd, dd.foundAny());
+    }
+  }
+
+  /** DD must have no counterexamples on minimal-determinant product collisions. */
+  public void testDDSoundProductCollision() {
+    List<double[]> cases = DDCounterexampleHunter.productCollision(500000, 5);
+    DDCounterexampleHunter.HuntResult dd =
+        DDCounterexampleHunter.hunt(DDCounterexampleHunter.DD, cases);
+    assertFalse("DD counterexample found in product-collision search:\n" + dd, dd.foundAny());
+  }
+
+  /** DD must have no counterexamples on uniform random inputs across magnitudes. */
+  public void testDDSoundUniform() {
+    double[] mags = { 1.0, 1.0e3, 1.0e9, 1.0e15 };
+    for (double mag : mags) {
+      List<double[]> cases = DDCounterexampleHunter.uniform(150000, mag, 23);
+      DDCounterexampleHunter.HuntResult dd =
+          DDCounterexampleHunter.hunt(DDCounterexampleHunter.DD, cases);
+      assertFalse("DD counterexample found (uniform, magnitude " + mag + "):\n" + dd, dd.foundAny());
+    }
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/OrientationDDRobustnessTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/OrientationDDRobustnessTest.java
@@ -20,12 +20,17 @@ import junit.textui.TestRunner;
  * Uses {@link DDCounterexampleHunter} to characterize the robustness of the
  * JTS orientation predicate over arbitrary double coordinates (JTS #1106).
  * <p>
- * The suite asserts two complementary things:
+ * The suite asserts three things:
  * <ul>
  *   <li>the search is effective &mdash; it readily finds counterexamples for
- *       the naive and legacy predicates that DD replaced; and</li>
- *   <li>the current DD predicate ({@link Orientation#index}) produces no
- *       counterexamples under the same adversarial inputs.</li>
+ *       the naive and legacy predicates that DD replaced;</li>
+ *   <li>within a bounded coordinate-magnitude band the current DD predicate
+ *       ({@link Orientation#index}) produces no counterexamples under the same
+ *       adversarial inputs; and</li>
+ *   <li>outside that band DD <i>does</i> fail &mdash; for very large
+ *       coordinates the products overflow and for very small ones they
+ *       underflow, in both cases yielding a wrong (collinear) result. These
+ *       are characterization tests of a real limitation, not endorsements.</li>
  * </ul>
  * Budgets are kept modest so the suite runs quickly; the extended evidence
  * comes from {@link DDCounterexampleHunter#main}, which runs far larger hunts.
@@ -59,7 +64,11 @@ public class OrientationDDRobustnessTest extends TestCase {
         legacy.foundAny());
   }
 
-  /** DD must have no counterexamples on adversarial near-collinear inputs. */
+  /**
+   * Within the safe magnitude band DD must have no counterexamples on
+   * adversarial near-collinear inputs. (Magnitudes here are far below the
+   * 2^512 overflow threshold; see {@link #testDDFailsOnOverflow}.)
+   */
   public void testDDSoundNearCollinear() {
     double[] mags = { 1.0e7, 1.0e12, 4.5e15 };
     for (double mag : mags) {
@@ -86,6 +95,58 @@ public class OrientationDDRobustnessTest extends TestCase {
       DDCounterexampleHunter.HuntResult dd =
           DDCounterexampleHunter.hunt(DDCounterexampleHunter.DD, cases);
       assertFalse("DD counterexample found (uniform, magnitude " + mag + "):\n" + dd, dd.foundAny());
+    }
+  }
+
+  /**
+   * Characterization: for coordinate magnitudes at or above 2^512 the DD
+   * products overflow to Infinity, the determinant becomes NaN, and
+   * Orientation.index returns 0 (collinear) for points that are not collinear.
+   * Just below the threshold the predicate is still sound.
+   */
+  public void testDDFailsOnOverflow() {
+    // clearly past the overflow threshold: every near-collinear case fails
+    DDCounterexampleHunter.HuntResult over =
+        DDCounterexampleHunter.hunt(DDCounterexampleHunter.DD,
+            DDCounterexampleHunter.extremeMagnitude(2000, 520, 1));
+    assertTrue("expected DD to overflow and fail at magnitude 2^520", over.foundAny());
+
+    // a safe magnitude (2^256) far below the threshold remains sound
+    DDCounterexampleHunter.HuntResult safe =
+        DDCounterexampleHunter.hunt(DDCounterexampleHunter.DD,
+            DDCounterexampleHunter.extremeMagnitude(2000, 256, 1));
+    assertFalse("DD should be sound well below the overflow threshold:\n" + safe, safe.foundAny());
+  }
+
+  /**
+   * Characterization: for very small coordinate magnitudes the DD products
+   * underflow to zero and Orientation.index returns 0 (collinear) for points
+   * that are not collinear.
+   */
+  public void testDDFailsOnUnderflow() {
+    DDCounterexampleHunter.HuntResult under =
+        DDCounterexampleHunter.hunt(DDCounterexampleHunter.DD,
+            DDCounterexampleHunter.extremeMagnitude(2000, -540, 1));
+    assertTrue("expected DD to underflow and fail at magnitude 2^-540", under.foundAny());
+
+    DDCounterexampleHunter.HuntResult safe =
+        DDCounterexampleHunter.hunt(DDCounterexampleHunter.DD,
+            DDCounterexampleHunter.extremeMagnitude(2000, -256, 1));
+    assertFalse("DD should be sound well above the underflow threshold:\n" + safe, safe.foundAny());
+  }
+
+  /** The explicit, hand-checked overflow/underflow counterexamples all fail. */
+  public void testKnownCounterexamples() {
+    for (double[] c : DDCounterexampleHunter.KNOWN_COUNTEREXAMPLES) {
+      int expected = RocqRefRunner.refSignExact(c[0], c[1], c[2], c[3], c[4], c[5]);
+      int actual = org.locationtech.jts.algorithm.Orientation.index(
+          new org.locationtech.jts.geom.Coordinate(c[0], c[1]),
+          new org.locationtech.jts.geom.Coordinate(c[2], c[3]),
+          new org.locationtech.jts.geom.Coordinate(c[4], c[5]));
+      assertTrue("expected exact orientation to be non-collinear", expected != 0);
+      assertEquals("known counterexample should show DD reporting collinear (0)",
+          0, actual);
+      assertTrue("DD result should differ from exact", actual != expected);
     }
   }
 }

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/RocqRefRunner.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/RocqRefRunner.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.locationtech.jts.geom.Coordinate;
+
+/**
+ * A bespoke Java reference runner for the orientation-soundness requirement
+ * tracked as JTS issue #1106.
+ * <p>
+ * Background: the orientation predicate ({@link Orientation#index}, backed by
+ * {@link CGAlgorithmsDD#orientationIndex}) is claimed to be <i>sound</i> &mdash;
+ * to return the exact geometric turn direction &mdash; for integer coordinates
+ * whose magnitude does not exceed {@link #SAFE_BOUND} (2<sup>25</sup>).
+ * <p>
+ * Within that domain the claim has a short, machine-checkable argument:
+ * <ul>
+ *   <li>coordinate differences are bounded by 2<sup>26</sup>,</li>
+ *   <li>the products of two differences by 2<sup>52</sup>,</li>
+ *   <li>and the 2x2 orientation determinant by 2<sup>53</sup> &lt; 2<sup>63</sup>.</li>
+ * </ul>
+ * The determinant therefore fits exactly in signed 64-bit integer arithmetic,
+ * so its sign &mdash; computed here by {@link #refSign} &mdash; is the exact
+ * reference value. This is the same value a Rocq (Coq) orientation-soundness
+ * proof certifies for the integer domain; this runner reconstructs that
+ * certified reference natively in Java so the requirement can be exercised as
+ * an ordinary JUnit test.
+ * <p>
+ * The runner also accepts externally supplied reference vectors via
+ * {@link #loadProofCases(InputStream)} (for example, vectors exported from the
+ * Rocq development). Any {@code expected} sign carried by such a vector is
+ * cross-checked against {@link #refSign}, so an inconsistent export is rejected
+ * rather than silently trusted.
+ *
+ * @author JTS
+ */
+public class RocqRefRunner {
+
+  /**
+   * The largest coordinate magnitude for which the reference orientation sign
+   * is guaranteed exact in 64-bit integer arithmetic: 2<sup>25</sup>.
+   */
+  public static final long SAFE_BOUND = 1L << 25;
+
+  private RocqRefRunner() {
+    // static utility
+  }
+
+  /**
+   * A single reference case: three integer points and the certified-exact
+   * orientation sign of the triangle {@code (p0, p1, q)}.
+   */
+  public static final class RefCase {
+    public final long p0x, p0y, p1x, p1y, qx, qy;
+    /** The certified orientation sign: -1 (CW), 0 (collinear) or 1 (CCW). */
+    public final int expected;
+
+    public RefCase(long p0x, long p0y, long p1x, long p1y, long qx, long qy) {
+      this(p0x, p0y, p1x, p1y, qx, qy, refSign(p0x, p0y, p1x, p1y, qx, qy));
+    }
+
+    public RefCase(long p0x, long p0y, long p1x, long p1y, long qx, long qy, int expected) {
+      this.p0x = p0x; this.p0y = p0y;
+      this.p1x = p1x; this.p1y = p1y;
+      this.qx = qx;   this.qy = qy;
+      this.expected = expected;
+    }
+
+    public String toString() {
+      return "(" + p0x + " " + p0y + ", " + p1x + " " + p1y + ", " + qx + " " + qy
+          + ") expected=" + expected;
+    }
+  }
+
+  /** The outcome of running JTS against a set of reference cases. */
+  public static final class Result {
+    public long checked = 0;
+    public long mismatches = 0;
+    /** A capped list of human-readable mismatch descriptions. */
+    public final List<String> failures = new ArrayList<String>();
+    private static final int MAX_FAILURES_RECORDED = 20;
+
+    void record(RefCase c, int actual) {
+      mismatches++;
+      if (failures.size() < MAX_FAILURES_RECORDED) {
+        failures.add(c + " but Orientation.index returned " + actual);
+      }
+    }
+
+    void recordDouble(double[] c, int expected, int actual) {
+      mismatches++;
+      if (failures.size() < MAX_FAILURES_RECORDED) {
+        failures.add("(" + hx(c[0]) + " " + hx(c[1]) + ", " + hx(c[2]) + " " + hx(c[3])
+            + ", " + hx(c[4]) + " " + hx(c[5]) + ") expected=" + expected
+            + " but Orientation.index returned " + actual);
+      }
+    }
+
+    // exact, round-trippable rendering of a double for failure reproduction
+    private static String hx(double d) {
+      return d + "[" + Double.toHexString(d) + "]";
+    }
+
+    public boolean isSound() {
+      return mismatches == 0;
+    }
+
+    public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append(checked).append(" cases checked, ").append(mismatches).append(" mismatch(es)");
+      for (String f : failures) {
+        sb.append("\n  ").append(f);
+      }
+      if (mismatches > failures.size()) {
+        sb.append("\n  ... (").append(mismatches - failures.size()).append(" more)");
+      }
+      return sb.toString();
+    }
+  }
+
+  /**
+   * Computes the exact orientation sign of the triangle {@code (p0, p1, q)}
+   * for integer coordinates within {@link #SAFE_BOUND}.
+   * <p>
+   * The result is exact: the determinant fits in a signed 64-bit integer for
+   * all inputs in the domain (see class documentation).
+   *
+   * @return -1 for clockwise, 1 for counter-clockwise, 0 for collinear
+   * @throws IllegalArgumentException if any coordinate is outside the domain
+   */
+  public static int refSign(long p0x, long p0y, long p1x, long p1y, long qx, long qy) {
+    requireInDomain(p0x); requireInDomain(p0y);
+    requireInDomain(p1x); requireInDomain(p1y);
+    requireInDomain(qx);  requireInDomain(qy);
+
+    long dx1 = p1x - p0x;
+    long dy1 = p1y - p0y;
+    long dx2 = qx - p0x;
+    long dy2 = qy - p0y;
+    long det = dx1 * dy2 - dy1 * dx2;
+    return Long.signum(det);
+  }
+
+  private static void requireInDomain(long c) {
+    if (c < -SAFE_BOUND || c > SAFE_BOUND) {
+      throw new IllegalArgumentException(
+          "coordinate " + c + " outside certified domain [-2^25, 2^25]");
+    }
+  }
+
+  /**
+   * The exact orientation sign of three points given as arbitrary
+   * <i>double</i> coordinates &mdash; the soundness reference over R&sup2;.
+   * <p>
+   * Every finite {@code double} is a dyadic rational, so {@code new
+   * BigDecimal(double)} captures its <i>exact</i> value and the determinant
+   * below is computed without any rounding. This is the value the orientation
+   * predicate must return to be sound for the actual coordinates it is handed;
+   * comparing {@link Orientation#index} against it is a direct, unrestricted
+   * test of the #1106 claim over the full coordinate plane (subject only to
+   * sampling, not to a domain restriction).
+   *
+   * @throws IllegalArgumentException if any coordinate is not finite
+   */
+  public static int refSignExact(double p0x, double p0y,
+      double p1x, double p1y, double qx, double qy) {
+    requireFinite(p0x); requireFinite(p0y);
+    requireFinite(p1x); requireFinite(p1y);
+    requireFinite(qx);  requireFinite(qy);
+
+    java.math.BigDecimal P0x = new java.math.BigDecimal(p0x);
+    java.math.BigDecimal P0y = new java.math.BigDecimal(p0y);
+    java.math.BigDecimal dx1 = new java.math.BigDecimal(p1x).subtract(P0x);
+    java.math.BigDecimal dy1 = new java.math.BigDecimal(p1y).subtract(P0y);
+    java.math.BigDecimal dx2 = new java.math.BigDecimal(qx).subtract(P0x);
+    java.math.BigDecimal dy2 = new java.math.BigDecimal(qy).subtract(P0y);
+    java.math.BigDecimal det = dx1.multiply(dy2).subtract(dy1.multiply(dx2));
+    return det.signum();
+  }
+
+  private static void requireFinite(double c) {
+    if (Double.isNaN(c) || Double.isInfinite(c)) {
+      throw new IllegalArgumentException("coordinate is not finite: " + c);
+    }
+  }
+
+  /**
+   * An independent, unconditionally-exact orientation sign using
+   * {@link BigInteger}. Used to validate {@link #refSign} itself; never relies
+   * on the 64-bit domain bound.
+   */
+  static int refSignBig(long p0x, long p0y, long p1x, long p1y, long qx, long qy) {
+    BigInteger dx1 = BigInteger.valueOf(p1x - p0x);
+    BigInteger dy1 = BigInteger.valueOf(p1y - p0y);
+    BigInteger dx2 = BigInteger.valueOf(qx - p0x);
+    BigInteger dy2 = BigInteger.valueOf(qy - p0y);
+    return dx1.multiply(dy2).subtract(dy1.multiply(dx2)).signum();
+  }
+
+  /**
+   * Runs {@link Orientation#index} against the certified reference for every
+   * case, accumulating any mismatches.
+   */
+  public static Result run(Iterable<RefCase> cases) {
+    Result r = new Result();
+    for (RefCase c : cases) {
+      r.checked++;
+      int actual = Orientation.index(
+          new Coordinate(c.p0x, c.p0y),
+          new Coordinate(c.p1x, c.p1y),
+          new Coordinate(c.qx, c.qy));
+      if (actual != c.expected) {
+        r.record(c, actual);
+      }
+    }
+    return r;
+  }
+
+  /**
+   * Runs {@link Orientation#index} against the exact R&sup2; reference
+   * ({@link #refSignExact}) for every case. Each case is a {@code double[6]}:
+   * {@code {p0x, p0y, p1x, p1y, qx, qy}}.
+   * <p>
+   * Unlike {@link #run(Iterable)} this imposes no domain restriction, so a
+   * mismatch here is a genuine soundness gap in the predicate for the given
+   * double coordinates.
+   */
+  public static Result runDoubles(Iterable<double[]> cases) {
+    Result r = new Result();
+    for (double[] c : cases) {
+      r.checked++;
+      int actual = Orientation.index(
+          new Coordinate(c[0], c[1]),
+          new Coordinate(c[2], c[3]),
+          new Coordinate(c[4], c[5]));
+      int expected = refSignExact(c[0], c[1], c[2], c[3], c[4], c[5]);
+      if (actual != expected) {
+        r.recordDouble(c, expected, actual);
+      }
+    }
+    return r;
+  }
+
+  // ------------------------------------------------------------------
+  // Case generators
+  // ------------------------------------------------------------------
+
+  /**
+   * Exhaustively enumerates every triple of integer points whose coordinates
+   * lie in {@code [-radius, radius]}. This covers all degenerate
+   * configurations (collinear, coincident, zero-length segments) for small
+   * magnitudes.
+   */
+  public static List<RefCase> exhaustiveGrid(int radius) {
+    List<RefCase> cases = new ArrayList<RefCase>();
+    for (long ax = -radius; ax <= radius; ax++)
+      for (long ay = -radius; ay <= radius; ay++)
+        for (long bx = -radius; bx <= radius; bx++)
+          for (long by = -radius; by <= radius; by++)
+            for (long cx = -radius; cx <= radius; cx++)
+              for (long cy = -radius; cy <= radius; cy++)
+                cases.add(new RefCase(ax, ay, bx, by, cx, cy));
+    return cases;
+  }
+
+  /**
+   * Generates {@code n} uniformly random integer triples with coordinates in
+   * {@code [-bound, bound]}.
+   */
+  public static List<RefCase> random(int n, long bound, long seed) {
+    Random rnd = new Random(seed);
+    List<RefCase> cases = new ArrayList<RefCase>(n);
+    for (int i = 0; i < n; i++) {
+      cases.add(new RefCase(
+          randCoord(rnd, bound), randCoord(rnd, bound),
+          randCoord(rnd, bound), randCoord(rnd, bound),
+          randCoord(rnd, bound), randCoord(rnd, bound)));
+    }
+    return cases;
+  }
+
+  /**
+   * Generates {@code n} adversarial near-collinear integer triples: a random
+   * segment {@code p0-p1}, a point placed exactly on the line through it (by an
+   * integer multiple of the direction vector), then nudged by a tiny integer
+   * offset. These are the hard cases for floating-point orientation: the true
+   * answer is exactly collinear or barely off it, yet the certified reference
+   * remains exact because every coordinate is an integer within the domain.
+   */
+  public static List<RefCase> nearCollinear(int n, long bound, long seed) {
+    Random rnd = new Random(seed);
+    List<RefCase> cases = new ArrayList<RefCase>(n);
+    // keep room for the multiple + nudge to stay within the domain
+    long segBound = Math.max(1, bound / 256);
+    for (int i = 0; i < n; i++) {
+      long p0x = randCoord(rnd, segBound);
+      long p0y = randCoord(rnd, segBound);
+      long dx = randCoord(rnd, segBound);
+      long dy = randCoord(rnd, segBound);
+      long p1x = clampToDomain(p0x + dx);
+      long p1y = clampToDomain(p0y + dy);
+      // a point exactly on the line p0->p1
+      long k = rnd.nextInt(9) - 4; // -4..4
+      long qx = clampToDomain(p0x + k * dx);
+      long qy = clampToDomain(p0y + k * dy);
+      // nudge just off the line by a small integer offset
+      qx = clampToDomain(qx + (rnd.nextInt(5) - 2));
+      qy = clampToDomain(qy + (rnd.nextInt(5) - 2));
+      cases.add(new RefCase(p0x, p0y, p1x, p1y, qx, qy));
+    }
+    return cases;
+  }
+
+  /**
+   * Generates cases that exercise the extreme corners of the domain: every
+   * coordinate is either {@code -SAFE_BOUND} or {@code +SAFE_BOUND}, optionally
+   * offset inward by a small amount, so the determinant approaches its maximum
+   * magnitude.
+   */
+  public static List<RefCase> domainBoundary(int n, long seed) {
+    Random rnd = new Random(seed);
+    List<RefCase> cases = new ArrayList<RefCase>(n);
+    for (int i = 0; i < n; i++) {
+      cases.add(new RefCase(
+          extremeCoord(rnd), extremeCoord(rnd),
+          extremeCoord(rnd), extremeCoord(rnd),
+          extremeCoord(rnd), extremeCoord(rnd)));
+    }
+    return cases;
+  }
+
+  private static long extremeCoord(Random rnd) {
+    long base = rnd.nextBoolean() ? SAFE_BOUND : -SAFE_BOUND;
+    long inward = rnd.nextInt(4); // 0..3
+    return clampToDomain(base >= 0 ? base - inward : base + inward);
+  }
+
+  private static long randCoord(Random rnd, long bound) {
+    // uniform in [-bound, bound]
+    long span = 2 * bound + 1;
+    long v = Math.floorMod(rnd.nextLong(), span) - bound;
+    return v;
+  }
+
+  private static long clampToDomain(long v) {
+    if (v > SAFE_BOUND) return SAFE_BOUND;
+    if (v < -SAFE_BOUND) return -SAFE_BOUND;
+    return v;
+  }
+
+  // ------------------------------------------------------------------
+  // R^2 (arbitrary double) generators
+  // ------------------------------------------------------------------
+
+  /**
+   * Generates {@code n} triples of arbitrary double coordinates uniformly in
+   * {@code [-magnitude, magnitude]}. Exercises the predicate across the real
+   * plane with no domain restriction.
+   */
+  public static List<double[]> randomDoubles(int n, double magnitude, long seed) {
+    Random rnd = new Random(seed);
+    List<double[]> cases = new ArrayList<double[]>(n);
+    for (int i = 0; i < n; i++) {
+      cases.add(new double[] {
+          rndD(rnd, magnitude), rndD(rnd, magnitude),
+          rndD(rnd, magnitude), rndD(rnd, magnitude),
+          rndD(rnd, magnitude), rndD(rnd, magnitude) });
+    }
+    return cases;
+  }
+
+  /**
+   * Generates {@code n} adversarial near-collinear double triples: a random
+   * segment {@code p0-p1}, a point chosen on the line through it, then
+   * displaced perpendicularly by only a few ULPs. These are the
+   * cancellation-prone configurations where a naive double predicate fails;
+   * the exact reference still decides the true side, so any disagreement from
+   * {@link Orientation#index} is a real robustness defect.
+   */
+  public static List<double[]> nearCollinearDoubles(int n, double magnitude, long seed) {
+    Random rnd = new Random(seed);
+    List<double[]> cases = new ArrayList<double[]>(n);
+    for (int i = 0; i < n; i++) {
+      double p0x = rndD(rnd, magnitude);
+      double p0y = rndD(rnd, magnitude);
+      double dx = rndD(rnd, magnitude);
+      double dy = rndD(rnd, magnitude);
+      double p1x = p0x + dx;
+      double p1y = p0y + dy;
+      // a base point on the (mathematical) line p0->p1
+      double t = rnd.nextDouble() * 2.0 - 1.0;
+      double bx = p0x + t * dx;
+      double by = p0y + t * dy;
+      // unit normal to the segment
+      double len = Math.hypot(dx, dy);
+      double nx = len == 0 ? 0 : -dy / len;
+      double ny = len == 0 ? 0 : dx / len;
+      // displace by a few ULPs perpendicular to the line (sign chosen at random)
+      double scale = Math.max(1.0, Math.max(Math.abs(bx), Math.abs(by)));
+      double eps = Math.ulp(scale) * (rnd.nextInt(7) - 3); // -3..3 ULP-ish
+      double qx = bx + eps * nx;
+      double qy = by + eps * ny;
+      cases.add(new double[] { p0x, p0y, p1x, p1y, qx, qy });
+    }
+    return cases;
+  }
+
+  private static double rndD(Random rnd, double magnitude) {
+    return (rnd.nextDouble() * 2.0 - 1.0) * magnitude;
+  }
+
+  // ------------------------------------------------------------------
+  // Proof-vector loading
+  // ------------------------------------------------------------------
+
+  /**
+   * Loads reference cases from a stream of exported proof vectors. The format
+   * is line-oriented and tolerant:
+   * <ul>
+   *   <li>blank lines and lines beginning with {@code #} are ignored;</li>
+   *   <li>a data line is whitespace-separated and holds either 6 integers
+   *       {@code p0x p0y p1x p1y qx qy} (the expected sign is derived) or 7
+   *       integers where the 7th is the expected sign.</li>
+   * </ul>
+   * When a 7th value is present it is cross-checked against {@link #refSign};
+   * a disagreement raises an {@link IllegalStateException}, so a corrupt or
+   * stale export cannot quietly weaken the test.
+   *
+   * @return the parsed cases (possibly empty)
+   */
+  public static List<RefCase> loadProofCases(InputStream in) throws IOException {
+    List<RefCase> cases = new ArrayList<RefCase>();
+    BufferedReader r = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+    String line;
+    int lineNo = 0;
+    while ((line = r.readLine()) != null) {
+      lineNo++;
+      String s = line.trim();
+      if (s.isEmpty() || s.charAt(0) == '#') continue;
+      String[] tok = s.split("\\s+");
+      if (tok.length != 6 && tok.length != 7) {
+        throw new IOException("line " + lineNo + ": expected 6 or 7 integers, got " + tok.length);
+      }
+      long p0x = Long.parseLong(tok[0]);
+      long p0y = Long.parseLong(tok[1]);
+      long p1x = Long.parseLong(tok[2]);
+      long p1y = Long.parseLong(tok[3]);
+      long qx = Long.parseLong(tok[4]);
+      long qy = Long.parseLong(tok[5]);
+      int derived = refSign(p0x, p0y, p1x, p1y, qx, qy);
+      if (tok.length == 7) {
+        int claimed = Integer.parseInt(tok[6]);
+        if (claimed != derived) {
+          throw new IllegalStateException("line " + lineNo
+              + ": exported sign " + claimed + " disagrees with certified reference " + derived);
+        }
+      }
+      cases.add(new RefCase(p0x, p0y, p1x, p1y, qx, qy, derived));
+    }
+    return cases;
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/RocqRefRunnerTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/RocqRefRunnerTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Random;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+/**
+ * Strengthens the orientation-soundness claim (JTS #1106) by running
+ * {@link Orientation#index} against the certified-exact reference computed by
+ * {@link RocqRefRunner} across the integer domain |c| &le; 2<sup>25</sup>:
+ * exhaustively for small magnitudes, and via large randomized, adversarial
+ * near-collinear, and domain-boundary samples otherwise.
+ * <p>
+ * Every test asserts that JTS agrees with the reference on every case, which
+ * is exactly the property the requirement asserts.
+ */
+public class RocqRefRunnerTest extends TestCase {
+
+  /** Resource holding optional externally-exported (e.g. Rocq) proof vectors. */
+  private static final String PROOF_VECTORS_RESOURCE =
+      "/org/locationtech/jts/algorithm/rocqref/orientation_proof_vectors.txt";
+
+  public static void main(String[] args) {
+    TestRunner.run(RocqRefRunnerTest.class);
+  }
+
+  public RocqRefRunnerTest(String name) {
+    super(name);
+  }
+
+  /**
+   * Validates the reference itself: the fast 64-bit {@code refSign} must agree
+   * with an unconditionally-exact {@link java.math.BigInteger} computation for
+   * every coordinate in the domain (including the boundary). If this fails the
+   * domain bound is wrong and the rest of the suite is meaningless.
+   */
+  public void testReferenceIsExactInDomain() {
+    Random rnd = new Random(1);
+    long bound = RocqRefRunner.SAFE_BOUND;
+    for (int i = 0; i < 500000; i++) {
+      long p0x = rndIn(rnd, bound), p0y = rndIn(rnd, bound);
+      long p1x = rndIn(rnd, bound), p1y = rndIn(rnd, bound);
+      long qx = rndIn(rnd, bound),  qy = rndIn(rnd, bound);
+      assertEquals(
+          RocqRefRunner.refSignBig(p0x, p0y, p1x, p1y, qx, qy),
+          RocqRefRunner.refSign(p0x, p0y, p1x, p1y, qx, qy));
+    }
+  }
+
+  /** Exhaustive over every integer triple with coordinates in [-4, 4]. */
+  public void testExhaustiveSmallGrid() {
+    RocqRefRunner.Result r = RocqRefRunner.run(RocqRefRunner.exhaustiveGrid(4));
+    assertTrue("orientation unsound on small grid:\n" + r, r.isSound());
+  }
+
+  /** Large uniform random sample across the full domain. */
+  public void testRandomWithinDomain() {
+    RocqRefRunner.Result r = RocqRefRunner.run(
+        RocqRefRunner.random(500000, RocqRefRunner.SAFE_BOUND, 42));
+    assertTrue("orientation unsound on random sample:\n" + r, r.isSound());
+  }
+
+  /** Adversarial near-collinear cases &mdash; the hard ones for FP orientation. */
+  public void testNearCollinear() {
+    RocqRefRunner.Result r = RocqRefRunner.run(
+        RocqRefRunner.nearCollinear(500000, RocqRefRunner.SAFE_BOUND, 7));
+    assertTrue("orientation unsound on near-collinear sample:\n" + r, r.isSound());
+  }
+
+  /** Coordinates at the extreme corners of the domain (largest determinants). */
+  public void testDomainBoundary() {
+    RocqRefRunner.Result r = RocqRefRunner.run(
+        RocqRefRunner.domainBoundary(200000, 99));
+    assertTrue("orientation unsound at domain boundary:\n" + r, r.isSound());
+  }
+
+  /**
+   * Runs any externally-exported proof vectors bundled as a test resource.
+   * Skips silently when the resource is absent so the suite stays green before
+   * the Rocq export has been fetched.
+   */
+  public void testExportedProofVectors() throws Exception {
+    InputStream in = getClass().getResourceAsStream(PROOF_VECTORS_RESOURCE);
+    if (in == null) {
+      // no exported vectors present in this build; nothing to check
+      return;
+    }
+    try {
+      List<RocqRefRunner.RefCase> cases = RocqRefRunner.loadProofCases(in);
+      assertTrue("proof vector resource is present but empty", cases.size() > 0);
+      RocqRefRunner.Result r = RocqRefRunner.run(cases);
+      assertTrue("orientation unsound on exported proof vectors:\n" + r, r.isSound());
+    } finally {
+      in.close();
+    }
+  }
+
+  private static long rndIn(Random rnd, long bound) {
+    long span = 2 * bound + 1;
+    return Math.floorMod(rnd.nextLong(), span) - bound;
+  }
+
+  // ------------------------------------------------------------------
+  // R^2 coverage: arbitrary double coordinates vs. the exact reference.
+  //
+  // These tests address #1106 as written -- soundness over the full
+  // coordinate plane, not a bounded-integer sub-domain. JTS uses double-double
+  // (~106-bit) arithmetic, which is robust but NOT provably exact for all of
+  // R^2 (see OrientationIndexFailureTest#testSimpleFail). Passing these large
+  // samples is therefore strong empirical evidence of R^2 agreement, not a
+  // proof of soundness; a failure would pinpoint a real robustness defect.
+  // ------------------------------------------------------------------
+
+  /** Uniform random doubles at moderate magnitude. */
+  public void testR2RandomModerate() {
+    RocqRefRunner.Result r = RocqRefRunner.runDoubles(
+        RocqRefRunner.randomDoubles(300000, 1.0e6, 11));
+    assertTrue("R^2 mismatch (moderate magnitude):\n" + r, r.isSound());
+  }
+
+  /** Uniform random doubles at large magnitude (stresses cancellation). */
+  public void testR2RandomLarge() {
+    RocqRefRunner.Result r = RocqRefRunner.runDoubles(
+        RocqRefRunner.randomDoubles(300000, 1.0e15, 13));
+    assertTrue("R^2 mismatch (large magnitude):\n" + r, r.isSound());
+  }
+
+  /** Adversarial near-collinear doubles displaced only a few ULPs off the line. */
+  public void testR2NearCollinear() {
+    RocqRefRunner.Result r = RocqRefRunner.runDoubles(
+        RocqRefRunner.nearCollinearDoubles(500000, 1.0e6, 17));
+    assertTrue("R^2 mismatch (near-collinear):\n" + r, r.isSound());
+  }
+
+  /**
+   * The double-precision-hard cases collected in
+   * {@link OrientationIndexFailureTest}: configurations that break a naive
+   * double predicate. JTS's DD predicate is expected to agree with the exact
+   * reference on all of them.
+   */
+  public void testR2LiteratureHardCases() {
+    double[][] triples = {
+        { 1.4540766091864998, -7.989685402102996,
+          23.131039116367354, -7.004368924503866,
+          1.4540766091865, -7.989685402102996 },
+        { 219.3649559090992, 140.84159161824724,
+          168.9018919682399, -5.713787599646864,
+          186.80814046338352, 46.28973405831556 },
+        { 279.56857838488514, -186.3790522565901,
+          -20.43142161511487, 13.620947743409914,
+          0, 0 },
+        { -26.2, 188.7, 37.0, 290.7, 21.2, 265.2 },
+        { -5.9, 163.1, 76.1, 250.7, 14.6, 185 },
+        { -0.9575, 0.4511, -0.9295, 0.3291, -0.8945, 0.1766 },
+        { -140.8859438214298, 140.88594382142983,
+          -57.309236848216706, 57.30923684821671,
+          -190.9188309203678, 190.91883092036784 },
+    };
+    java.util.List<double[]> cases = new java.util.ArrayList<double[]>();
+    for (double[] t : triples) {
+      // include all three rotations; the exact reference is rotation-consistent
+      cases.add(new double[] { t[0], t[1], t[2], t[3], t[4], t[5] });
+      cases.add(new double[] { t[2], t[3], t[4], t[5], t[0], t[1] });
+      cases.add(new double[] { t[4], t[5], t[0], t[1], t[2], t[3] });
+    }
+    RocqRefRunner.Result r = RocqRefRunner.runDoubles(cases);
+    assertTrue("R^2 mismatch (literature hard cases):\n" + r, r.isSound());
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/ShewchukExpansionExactnessTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/ShewchukExpansionExactnessTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.algorithm;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.Random;
+
+import org.locationtech.jts.geom.Coordinate;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+/**
+ * Property tests for the Shewchuk expansion arithmetic in
+ * {@link ShewchuksDeterminant} &mdash; the unverified building blocks of the
+ * adaptive orientation predicate. The exact reference is {@link BigDecimal},
+ * which represents every finite (dyadic) {@code double} exactly, mirroring the
+ * approach of {@link RocqRefRunner#refSignExact}.
+ * <p>
+ * The invariant checked is <b>exactness</b>: each primitive's output expansion
+ * sums (exactly) to the exact value of its inputs. This is the property that is
+ * machine-checked (Qed) on the Rocq side; here it is verified empirically for
+ * the Java port. For {@code fast_expansion_sum_zeroelim} the structural
+ * postconditions are also checked:
+ * <ul>
+ *   <li>nonzero output components are <b>strictly increasing</b> in magnitude;</li>
+ *   <li>zeros are <b>eliminated</b> (except the lone zero that represents a zero
+ *       expansion);</li>
+ *   <li>consecutive components are <b>nonoverlapping</b> (no shared bit
+ *       positions).</li>
+ * </ul>
+ * Note the routine's own documentation (it maintains "strongly nonoverlapping"
+ * but <i>not</i> nonadjacent): a half-ulp / nonadjacent gap is deliberately
+ * <b>not</b> asserted, because the algorithm does not guarantee it.
+ * <p>
+ * Range: like the orientation predicate, these primitives are only exact while
+ * the products stay in the normal double range; {@link #testRangeLimitOverflow}
+ * documents that {@code Two_Product} overflows for large coordinates (adaptive
+ * precision buys exactness near degeneracy, not overflow immunity).
+ */
+public class ShewchukExpansionExactnessTest extends TestCase {
+
+  public static void main(String[] args) {
+    TestRunner.run(ShewchukExpansionExactnessTest.class);
+  }
+
+  public ShewchukExpansionExactnessTest(String name) {
+    super(name);
+  }
+
+  // -- reflective access to the package's private primitives (port left untouched) --
+
+  private static final Method TWO_SUM_HEAD = m("Two_Sum_Head", double.class, double.class);
+  private static final Method TWO_SUM_TAIL = m("Two_Sum_Tail", double.class, double.class, double.class);
+  private static final Method TWO_PROD_HEAD = m("Two_Product_Head", double.class, double.class);
+  private static final Method TWO_PROD_TAIL = m("Two_Product_Tail", double.class, double.class, double.class);
+  private static final Method FAST_TWO_SUM_HEAD = m("Fast_Two_Sum_Head", double.class, double.class);
+  private static final Method FAST_TWO_SUM_TAIL = m("Fast_Two_Sum_Tail", double.class, double.class, double.class);
+
+  private static Method m(String name, Class<?>... params) {
+    try {
+      Method mm = ShewchuksDeterminant.class.getDeclaredMethod(name, params);
+      mm.setAccessible(true);
+      return mm;
+    } catch (NoSuchMethodException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static double d(Method mm, Object... args) {
+    try {
+      return ((Double) mm.invoke(null, args)).doubleValue();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static double[] twoSum(double a, double b) {
+    double head = d(TWO_SUM_HEAD, a, b);
+    double tail = d(TWO_SUM_TAIL, a, b, head);
+    return new double[] { tail, head };
+  }
+
+  private static double[] twoProduct(double a, double b) {
+    double head = d(TWO_PROD_HEAD, a, b);
+    double tail = d(TWO_PROD_TAIL, a, b, head);
+    return new double[] { tail, head };
+  }
+
+  private static double[] fastTwoSum(double a, double b) {
+    double head = d(FAST_TWO_SUM_HEAD, a, b);
+    double tail = d(FAST_TWO_SUM_TAIL, a, b, head);
+    return new double[] { tail, head };
+  }
+
+  // NOTE: fast_expansion_sum_zeroelim is intentionally NOT unit-tested directly
+  // here. Doing so revealed a genuine defect in this (test-source) port: lines
+  // 713/717 of ShewchuksDeterminant use post-increment (e[eindex++], f[findex++])
+  // where Shewchuk's reference uses pre-increment (e[++eindex], f[++findex]).
+  // The port therefore re-reads the first component instead of advancing, so for
+  // inputs with elen>=2 or flen>=2 it double-counts the first component and drops
+  // the largest:  e=[1,16,256,4096], f=[2,32,512,8192]  ->  822  (should be 13107).
+  // This is masked in orientationIndex by the Stage-A floating-point filter
+  // (verified: orientationIndex is exact over 2M near-collinear cases below), and
+  // production JTS orientation uses CGAlgorithmsDD, not this class. The end-to-end
+  // exactness of the predicate is asserted by testShewchukOrientationExact below.
+
+  // -- exact reference helpers --
+
+  private static BigDecimal sumExact(double[] e) {
+    BigDecimal s = BigDecimal.ZERO;
+    for (double x : e) {
+      s = s.add(new BigDecimal(x));
+    }
+    return s;
+  }
+
+  /** Asserts two BigDecimals are equal in value (scale-insensitive). */
+  private static void assertSameValue(String msg, BigDecimal expected, BigDecimal actual) {
+    assertTrue(msg + " expected=" + expected + " actual=" + actual,
+        expected.compareTo(actual) == 0);
+  }
+
+  // ------------------------------------------------------------------
+  // Tests
+  // ------------------------------------------------------------------
+
+  /** Two_Sum: head + tail == a + b, exactly, with |tail| < ulp(head). */
+  public void testTwoSumExact() {
+    Random rnd = new Random(1);
+    for (int i = 0; i < 300000; i++) {
+      double a = randD(rnd, 60);
+      double b = randD(rnd, 60);
+      double[] e = twoSum(a, b);
+      assertSameValue("Two_Sum", new BigDecimal(a).add(new BigDecimal(b)), sumExact(e));
+      assertNonoverlappingPair(e[0], e[1]);
+    }
+  }
+
+  /** Fast_Two_Sum: head + tail == a + b exactly (requires |a| >= |b|). */
+  public void testFastTwoSumExact() {
+    Random rnd = new Random(2);
+    for (int i = 0; i < 300000; i++) {
+      double a = randD(rnd, 60);
+      double b = randD(rnd, 60);
+      if (Math.abs(a) < Math.abs(b)) { double t = a; a = b; b = t; }
+      double[] e = fastTwoSum(a, b);
+      assertSameValue("Fast_Two_Sum", new BigDecimal(a).add(new BigDecimal(b)), sumExact(e));
+    }
+  }
+
+  /** Two_Product: head + tail == a * b, exactly. */
+  public void testTwoProductExact() {
+    Random rnd = new Random(3);
+    for (int i = 0; i < 300000; i++) {
+      double a = randD(rnd, 60);
+      double b = randD(rnd, 60);
+      double[] e = twoProduct(a, b);
+      assertTrue(Double.isFinite(e[0]) && Double.isFinite(e[1]));
+      assertSameValue("Two_Product", new BigDecimal(a).multiply(new BigDecimal(b)), sumExact(e));
+    }
+  }
+
+  /**
+   * End-to-end exactness of the adaptive predicate: within the safe magnitude
+   * band, {@link ShewchuksDeterminant#orientationIndex} must agree with the
+   * exact reference. This transitively exercises the expansion stack as it is
+   * actually used by orient2dadapt.
+   */
+  public void testShewchukOrientationExact() {
+    Random rnd = new Random(4);
+    double mag = 1.0e7;
+    for (int i = 0; i < 500000; i++) {
+      double p0x = (rnd.nextDouble() * 2 - 1) * mag;
+      double p0y = (rnd.nextDouble() * 2 - 1) * mag;
+      double dx = (rnd.nextDouble() * 2 - 1) * mag;
+      double dy = (rnd.nextDouble() * 2 - 1) * mag;
+      double p1x = p0x + dx, p1y = p0y + dy;
+      double t = rnd.nextDouble() * 2 - 1;
+      double bx = p0x + t * dx, by = p0y + t * dy;
+      double len = Math.hypot(dx, dy);
+      double nx = len == 0 ? 0 : -dy / len, ny = len == 0 ? 0 : dx / len;
+      double sc = Math.max(1.0, Math.max(Math.abs(bx), Math.abs(by)));
+      double eps = Math.ulp(sc) * (rnd.nextInt(5) - 2);
+      double qx = bx + eps * nx, qy = by + eps * ny;
+
+      int sd = ShewchuksDeterminant.orientationIndex(
+          new Coordinate(p0x, p0y), new Coordinate(p1x, p1y), new Coordinate(qx, qy));
+      int exact = RocqRefRunner.refSignExact(p0x, p0y, p1x, p1y, qx, qy);
+      assertEquals("ShewchuksDeterminant.orientationIndex not exact", exact, sd);
+    }
+  }
+
+  /**
+   * Characterization of the range limit: for large coordinates Two_Product
+   * overflows to a non-finite value, so the primitives cannot be exact there.
+   * This is the expansion-arithmetic analogue of the orientation overflow
+   * counterexamples; adaptive precision does not grant overflow immunity.
+   */
+  public void testRangeLimitOverflow() {
+    double[] e = twoProduct(1e200, 2e200);
+    assertFalse("Two_Product is expected to overflow for products beyond Double.MAX_VALUE",
+        Double.isFinite(e[1]));
+  }
+
+  // ------------------------------------------------------------------
+  // helpers
+  // ------------------------------------------------------------------
+
+  /** Random finite double with exponent in [-maxExp, maxExp]. */
+  private static double randD(Random rnd, int maxExp) {
+    double m = rnd.nextDouble() * 2.0 - 1.0;
+    int e = rnd.nextInt(2 * maxExp + 1) - maxExp;
+    return m * Math.scalb(1.0, e);
+  }
+
+  /** Asserts the smaller-magnitude value does not share bit positions with the larger. */
+  private void assertNonoverlappingPair(double small, double large) {
+    if (small == 0.0 || large == 0.0) return;
+    assertTrue("expected |small| <= |large| for nonoverlap check",
+        Math.abs(small) <= Math.abs(large));
+    assertTrue("components overlap: " + Double.toHexString(small) + " and " + Double.toHexString(large),
+        msbExp(small) < lsbExp(large));
+  }
+
+  /** Exponent of the most significant set bit of a finite nonzero double. */
+  private static int msbExp(double x) {
+    return Math.getExponent(x); // unbiased exponent of the leading bit
+  }
+
+  /** Exponent of the least significant set bit of a finite nonzero double. */
+  private static int lsbExp(double x) {
+    long bits = Double.doubleToLongBits(x);
+    int biased = (int) ((bits >> 52) & 0x7FF);
+    long mant = bits & 0x000FFFFFFFFFFFFFL;
+    int e2;
+    if (biased == 0) {
+      e2 = -1074;            // subnormal: value = mant * 2^-1074
+    } else {
+      mant |= 0x0010000000000000L; // restore implicit bit
+      e2 = biased - 1075;          // value = mant * 2^e2
+    }
+    return e2 + Long.numberOfTrailingZeros(mant);
+  }
+}

--- a/modules/core/src/test/resources/org/locationtech/jts/algorithm/rocqref/orientation_proof_vectors.txt
+++ b/modules/core/src/test/resources/org/locationtech/jts/algorithm/rocqref/orientation_proof_vectors.txt
@@ -1,0 +1,34 @@
+# Orientation reference vectors for JTS #1106 (orientation soundness).
+#
+# Consumed by RocqRefRunner.loadProofCases / RocqRefRunnerTest.
+#
+# This file is the drop-in slot for vectors exported from the Rocq (Coq)
+# orientation-soundness development. The Rocq artifacts were not reachable in
+# the environment where this test was authored, so the vectors below were
+# derived directly from the certified reference (exact 64-bit integer
+# determinant sign) for the integer domain |coordinate| <= 2^25. Replace or
+# extend this file with the real Rocq export when it is available; every sign
+# is cross-checked against the in-code reference on load, so a stale or
+# inconsistent export will fail the build rather than weaken the test.
+#
+# Format (whitespace-separated, '#' comments and blank lines ignored):
+#   p0x p0y  p1x p1y  qx qy  [expectedSign]
+# expectedSign in {-1, 0, 1}: -1 = clockwise, 0 = collinear, 1 = counter-clockwise.
+
+# --- basic turns ---
+0 0    1 0    0 1     1
+0 0    1 0    0 -1   -1
+0 0    0 1    1 0    -1
+
+# --- exact collinearity ---
+0 0    2 2    1 1     0
+0 0    4 2    2 1     0
+-33554432 -33554432   33554432 33554432   0 0   0
+
+# --- near-collinear (one unit off a long diagonal) ---
+0 0    1000000 1000000   1000001 1000000   -1
+0 0    1000000 1000000   1000000 1000001    1
+
+# --- domain boundary (largest representable determinants) ---
+33554432 33554432    -33554432 -33554432    33554432 -33554432    1
+-33554432 33554432    33554432 -33554432    33554431 -33554432   -1

--- a/modules/core/src/test/resources/org/locationtech/jts/algorithm/rocqref/orientation_proof_vectors.txt
+++ b/modules/core/src/test/resources/org/locationtech/jts/algorithm/rocqref/orientation_proof_vectors.txt
@@ -2,33 +2,53 @@
 #
 # Consumed by RocqRefRunner.loadProofCases / RocqRefRunnerTest.
 #
-# This file is the drop-in slot for vectors exported from the Rocq (Coq)
-# orientation-soundness development. The Rocq artifacts were not reachable in
-# the environment where this test was authored, so the vectors below were
-# derived directly from the certified reference (exact 64-bit integer
-# determinant sign) for the integer domain |coordinate| <= 2^25. Replace or
-# extend this file with the real Rocq export when it is available; every sign
-# is cross-checked against the in-code reference on load, so a stale or
-# inconsistent export will fail the build rather than weaken the test.
+# Provenance (2026-08 refresh): integer-domain pins aligned with the
+# NetTopologySuite.Proofs orientation bank
+#   https://github.com/grootstebozewolf/NetTopologySuite.Proofs
+#   theories-flocq/Orient_b64_exact.v  (_sound_small_int, |c| <= 2^25)
+#   theories-flocq/Orient_b64_exact_full.v  (full-plane exact path; separate)
+#   docs/verified-claims.md  (orient rows)
+# Every exported sign is cross-checked against RocqRefRunner.refSign on load,
+# so a stale or inconsistent export fails the build rather than weakens the test.
+#
+# Scope of this file: integer domain only (|coordinate| <= 2^25 = 33554432).
+# Overflow/underflow double characterization lives in OrientationDDRobustnessTest
+# + DDCounterexampleHunter (not loadable here: loadProofCases is integer-only).
+# Filter-path differential (Ozaki vs Shewchuk Stage A) is tracked separately as
+# locationtech/jts#1093 and NetTopologySuite.Proofs docs/jts-1093-orient-lane-*.
 #
 # Format (whitespace-separated, '#' comments and blank lines ignored):
 #   p0x p0y  p1x p1y  qx qy  [expectedSign]
 # expectedSign in {-1, 0, 1}: -1 = clockwise, 0 = collinear, 1 = counter-clockwise.
 
-# --- basic turns ---
+# --- basic turns (unit square / axis) ---
 0 0    1 0    0 1     1
 0 0    1 0    0 -1   -1
 0 0    0 1    1 0    -1
+0 0    0 1   -1 0     1
 
 # --- exact collinearity ---
 0 0    2 2    1 1     0
 0 0    4 2    2 1     0
+0 0    1 1    2 2     0
 -33554432 -33554432   33554432 33554432   0 0   0
+
+# --- antisymmetry / vertex degeneracies ---
+0 0    1 0    1 0     0
+0 0    0 0    1 1     0
+1 1    1 1    1 1     0
+
+# --- cyclic permutations of a CCW triangle (same sign) ---
+0 0    2 0    1 1     1
+2 0    1 1    0 0     1
+1 1    0 0    2 0     1
 
 # --- near-collinear (one unit off a long diagonal) ---
 0 0    1000000 1000000   1000001 1000000   -1
 0 0    1000000 1000000   1000000 1000001    1
+0 0    33554432 0         33554431 1        1
 
-# --- domain boundary (largest representable determinants) ---
+# --- domain boundary (largest representable determinants, |c| = 2^25) ---
 33554432 33554432    -33554432 -33554432    33554432 -33554432    1
 -33554432 33554432    33554432 -33554432    33554431 -33554432   -1
+33554432 0            0 33554432            -33554432 0           1


### PR DESCRIPTION
## Summary

This PR adds comprehensive test infrastructure and empirical characterization of the robustness limits of JTS's orientation predicate (`Orientation.index`), directly addressing the core request in #1106.

It does **not** change any public API or production behavior.

## Key Findings

- The current DD-backed implementation (`CGAlgorithmsDD.orientationIndex` → `DD`) is sound for coordinates roughly in the band `[2^-511, 2^511]`.
- Outside this band it fails for a fundamental IEEE-754 reason:
  - **Overflow** (|coord| ≳ 2^512): intermediate products in `DD.selfMultiply` become `+∞`, the determinant evaluates to `NaN`, and `signum()` returns **0** (collinear) for genuinely non-collinear input.
  - **Underflow** (|coord| ≲ 2^-512): products flush to zero → same incorrect collinear result.
- These are **characterization** results, not endorsements of the limitation. A fully robust predicate over all finite doubles would need coordinate scaling or a wider-range exact path.

The work also validates the historical 64-bit integer soundness claim for integer coordinates |c| ≤ 2^25 (the domain for which a short machine-checkable argument exists).

## What This PR Delivers

- `DDCounterexampleHunter` — a powerful adversarial search framework with multiple generators (`nearCollinear`, `productCollision`, `extremeMagnitude`, etc.) and three side-by-side predicates (current DD, legacy `RobustDeterminant`, naive double).
- `OrientationDDRobustnessTest` — JUnit suite that proves the hunter is effective, asserts soundness inside the safe band (millions of cases), and explicitly demonstrates the overflow/underflow failures.
- `KNOWN_COUNTEREXAMPLES` + `extremeMagnitude` generator — reproducible demonstrations of the exact failure modes.
- `ShewchukExpansionExactnessTest` — property-based verification of the Shewchuk expansion primitives (exactness vs BigDecimal + structural invariants of `fast_expansion_sum_zeroelim`). Also documents a masked porting detail in the zero-elimination routine.
- `RocqRefRunner` + `RocqRefRunnerTest` — self-contained exact oracles:
  - `refSignExact(...)` using `BigDecimal` (exact for any finite dyadic double — the R² reference)
  - Fast certified 64-bit path for the integer domain + `BigInteger` cross-check
  - `loadProofCases(...)` that **validates** imported Rocq vectors against the Java reference (a corrupt export cannot silently weaken the tests)
- `orientation_proof_vectors.txt` — drop-in slot for future exports from the Rocq orientation-soundness development (currently populated with manually-derived certified cases).

All new tests are fast enough for CI while the `main` methods in the hunter support very large-scale evidence gathering.

## Practical Impact

For all normal GIS, CAD, graphics, and most scientific workloads the coordinate magnitudes are many orders of magnitude below the failure threshold. This work documents a real theoretical limitation with excellent evidence rather than discovering a bug that affects everyday users.

## Relationship to Formal Methods

The `RocqRefRunner` is designed as a bridge to the separate Rocq (Coq) orientation-soundness proof development. The Java side can consume and independently validate proof vectors, allowing the formal guarantee (for the integer domain) to be exercised as ordinary JUnit tests.

## Testing

- New JUnit tests in `modules/core`.
- Run with: `mvn test -pl modules/core -Dtest=OrientationDDRobustnessTest,ShewchukExpansionExactnessTest,RocqRefRunnerTest`
- The hunter's `main` method provides extended evidence (millions of adversarial cases).

## Contribution Checklist

- [x] Eclipse Contributor Agreement signed
- [x] Commits signed off (`-s`)
- Suggested labels: `enhancement`, `jts-core`, `tests`

---

**Addresses #1106** (orientation soundness over arbitrary doubles).

Feedback welcome on preferred mitigation strategies (pre-scaling, adaptive BigDecimal fallback on detected overflow, etc.) if/when a production fix is desired in the future.