### PR TITLE
Expose MinimumAreaRectangle convex-hint API (#1149)

### DIFF
--- a/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
+++ b/modules/core/src/main/java/org/locationtech/jts/algorithm/MinimumAreaRectangle.java
@@ -52,6 +52,24 @@ public class MinimumAreaRectangle
   public static Geometry getMinimumRectangle(Geometry geom) {
     return (new MinimumAreaRectangle(geom)).getMinimumRectangle();
   }
+
+  /**
+   * Gets the minimum-area rectangular {@link Polygon} which encloses the input geometry,
+   * with a hint whether the geometry is already convex.
+   * If the geometry is known to be convex, setting {@code isConvex} to {@code true}
+   * avoids computing the convex hull.
+   * If the convex hull of the input is degenerate (a line or point)
+   * a {@link LineString} or a {@link Point} is returned.
+   *
+   * @param geom the geometry
+   * @param isConvex {@code true} if the input geometry is convex
+   * @return the minimum rectangle enclosing the geometry
+   *
+   * @see #MinimumAreaRectangle(Geometry, boolean)
+   */
+  public static Geometry getMinimumRectangle(Geometry geom, boolean isConvex) {
+    return (new MinimumAreaRectangle(geom, isConvex)).getMinimumRectangle();
+  }
   
   private final Geometry inputGeom;
   private final boolean isConvex;
@@ -81,7 +99,14 @@ public class MinimumAreaRectangle
     this.isConvex = isConvex;
   }
 
-  private Geometry getMinimumRectangle()
+  /**
+   * Gets the minimum-area rectangular {@link Polygon} which encloses the input geometry.
+   * If the convex hull of the input is degenerate (a line or point)
+   * a {@link LineString} or a {@link Point} is returned.
+   *
+   * @return the minimum rectangle enclosing the geometry
+   */
+  public Geometry getMinimumRectangle()
   {
     if (inputGeom.isEmpty()) {
       return inputGeom.getFactory().createPolygon();

--- a/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumAreaRectanglelTest.java
+++ b/modules/core/src/test/java/org/locationtech/jts/algorithm/MinimumAreaRectanglelTest.java
@@ -70,6 +70,22 @@ public class MinimumAreaRectanglelTest extends GeometryTestCase {
     checkMinRectangle("POLYGON ((3 8, 6 8, 9 5, 7 3, 3 1, 2 4, 3 8))", 
         "POLYGON ((0.2 6.6, 6.6 9.8, 9.4 4.2, 3 1, 0.2 6.6))");
   }
+
+  /**
+   * Convex-hint API: static factory and public instance method (JTS #1149).
+   * Result must match the non-hint path for a convex polygon.
+   */
+  public void testConvexHintStaticAndInstance() {
+    String wkt = "POLYGON ((3 8, 6 8, 9 5, 7 3, 3 1, 2 4, 3 8))";
+    Geometry geom = read(wkt);
+    Geometry expected = MinimumAreaRectangle.getMinimumRectangle(geom);
+
+    Geometry viaStatic = MinimumAreaRectangle.getMinimumRectangle(geom, true);
+    checkEqual(expected, viaStatic, TOL);
+
+    Geometry viaInstance = new MinimumAreaRectangle(geom, true).getMinimumRectangle();
+    checkEqual(expected, viaInstance, TOL);
+  }
   
   /**
    * Failure case from https://trac.osgeo.org/postgis/ticket/5163


### PR DESCRIPTION
## Summary
- Makes instance `getMinimumRectangle()` public so the convex-hint constructor is usable.
- Adds static factory `getMinimumRectangle(Geometry, boolean isConvex)` so callers can skip convex-hull computation when the input is already known to be convex.
- Matches the usability of `MinimumDiameter` for the instance path (see #1149).

## Test plan
- [x] `mvn -pl modules/core test -Dtest=MinimumAreaRectanglelTest` — 12 tests, 0 failures
- [x] New `testConvexHintStaticAndInstance` checks static+instance convex paths match the default path on a convex polygon

Fixes #1149