### PR TITLE
Add equals/hashCode consistent with compareTo for value-semantics Comparable classes

### DIFF
--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -58,6 +58,7 @@ Distributions for older JTS versions can be obtained at the
 * Fix `LineSegment.project` to handle segments projecting onto a single endpoint (#1179)
 * Fix DD equals and compareTo (#1186)
 * Fix `RelateNG.computeLineEnds` incorrectly skipping boundary points for disjoint line components (#1175)
+* Add `equals` and `hashCode` consistent with `compareTo` for value-semantics `Comparable` classes (`LinearLocation`, `EdgeIntersection`, `NodeSection`, `OrientedCoordinateArray`) (#1184)
 
 ### Performance Improvements
 

--- a/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeIntersection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeIntersection.java
@@ -12,6 +12,7 @@
 package org.locationtech.jts.geomgraph;
 
 import java.io.PrintStream;
+import java.util.Objects;
 
 import org.locationtech.jts.geom.Coordinate;
 
@@ -62,6 +63,27 @@ public class EdgeIntersection
     EdgeIntersection other = (EdgeIntersection) obj;
     return compare(other.segmentIndex, other.dist);
   }
+
+  /**
+   * Tests whether this intersection is at the same location
+   * (segment index and distance) as another.
+   * This is consistent with {@link #compareTo(Object)}.
+   *
+   * @param o the object to compare to
+   * @return true if this intersection is at the same location as the argument
+   */
+  public boolean equals(Object o)
+  {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    return compareTo(o) == 0;
+  }
+
+  public int hashCode()
+  {
+    return Objects.hash(segmentIndex, dist);
+  }
+
   /**
    * Comparison with segment and distance.
    *

--- a/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
+++ b/modules/core/src/main/java/org/locationtech/jts/linearref/LinearLocation.java
@@ -12,6 +12,8 @@
 
 package org.locationtech.jts.linearref;
 
+import java.util.Objects;
+
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineSegment;
@@ -332,6 +334,24 @@ public class LinearLocation
     if (segmentFraction > other.segmentFraction) return 1;
     // same location
     return 0;
+  }
+
+  /**
+   * Tests whether this location is equal to another,
+   * i.e. has the same component index, segment index and segment fraction.
+   * This is consistent with {@link #compareTo(Object)}.
+   *
+   * @param o the object to compare to
+   * @return true if the locations are equal
+   */
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    return compareTo(o) == 0;
+  }
+
+  public int hashCode() {
+    return Objects.hash(componentIndex, segmentIndex, segmentFraction);
   }
 
   /**

--- a/modules/core/src/main/java/org/locationtech/jts/noding/OrientedCoordinateArray.java
+++ b/modules/core/src/main/java/org/locationtech/jts/noding/OrientedCoordinateArray.java
@@ -79,6 +79,36 @@ public class OrientedCoordinateArray
     return comp;
   }
 
+  /**
+   * Tests whether this oriented coordinate array is equal to another,
+   * i.e. represents the same coordinate sequence up to orientation.
+   * This is consistent with {@link #compareTo(Object)}.
+   *
+   * @param o the object to compare to
+   * @return true if the arrays are equal (orientation-independently)
+   */
+  public boolean equals(Object o)
+  {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    return compareTo(o) == 0;
+  }
+
+  public int hashCode()
+  {
+    // Walk the points in canonical orientation order (as compareTo does),
+    // so an array and its reverse -- which are equal here -- hash equally.
+    int dir = orientation ? 1 : -1;
+    int limit = orientation ? pts.length : -1;
+    int i = orientation ? 0 : pts.length - 1;
+    int result = 17;
+    while (i != limit) {
+      result = 31 * result + pts[i].hashCode();
+      i += dir;
+    }
+    return result;
+  }
+
   private static int compareOriented(Coordinate[] pts1,
                                      boolean orientation1,
                                      Coordinate[] pts2,

--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/NodeSection.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/NodeSection.java
@@ -12,6 +12,7 @@
 package org.locationtech.jts.operation.relateng;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 import org.locationtech.jts.algorithm.PolygonNodeTopology;
 import org.locationtech.jts.geom.Coordinate;
@@ -182,7 +183,29 @@ class NodeSection implements Comparable<NodeSection>
     
     return compareWithNull(v1, o.v1);
   }
-  
+
+  /**
+   * Tests whether this section is equal to another,
+   * i.e. has the same parent geometry, dimension, element id, ring id
+   * and edge vertices.
+   * Like {@link #compareTo(NodeSection)}, sections are assumed to be
+   * at the same node point, and this is consistent with that ordering.
+   *
+   * @param o the object to compare to
+   * @return true if the sections are equal
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    return compareTo((NodeSection) o) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(isA, dim, id, ringId, v0, v1);
+  }
+
   private static int compareWithNull(Coordinate v0, Coordinate v1) {
     if (v0 == null) {
       if (v1 == null) 

--- a/modules/core/src/test/java/org/locationtech/jts/geomgraph/EdgeIntersectionTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/geomgraph/EdgeIntersectionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.geomgraph;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.locationtech.jts.geom.Coordinate;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+/**
+ * Tests {@link EdgeIntersection#equals(Object)} and {@link EdgeIntersection#hashCode()}
+ * for consistency with {@link EdgeIntersection#compareTo(Object)} (JTS #1184).
+ */
+public class EdgeIntersectionTest extends TestCase {
+
+  public static void main(String args[]) {
+    TestRunner.run(EdgeIntersectionTest.class);
+  }
+
+  public EdgeIntersectionTest(String name) { super(name); }
+
+  public void testEqualsValuesConsistentWithCompareTo() {
+    EdgeIntersection ei = new EdgeIntersection(new Coordinate(1, 2), 3, 0.5);
+    EdgeIntersection eiSame = new EdgeIntersection(new Coordinate(1, 2), 3, 0.5);
+    assertTrue(ei.compareTo(eiSame) == 0);
+    assertEquals(ei, eiSame);
+  }
+
+  public void testEqualsHashCodeContract() {
+    EdgeIntersection ei = new EdgeIntersection(new Coordinate(1, 2), 3, 0.5);
+    EdgeIntersection eiSame = new EdgeIntersection(new Coordinate(1, 2), 3, 0.5);
+    assertEquals(ei.hashCode(), eiSame.hashCode());
+    Set<EdgeIntersection> set = new HashSet<EdgeIntersection>();
+    set.add(ei);
+    set.add(eiSame);
+    assertEquals(1, set.size());
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/linearref/LinearLocationTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/linearref/LinearLocationTest.java
@@ -39,6 +39,28 @@ public class LinearLocationTest
 
   public LinearLocationTest(String name) { super(name); }
 
+  public void testEqualsValuesConsistentWithCompareTo() throws Exception
+  {
+    LinearLocation loc = new LinearLocation(1, 2, 0.5);
+    LinearLocation locSame = new LinearLocation(1, 2, 0.5);
+    // two locations the compareTo orders as equal must also be equals()
+    assertTrue(loc.compareTo(locSame) == 0);
+    assertEquals(loc, locSame);
+  }
+
+  public void testEqualsHashCodeContract() throws Exception
+  {
+    LinearLocation loc = new LinearLocation(1, 2, 0.5);
+    LinearLocation locSame = new LinearLocation(1, 2, 0.5);
+    // equal objects must report equal hash codes (Object.equals/hashCode contract)
+    assertEquals(loc.hashCode(), locSame.hashCode());
+    // and must therefore deduplicate in hash-based collections
+    java.util.Set<LinearLocation> set = new java.util.HashSet<LinearLocation>();
+    set.add(loc);
+    set.add(locSame);
+    assertEquals(1, set.size());
+  }
+
   public void testZeroLengthLineString() throws Exception
   {
     Geometry line = reader.read("LINESTRING (10 0, 10 0)");

--- a/modules/core/src/test/java/org/locationtech/jts/noding/OrientedCoordinateArrayTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/noding/OrientedCoordinateArrayTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.noding;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.locationtech.jts.geom.Coordinate;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+/**
+ * Tests {@link OrientedCoordinateArray#equals(Object)} and
+ * {@link OrientedCoordinateArray#hashCode()} for consistency with
+ * {@link OrientedCoordinateArray#compareTo(Object)} (JTS #1184), including
+ * the orientation-independence the class exists to provide.
+ */
+public class OrientedCoordinateArrayTest extends TestCase {
+
+  public static void main(String args[]) {
+    TestRunner.run(OrientedCoordinateArrayTest.class);
+  }
+
+  public OrientedCoordinateArrayTest(String name) { super(name); }
+
+  private static Coordinate[] coords(double... xy) {
+    Coordinate[] pts = new Coordinate[xy.length / 2];
+    for (int i = 0; i < pts.length; i++)
+      pts[i] = new Coordinate(xy[2 * i], xy[2 * i + 1]);
+    return pts;
+  }
+
+  private static Coordinate[] reverse(Coordinate[] pts) {
+    Coordinate[] r = new Coordinate[pts.length];
+    for (int i = 0; i < pts.length; i++)
+      r[i] = pts[pts.length - 1 - i];
+    return r;
+  }
+
+  public void testEqualsValuesConsistentWithCompareTo() {
+    Coordinate[] pts = coords(0, 0, 1, 1, 2, 0);
+    OrientedCoordinateArray a = new OrientedCoordinateArray(pts);
+    OrientedCoordinateArray b = new OrientedCoordinateArray(coords(0, 0, 1, 1, 2, 0));
+    assertTrue(a.compareTo(b) == 0);
+    assertEquals(a, b);
+  }
+
+  public void testEqualsHashCodeContract() {
+    OrientedCoordinateArray a = new OrientedCoordinateArray(coords(0, 0, 1, 1, 2, 0));
+    OrientedCoordinateArray b = new OrientedCoordinateArray(coords(0, 0, 1, 1, 2, 0));
+    assertEquals(a.hashCode(), b.hashCode());
+    Set<OrientedCoordinateArray> set = new HashSet<OrientedCoordinateArray>();
+    set.add(a);
+    set.add(b);
+    assertEquals(1, set.size());
+  }
+
+  public void testEqualsHashCodeOrientationIndependent() {
+    // an asymmetric array, so a stored-order hash would differ from its reverse
+    Coordinate[] pts = coords(0, 0, 5, 1, 2, 7, 9, 3);
+    OrientedCoordinateArray fwd = new OrientedCoordinateArray(pts);
+    OrientedCoordinateArray rev = new OrientedCoordinateArray(reverse(pts));
+    // the class compares orientation-independently, so these are equal ...
+    assertTrue(fwd.compareTo(rev) == 0);
+    assertEquals(fwd, rev);
+    // ... therefore their hash codes must agree, and they must dedup
+    assertEquals(fwd.hashCode(), rev.hashCode());
+    Set<OrientedCoordinateArray> set = new HashSet<OrientedCoordinateArray>();
+    set.add(fwd);
+    set.add(rev);
+    assertEquals(1, set.size());
+  }
+}

--- a/modules/core/src/test/java/org/locationtech/jts/operation/relateng/NodeSectionTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/operation/relateng/NodeSectionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jts.operation.relateng;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Dimension;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+/**
+ * Tests {@link NodeSection#equals(Object)} and {@link NodeSection#hashCode()}
+ * for consistency with {@link NodeSection#compareTo(NodeSection)} (JTS #1184).
+ */
+public class NodeSectionTest extends TestCase {
+
+  public static void main(String args[]) {
+    TestRunner.run(NodeSectionTest.class);
+  }
+
+  public NodeSectionTest(String name) { super(name); }
+
+  private static NodeSection section(int id, Coordinate v0, Coordinate v1) {
+    Coordinate nodePt = new Coordinate(5, 5);
+    return new NodeSection(true, Dimension.A, id, 0, null, false, v0, nodePt, v1);
+  }
+
+  public void testEqualsValuesConsistentWithCompareTo() {
+    NodeSection ns = section(1, new Coordinate(0, 0), new Coordinate(10, 10));
+    NodeSection nsSame = section(1, new Coordinate(0, 0), new Coordinate(10, 10));
+    assertTrue(ns.compareTo(nsSame) == 0);
+    assertEquals(ns, nsSame);
+  }
+
+  public void testEqualsHashCodeContract() {
+    NodeSection ns = section(1, new Coordinate(0, 0), new Coordinate(10, 10));
+    NodeSection nsSame = section(1, new Coordinate(0, 0), new Coordinate(10, 10));
+    assertEquals(ns.hashCode(), nsSame.hashCode());
+    Set<NodeSection> set = new HashSet<NodeSection>();
+    set.add(ns);
+    set.add(nsSame);
+    assertEquals(1, set.size());
+  }
+}


### PR DESCRIPTION
Several JTS classes implement `Comparable` with a meaningful `compareTo()` but do not override `equals()`, so two objects that `compareTo()` orders as equal (returns 0) are not equal by `equals()`. This violates the recommended consistency between `compareTo` and `equals`, and means the affected types misbehave as keys in hash-based collections.

Add `equals()` and `hashCode()` to the classes whose `compareTo` defines a genuine value equality, defining `equals()` as `(compareTo == 0)` so the relation holds by construction, with `hashCode()` over the same fields.

### Changes Made:
- `LinearLocation` — `(componentIndex, segmentIndex, segmentFraction)`.
- `EdgeIntersection` — `(segmentIndex, dist)`.
- `NodeSection` — `(isA, dim, id, ringId, v0, v1)`.
- `OrientedCoordinateArray` — points walked in canonical orientation order, so an array and its reverse (which compare equal) hash equally.
- Add consistency tests for each updated class (equals/compareTo agreement, the equals/hashCode contract, and orientation-independence for `OrientedCoordinateArray`).
- Update history.

The remaining `Comparable` classes (`BoundablePair`, `EdgeEnd`, `Corner`, `SweepLineEvent`, `OffsetCurveSection`, …) use `compareTo` as a sort or priority ordering keyed on a subset of state, where `compareTo == 0` does not imply object identity (e.g. `BoundablePair` orders by distance only). Aligning `equals` there would conflate distinct objects, so they are intentionally left unchanged, as the `Comparable` contract permits.

**Fixes #1184**
