### PR TITLE
Bump net.sourceforge.pmd:pmd-core from 6.36.0 to 7.22.0

### DIFF
--- a/build-tools/src/main/resources/jts/pmd-ruleset.xml
+++ b/build-tools/src/main/resources/jts/pmd-ruleset.xml
@@ -40,7 +40,7 @@ under the License.
     -->
     
     <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" />
-    <rule ref="category/java/performance.xml/BooleanInstantiation" />
+    <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation" />
     <!--
     <rule ref="category/java/performance.xml/ByteInstantiation" />
     <rule ref="category/java/performance.xml/IntegerInstantiation" />

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <!-- build environment target versions -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <pmd.version>6.36.0</pmd.version>
+        <pmd.version>7.22.0</pmd.version>
         <checkstyle.version>8.44</checkstyle.version>
         <!--cast, deprecation, divzero, empty, fallthrough, finally, overrides, path, serial, and unchecked -->
         <lint>unchecked</lint>
@@ -241,7 +241,7 @@
                 </plugin>
                 <plugin>
                   <artifactId>maven-pmd-plugin</artifactId>
-                  <version>3.14.0</version>
+                  <version>3.28.0</version>
                 </plugin>
                 <plugin>
                   <artifactId>maven-project-info-reports-plugin</artifactId>


### PR DESCRIPTION
Bump net.sourceforge.pmd:pmd-core from 6.36.0 to 7.22.0.  Fix obsolete PMD rules.