### PR TITLE
Fix KMLReader XML parser security hole

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/kml/KMLReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/kml/KMLReader.java
@@ -97,6 +97,10 @@ public class KMLReader {
         this.attributeNames = attributeNames == null
                 ? Collections.emptySet()
                 : new HashSet<>(attributeNames);
+        // Disable DTDs completely (prevents DOCTYPE declarations)
+        inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        // Prevent external entity expansion from DTDs
+        inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
     }
 
     /**


### PR DESCRIPTION
Fixes teh `KMLReader` usage of XML parser to avoid exposure to the XXE security hole.

The original report said:

> We discovered that there’s lack of hardening for XXE for the KMLReader (jts-core).
> 
> Problem: The class initialises its XMLInputFactory via XMLInputFactory.newInstance() at field declaration (modules/core/src/main/java/org/locationtech/jts/io/kml/KMLReader.java and never sets SUPPORT_DTD or IS_SUPPORTING_EXTERNAL_ENTITIES. None of the four public constructors accept a caller-supplied factory either, so a consumer cannot harden it from outside.
> 
> Impact: This leads to an XXE vulnerability in a project depending on the KMLReader.
> 
> Potential fix: KML geometry has no legitimate use for DTDs or external entities, so this should not change behaviour for valid input. 
