### PR TITLE
Fix BaseGeometryFunction.hashCode to be consistent with equals

### DIFF
--- a/doc/JTS_Version_History.md
+++ b/doc/JTS_Version_History.md
@@ -76,6 +76,10 @@ Distributions for older JTS versions can be obtained at the
 * Add Layer List Zoom to Geometry button
 * Add Layer List Copy Geometry button
 
+### Bug Fixes
+
+* Fix `BaseGeometryFunction.hashCode` to be consistent with `equals` (exclude parameter names)
+
 # Version 1.20.0
 
 *Release Date: 09/18/2024*

--- a/modules/app/src/main/java/org/locationtech/jtstest/geomfunction/BaseGeometryFunction.java
+++ b/modules/app/src/main/java/org/locationtech/jtstest/geomfunction/BaseGeometryFunction.java
@@ -184,10 +184,12 @@ implements GeometryFunction, Comparable
    */
   @Override
   public int hashCode() {
+    // Must use the same fields as equals() (the function signature:
+    // name, parameter types, return type). Parameter names are not part
+    // of equality, so they must not contribute to the hash code.
     final int prime = 31;
     int result = 1;
     result = prime * result + ((name == null) ? 0 : name.hashCode());
-    result = prime * result + Arrays.hashCode(parameterNames);
     result = prime * result + Arrays.hashCode(parameterTypes);
     result = prime * result + ((returnType == null) ? 0 : returnType.hashCode());
     return result;

--- a/modules/app/src/test/java/org/locationtech/jtstest/geomfunction/BaseGeometryFunctionTest.java
+++ b/modules/app/src/test/java/org/locationtech/jtstest/geomfunction/BaseGeometryFunctionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Vivid Solutions.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.locationtech.jtstest.geomfunction;
+
+import org.locationtech.jts.geom.Geometry;
+
+import junit.framework.TestCase;
+import junit.textui.TestRunner;
+
+/**
+ * Tests that {@link BaseGeometryFunction#hashCode()} is consistent with
+ * {@link BaseGeometryFunction#equals(Object)}: equality is defined by the
+ * function signature (name, parameter types, return type), so two functions
+ * equal by that definition must report the same hash code.
+ */
+public class BaseGeometryFunctionTest extends TestCase {
+
+  public static void main(String args[]) {
+    TestRunner.run(BaseGeometryFunctionTest.class);
+  }
+
+  public BaseGeometryFunctionTest(String name) { super(name); }
+
+  private static class TestFunction extends BaseGeometryFunction {
+    TestFunction(String category, String name, String[] parameterNames,
+        Class[] parameterTypes, Class returnType) {
+      super(category, name, parameterNames, parameterTypes, returnType);
+    }
+    public Object invoke(Geometry geom, Object[] args) { return null; }
+  }
+
+  public void testEqualsHashCodeContract() {
+    // equals() is defined by the signature and ignores parameter names,
+    // so these two functions are equal ...
+    BaseGeometryFunction a = new TestFunction("cat", "fn",
+        new String[] { "x" }, new Class[] { Geometry.class }, Geometry.class);
+    BaseGeometryFunction b = new TestFunction("cat", "fn",
+        new String[] { "y" }, new Class[] { Geometry.class }, Geometry.class);
+    assertTrue(a.equals(b));
+    // ... therefore they must report equal hash codes
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+}


### PR DESCRIPTION
`BaseGeometryFunction.equals()` defines two functions as equal when they have the same signature (name, parameter types and return type), and explicitly ignores parameter names. `hashCode()`, however, also mixed in the parameter names (`Arrays.hashCode(parameterNames)`), so two functions that are equal but differ only in their parameter names produced different hash codes — violating the `Object.equals`/`hashCode` contract and causing them to misbehave as keys in hash-based collections.

### Changes Made:
- Drop `parameterNames` from `BaseGeometryFunction.hashCode()` so it uses exactly the fields `equals()` compares (name, parameter types, return type).
- Add a test for the `equals`/`hashCode` contract.
- Update history (TestBuilder Bug Fixes).

`compareTo()` remains ordered by name and return type only — coarser than `equals()`, which the `Comparable` contract permits — so it is left unchanged.

This was found by a conformance sweep of the `jts-io` and `jts-app` modules for `equals`/`hashCode`/`Comparable` inconsistencies; `jts-io` was clean.
