### PR TITLE
Add DD.hashCode consistent with DD.equals

### DIFF
--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -58,6 +58,7 @@ Distributions for older JTS versions can be obtained at the
 * Fix `LineSegment.project` to handle segments projecting onto a single endpoint (#1179)
 * Fix DD equals and compareTo (#1186)
 * Fix `RelateNG.computeLineEnds` incorrectly skipping boundary points for disjoint line components (#1175)
+* Add `DD.hashCode` consistent with `DD.equals` (#1186)
 
 ### Performance Improvements
 

--- a/modules/core/src/main/java/org/locationtech/jts/math/DD.java
+++ b/modules/core/src/main/java/org/locationtech/jts/math/DD.java
@@ -12,6 +12,7 @@
 package org.locationtech.jts.math;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Implements extended-precision floating-point numbers 
@@ -992,7 +993,16 @@ public strictfp final class DD
     DD dd = (DD) o;
     return hi == dd.hi && lo == dd.lo;
   }
-  
+
+  public int hashCode()
+  {
+    // equals() compares hi/lo with ==, under which -0.0 and +0.0 are equal,
+    // whereas Double.hashCode distinguishes them. Adding 0.0 normalizes
+    // -0.0 to +0.0 (and leaves every other value unchanged) so that equal
+    // values always hash equally.
+    return Objects.hash(hi + 0.0, lo + 0.0);
+  }
+
   /**
    * Tests whether this value is greater than another <tt>DoubleDouble</tt> value.
    * @param y a DoubleDouble value

--- a/modules/core/src/test/java/org/locationtech/jts/math/DDBasicTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/math/DDBasicTest.java
@@ -30,6 +30,31 @@ public class DDBasicTest
 
   public DDBasicTest(String name) { super(name); }
 
+  public void testEqualsHashCodeContract()
+  {
+    DD a = new DD(1.5, 1e-20);
+    DD b = new DD(1.5, 1e-20);
+    assertTrue(a.equals(b));
+    // equal objects must report equal hash codes
+    assertEquals(a.hashCode(), b.hashCode());
+    java.util.Set<DD> set = new java.util.HashSet<DD>();
+    set.add(a);
+    set.add(b);
+    assertEquals(1, set.size());
+  }
+
+  public void testEqualsHashCodeSignedZero()
+  {
+    // equals() compares hi/lo with ==, so -0.0 and +0.0 are equal;
+    // hashCode() must agree even though Double.hashCode distinguishes them.
+    // A mixed sign (one component -0.0, the other +0.0) is the case that
+    // a naive Objects.hash(hi, lo) gets wrong.
+    DD posZero = new DD(0.0, 0.0);
+    DD negZero = new DD(-0.0, 0.0);
+    assertTrue(posZero.equals(negZero));
+    assertEquals(posZero.hashCode(), negZero.hashCode());
+  }
+
   public void testNaN()
   {
   	assertTrue(DD.valueOf(1).divide(DD.valueOf(0)).isNaN());


### PR DESCRIPTION
`DD` implements value-based `equals(Object)` (added in #1186) but does not override `hashCode()`, so two `DD` values that are equal report different (identity) hash codes and misbehave when used in hash-based collections. This is a follow-up to #1186 adding the missing `hashCode()`.

### Changes Made:
- Add `DD.hashCode()` over `(hi, lo)`, the same fields `equals()` compares.
- `equals()` compares `hi`/`lo` with `==`, under which `-0.0` and `+0.0` are equal, whereas `Double.hashCode` distinguishes them. The hash normalizes signed zero (adding `0.0`, which maps `-0.0` to `+0.0` and leaves every other value unchanged) so equal values always hash equally.
- Add tests for the `equals`/`hashCode` contract, including the signed-zero edge case.
- Update history.

Follow-up to #1186.
