### PR TITLE
Use try-with-resources in WKT and WKB readers

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/io/WKBHexFileReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKBHexFileReader.java
@@ -110,21 +110,18 @@ public class WKBHexFileReader
 	public List read() 
 	throws IOException, ParseException 
 	{
-    // do this here so that constructors don't throw exceptions
-    if (file != null)
-      reader = new FileReader(file);
-    
-		count = 0;
-		try {
-			BufferedReader bufferedReader = new BufferedReader(reader);
-			try {
-				return read(bufferedReader);
-			} finally {
-				bufferedReader.close();
-			}
-		} finally {
-			reader.close();
+		Reader inputReader;
+		if (file != null) {
+			inputReader = new FileReader(file);
+		} else {
+			inputReader = reader;
 		}
+
+		count = 0;
+		try (BufferedReader bufferedReader = new BufferedReader(inputReader)) {
+			return read(bufferedReader);
+		}
+
 	}
 	
 	private List read(BufferedReader bufferedReader) throws IOException,

--- a/modules/core/src/main/java/org/locationtech/jts/io/WKTFileReader.java
+++ b/modules/core/src/main/java/org/locationtech/jts/io/WKTFileReader.java
@@ -122,22 +122,19 @@ public class WKTFileReader
 	public List read() 
 	throws IOException, ParseException 
 	{
-    // do this here so that constructors don't throw exceptions
-    if (file != null)
-      reader = new FileReader(file);
-    
-		count = 0;
-		try {
-			BufferedReader bufferedReader = new BufferedReader(reader);
-			try {
-				return read(bufferedReader);
-			} finally {
-				bufferedReader.close();
-			}
-		} finally {
-			reader.close();
-		}
-	}
+        Reader inputReader;
+        if (file != null) {
+            inputReader = new FileReader(file);
+        } else {
+            inputReader = reader;
+        }
+
+        count = 0;
+        try (BufferedReader bufferedReader = new BufferedReader(inputReader)) {
+            return read(bufferedReader);
+        }
+
+    }
 	
   private List read(BufferedReader bufferedReader) 
       throws IOException, ParseException {


### PR DESCRIPTION
 ## Summary

  This PR simplifies resource management in `WKTFileReader` and `WKBHexFileReader`.

  ## Changes

  - Replaced nested `try/finally` blocks with try-with-resources.
  - Kept reader cleanup behavior unchanged.
  - Kept the change localized to the two reader classes.

  ## Rationale

  Both classes used similar manual resource-closing logic. Try-with-resources makes the cleanup behavior clearer and
  less error-prone while preserving existing behavior.

  ## Validation

  Ran:

  ```bash
  mvn -pl modules/core verify

  Result:

  - Checkstyle: 0 violations
  - Tests run: 2294
  - Failures: 0
  - Errors: 0
  - PMD completed
  - Build successful

