### PR TITLE
Allocate polyLocator as PointOnGeometryLocator[] for Android ART (#1192)

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelatePointLocator.java
+++ b/modules/core/src/main/java/org/locationtech/jts/operation/relateng/RelatePointLocator.java
@@ -89,9 +89,9 @@ class RelatePointLocator {
     }
     
     if (polygons != null) {
-      polyLocator = isPrepared 
-          ? new IndexedPointInAreaLocator[polygons.size()]
-              : new SimplePointInAreaLocator[polygons.size()];
+      // Use the declared interface array type so Android ART can verify
+      // the assignment (concrete-array ternary is Object[] under ART; #1192)
+      polyLocator = new PointOnGeometryLocator[polygons.size()];
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes Android ART `dex2oat` verification failure in `RelatePointLocator.init` when assigning a ternary of concrete locator arrays to `PointOnGeometryLocator[]` (reported in #1192).
- Allocate the declared interface array type instead; locators are still created lazily in `getLocator()` with the prepared vs simple choice unchanged.
- Minimal one-site change; no API or behavior change on desktop JVMs.

## Test plan
- [x] `mvn -pl modules/core test -Dtest=RelatePointLocatorTest,RelateNGTest,RelateNGGCTest,RelateNGBoundaryNodeRuleTest,RelateNGRobustnessTest,RelatePredicateTest` — 133 tests, 0 failures
- [ ] Confirm Android / ART build no longer fails `dex2oat` on `RelatePointLocator` (reporter environment if available)

Fixes #1192